### PR TITLE
Ensure hardwood scrap gets grabbed even if breakfast has not run yet

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -276,6 +276,11 @@ boolean auto_latheHardwood(item toLathe)
 	if(item_amount($item[SpinMaster&trade; lathe]) < 1)
 		return false;
 
+	// if breakfast hasn't run and you haven't grabbed it manually, we won't
+	// see the scrap if we don't go grab it ourself. So do that, if needed.
+	if(!get_property("_spinmasterLatheVisited").to_boolean())
+		visit_url("shop.php?whichshop=lathe");
+
 	// can't lathe without hardwood
 	if(item_amount($item[flimsy hardwood scraps]) < 1)
 		return false;


### PR DESCRIPTION
# Description

Just a minor fix for a lathe issue that only shows up on day 1 or if you don't have breakfast automatically happen.

## How Has This Been Tested?

Ran day 1 before running breakfast and still lathed an appropriate weapon.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
