### PR TITLE
Fix Blood Bubbled ignored if Blood Bond isnt available

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1449,7 +1449,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 
 	boolean use_opportunity_blood_skills(int hp_restored_per_use, int final_hp)
 	{
-		if (!auto_have_skill($skill[Blood Bond]) && !auto_have_skill($skill[Blood Bond]))
+		if (!auto_have_skill($skill[Blood Bond]) && !auto_have_skill($skill[Blood Bubble]))
 		{
 			return false;
 		}


### PR DESCRIPTION
# Description

If the player owns Blood Bubble but not Blood Bond, a typo resulted in the function returning early.

## How Has This Been Tested?

Modified locally, now executes properly.
