### PR TITLE
hotfix in_zombieSlayer() crash

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -75,6 +75,7 @@ import <autoscend/paths/two_crazy_random_summer.ash>
 import <autoscend/paths/way_of_the_surprising_fist.ash>
 import <autoscend/paths/wildfire.ash>
 import <autoscend/paths/you_robot.ash>
+import <autoscend/paths/zombie_slayer.ash>
 
 import <autoscend/quests/level_01.ash>
 import <autoscend/quests/level_02.ash>


### PR DESCRIPTION
hotfix autoscend crashing due to not finding function in_zombieSlayer(). this was due to the new file `zombie_slayer.ash` not being imported

## How Has This Been Tested?

ran autoscend with and without the hotfix

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
