### PR TITLE
Path code consistency cleanup 

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -53,6 +53,7 @@ import <autoscend/paths/avatar_of_jarlsberg.ash>
 import <autoscend/paths/avatar_of_sneaky_pete.ash>
 import <autoscend/paths/avatar_of_west_of_loathing.ash>
 import <autoscend/paths/bees_hate_you.ash>
+import <autoscend/paths/bugbear_invasion.ash>
 import <autoscend/paths/casual.ash>
 import <autoscend/paths/community_service.ash>
 import <autoscend/paths/dark_gyffte.ash>
@@ -518,7 +519,7 @@ boolean fortuneCookieEvent()
 
 		location goal = $location[The Hidden Temple];
 
-		if((my_path() == "Community Service") && (my_daycount() == 1))
+		if(in_community() && (my_daycount() == 1))
 		{
 			goal = $location[The Limerick Dungeon];
 		}
@@ -702,7 +703,7 @@ void initializeDay(int day)
 		}
 	}
 
-	if((item_amount($item[GameInformPowerDailyPro Magazine]) > 0) && (my_daycount() == 2) && (auto_my_path() == "Community Service"))
+	if((item_amount($item[GameInformPowerDailyPro Magazine]) > 0) && (my_daycount() == 2) && in_community())
 	{
 		visit_url("inv_use.php?pwd=&which=3&whichitem=6174", true);
 		visit_url("inv_use.php?pwd=&which=3&whichitem=6174&confirm=Yep.", true);
@@ -792,7 +793,7 @@ void initializeDay(int day)
 
 			heavyrains_initializeDay(day);
 			// It's nice to have a moxie weapon for Flock of Bats form
-			if(my_class() == $class[Vampyre] && get_property("darkGyfftePoints").to_int() < 21 && !possessEquipment($item[disco ball]))
+			if(in_darkGyffte() && get_property("darkGyfftePoints").to_int() < 21 && !possessEquipment($item[disco ball]))
 			{
 				acquireGumItem($item[disco ball]);
 			}
@@ -839,7 +840,7 @@ void initializeDay(int day)
 			auto_beachCombHead("exp");
 		}
 
-		if((get_property("lastCouncilVisit").to_int() < my_level()) && (auto_my_path() != "Community Service"))
+		if((get_property("lastCouncilVisit").to_int() < my_level()) && !in_community())
 		{
 			cli_execute("counters");
 			council();
@@ -914,7 +915,7 @@ void initializeDay(int day)
 				pullXWhenHaveY($item[frost flower], 1, 0);
 			}
 		}
-		if (chateaumantegna_havePainting() && !isActuallyEd() && auto_my_path() != "Community Service")
+		if (chateaumantegna_havePainting() && !isActuallyEd() && !in_community())
 		{
 			if(auto_have_familiar($familiar[Reanimated Reanimator]))
 			{
@@ -1205,7 +1206,7 @@ boolean Lsc_flyerSeals()
 
 boolean councilMaintenance()
 {
-	if (auto_my_path() == "Community Service" || in_koe())
+	if (in_community() || in_koe())
 	{
 		return false;
 	}
@@ -1717,7 +1718,7 @@ boolean doTasks()
 	if(LM_kolhs()) 						return true;
 	if(LM_jarlsberg())					return true;
 
-	if(auto_my_path() != "Community Service")
+	if(!in_community())
 	{
 		cheeseWarMachine(0, 0, 0, 0);
 
@@ -1752,7 +1753,7 @@ boolean doTasks()
 	{
 		return true;
 	}
-	if(auto_my_path() == "Community Service")
+	if(in_community())
 	{
 		abort("Should not have gotten here, aborted LA_cs_communityService method allowed return to caller. Uh oh.");
 	}

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -173,7 +173,7 @@ boolean pullXWhenHaveY(item it, int howMany, int whenHave)
 	{
 		return pullXWhenHaveYCasual(it, howMany, whenHave);
 	}
-	if(auto_my_path() == "Community Service")
+	if(in_community())
 	{
 		return false;
 	}
@@ -745,7 +745,7 @@ int handlePulls(int day)
 			pullXWhenHaveY($item[hand in glove], 1, 0);
 		}
 
-		if(!in_heavyrains() && (auto_my_path() != "License to Adventure") && !($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed] contains my_class()))
+		if(!in_heavyrains() && !in_lta() && !($classes[Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Ed] contains my_class()))
 		{
 			if(!possessEquipment($item[Snow Suit]) && !possessEquipment($item[Astral Pet Sweater]) && glover_usable($item[Snow Suit]))
 			{
@@ -779,7 +779,7 @@ int handlePulls(int day)
 		
 		pullLegionKnife();
 
-		if(my_class() == $class[Vampyre])
+		if(in_darkGyffte())
 		{
 			auto_log_info("You are a powerful vampire who is doing a softcore run. Turngen is busted in this path, so let's see how much we can get.", "blue");
 			if((storage_amount($item[mime army shotglass]) > 0) && is_unrestricted($item[mime army shotglass]))
@@ -1039,7 +1039,7 @@ boolean LX_craftAcquireItems()
 		}
 	}
 
-	if(auto_my_path() != "Community Service")
+	if(!in_community())
 	{
 		if(item_amount($item[Portable Pantogram]) > 0)
 		{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -75,7 +75,7 @@ int pullsNeeded(string data)
 	{
 		return 0;
 	}
-	if (isActuallyEd() || auto_my_path() == "Community Service")
+	if (isActuallyEd() || in_community())
 	{
 		return 0;
 	}
@@ -393,7 +393,7 @@ boolean doBedtime()
 			}
 		}
 	}
-	boolean out_of_blood = (my_class() == $class[Vampyre] && item_amount($item[blood bag]) == 0);
+	boolean out_of_blood = (in_darkGyffte() && item_amount($item[blood bag]) == 0);
 	if((fullness_left() > 0) && can_eat() && !out_of_blood)
 	{
 		return false;
@@ -535,7 +535,7 @@ boolean doBedtime()
 
 	if((friars_available()) && (!get_property("friarsBlessingReceived").to_boolean()))
 	{
-		if(in_pokefam() || my_class() == $class[Vampyre])
+		if(in_pokefam() || in_darkGyffte())
 		{
 			cli_execute("friars food");
 		}

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -405,14 +405,14 @@ boolean auto_run_choice(int choice, string page)
 		case 924: // You Found Your Thrill (The Black Forest)
 			if(get_property("auto_getBeehive").to_boolean() && my_adventures() > 3) {
 				run_choice(3); // go to Bee Persistent (#1018)
-			} else if (!possessEquipment($item[Blackberry Galoshes]) && item_amount($item[Blackberry]) >= 3 && my_class() != $class[Vampyre]) {
+			} else if (!possessEquipment($item[Blackberry Galoshes]) && item_amount($item[Blackberry]) >= 3 && !in_darkGyffte()) {
 				run_choice(2); // go to The Blackberry Cobbler (#928)
 			} else {
 				run_choice(1); // Attack the bushes (fight blackberry bush)
 			}
 			break;
 		case 928: // You Found Your Thrill (The Black Forest)
-			if (!possessEquipment($item[Blackberry Galoshes]) && item_amount($item[Blackberry]) >= 3 && my_class() != $class[Vampyre]) {
+			if (!possessEquipment($item[Blackberry Galoshes]) && item_amount($item[Blackberry]) >= 3 && !in_darkGyffte()) {
 				run_choice(4); // get Blackberry Galoshes
 			} else {
 				run_choice(5); // skip
@@ -499,7 +499,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(1);
 			break;
 		case 1115: // VYKEA! (VYKEA)
-			if (!get_property("_VYKEACafeteriaRaided").to_boolean() && auto_my_path() != "Community Service") {
+			if (!get_property("_VYKEACafeteriaRaided").to_boolean() && !in_community()) {
 				run_choice(1); // get consumables
 			} else if (!get_property("_VYKEALoungeRaided").to_boolean()) {
 				run_choice(4); // get Wal-Mart gift certificates

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -408,7 +408,7 @@ boolean canDrink(item toDrink, boolean checkValidity)
 	{
 		return false;
 	}
-	if (my_class() == $class[Avatar of Jarlsberg] && toDrink != $item[Steel Margarita])
+	if(is_jarlsberg() && toDrink != $item[Steel Margarita])
 	{
 		return contains_text(craft_type(toDrink), "Jarlsberg's Kitchen");
 	}
@@ -416,7 +416,7 @@ boolean canDrink(item toDrink, boolean checkValidity)
 	{
 		return false;
 	}
-	if((auto_my_path() == "Dark Gyffte") != ($items[vampagne, dusty bottle of blood, Red Russian, mulled blood, bottle of Sanguiovese] contains toDrink))
+	if(in_darkGyffte() != ($items[vampagne, dusty bottle of blood, Red Russian, mulled blood, bottle of Sanguiovese] contains toDrink))
 	{
 		return false;
 	}
@@ -427,7 +427,7 @@ boolean canDrink(item toDrink, boolean checkValidity)
 			return false;
 		}
 	}
-	if(auto_my_path() == "License to Adventure")
+	if(in_lta())
 	{
 		item [int] martinis = bondDrinks();
 		boolean found = false;
@@ -472,7 +472,7 @@ boolean canEat(item toEat, boolean checkValidity)
 	{
 		return false;
 	}
-	if (my_class() == $class[Avatar of Jarlsberg])
+	if(is_jarlsberg())
 	{
 		return contains_text(craft_type(toEat), "Jarlsberg's Kitchen");
 	}
@@ -480,12 +480,12 @@ boolean canEat(item toEat, boolean checkValidity)
 	{
 		return false;
 	}
-	if((auto_my_path() == "Dark Gyffte") && (toEat == $item[magical sausage]))
+	if(in_darkGyffte() && (toEat == $item[magical sausage]))
 	{
 		// the one thing you can eat as Vampyre AND other classes
 		return true;
 	}
-	if((auto_my_path() == "Dark Gyffte") != ($items[blood-soaked sponge cake, blood roll-up, blood snowcone, actual blood sausage, bloodstick] contains toEat))
+	if(in_darkGyffte() != ($items[blood-soaked sponge cake, blood roll-up, blood snowcone, actual blood sausage, bloodstick] contains toEat))
 	{
 		return false;
 	}
@@ -591,7 +591,7 @@ void consumeStuff()
 	{
 		return;
 	}
-	if(auto_my_path() == "Community Service")
+	if(in_community())
 	{
 		cs_eat_spleen();
 		return;
@@ -870,7 +870,7 @@ boolean autoConsume(ConsumeAction action)
 boolean loadConsumables(string _type, ConsumeAction[int] actions)
 {
 	// Just in case!
-	if(auto_my_path() == "Dark Gyffte")
+	if(in_darkGyffte())
 	{
 		abort("We shouldn't be calling loadConsumables() in Dark Gyffte. Please report this.");
 	}
@@ -1257,7 +1257,7 @@ ConsumeAction auto_bestNightcap()
 
 void auto_printNightcap()
 {
-	if(my_path() == "Dark Gyffte")
+	if(in_darkGyffte())
 	{
 		return;		//disable it for now. TODO make a custom function for vampyre nightcap drinking specifically
 	}
@@ -1271,7 +1271,7 @@ void auto_drinkNightcap()
 	{
 		return;
 	}
-	if(my_path() == "Dark Gyffte")
+	if(in_darkGyffte())
 	{
 		return;		//disable it for now. TODO make a custom function for vampyre nightcap drinking specifically
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -186,7 +186,7 @@ string defaultMaximizeStatement()
 		res += ",mox";
 	}
 
-	if(my_class() == $class[Vampyre])
+	if(in_darkGyffte())
 	{
 		res += ",0.8hp,3hp regen";
 	}
@@ -340,7 +340,7 @@ void finalizeMaximize()
 		addBonusToMaximize($item[Powerful Glove], 1000); // pixels
 	}
 	// Vampyre autogenerates scraps because of some weird ensorcel interaction. Even without ensorcel active.
-	if(pathHasFamiliar() || my_class() == $class[Vampyre])
+	if(pathHasFamiliar() || in_darkGyffte())
 	{
 		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -725,7 +725,7 @@ void preAdvUpdateFamiliar(location place)
 		}
 	}
 	
-	if(my_path() != "Community Service" && auto_checkFamiliarMummery(my_familiar()))
+	if(!in_community() && auto_checkFamiliarMummery(my_familiar()))
 	{
 		mummifyFamiliar();
 	}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -120,12 +120,12 @@ boolean auto_post_adventure()
 		}
 	}
 
-	if((get_property("lastEncounter") == "Daily Briefing") && (auto_my_path() == "License to Adventure"))
+	if((get_property("lastEncounter") == "Daily Briefing") && in_lta())
 	{
 		set_property("_auto_bondBriefing", "started");
 	}
 
-	if((get_property("_villainLairProgress").to_int() < 999) && ((get_property("_villainLairColor") != "") || get_property("_villainLairColorChoiceUsed").to_boolean()) && (auto_my_path() == "License to Adventure") && (my_location() == $location[Super Villain\'s Lair]))
+	if((get_property("_villainLairProgress").to_int() < 999) && ((get_property("_villainLairColor") != "") || get_property("_villainLairColorChoiceUsed").to_boolean()) && in_lta() && (my_location() == $location[Super Villain\'s Lair]))
 	{
 		if(item_amount($item[Can Of Minions-Be-Gone]) > 0)
 		{
@@ -350,7 +350,7 @@ boolean auto_post_adventure()
 		buffMaintain($effect[Go Get \'Em\, Tiger!], 0, 1, 1);
 	}
 
-	if(my_path() == "Community Service")
+	if(in_community())
 	{
 		if(auto_have_skill($skill[Summon BRICKOs]) && (get_property("_brickoEyeSummons").to_int() < 3))
 		{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -576,7 +576,7 @@ boolean auto_pre_adventure()
 	}
 
 	//my_mp is broken in Dark Gyffte
-	if (my_class() != $class[Vampyre])
+	if (!in_darkGyffte())
 	{
 		int wasted_mp = my_mp() + mp_regen() - my_maxmp();
 		if(wasted_mp > 0 && my_mp() > 400)

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1695,7 +1695,7 @@ boolean acquireMP(int goal, int meat_reserve)
 boolean acquireMP(int goal, int meat_reserve, boolean useFreeRests)
 {
 	//vampyres don't use MP
-	if(my_class() == $class[Vampyre])
+	if(in_darkGyffte())
 	{
 		return false;
 	}
@@ -1813,7 +1813,7 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests)
 
 	//vampyres can only be restored using blood bags, which are too valuable to waste on healing HP.
 	//better to make food/drink from them and then rest in your coffin
-	if(my_class() == $class[Vampyre])
+	if(in_darkGyffte())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4083,11 +4083,11 @@ boolean auto_check_conditions(string conds)
 					return true;
 				if(isActuallyEd() && get_property("stenchCursedMonster").to_monster() == check_sniffed)
 					return true;
-				if(my_class() == $class[Avatar of Sneaky Pete] && get_property("makeFriendsMonster").to_monster() == check_sniffed)
+				if(is_pete() && get_property("makeFriendsMonster").to_monster() == check_sniffed)
 					return true;
 				if($classes[Cow Puncher, Beanslinger, Snake Oiler] contains my_class() && get_property("longConMonster").to_monster() == check_sniffed)
 					return true;
-				if(my_class() == $class[Vampyre] && get_property("auto_bat_soulmonster").to_monster() == check_sniffed)
+				if(in_darkGyffte() && get_property("auto_bat_soulmonster").to_monster() == check_sniffed)
 					return true;
 				if(get_property("_gallapagosMonster").to_monster() == check_sniffed)
 					return true;

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -288,19 +288,19 @@ generic_t zone_needItem(location loc)
 		}
 		break;
 	case $location[The Haunted Pantry]:
-		if((auto_my_path() == "Community Service") && (item_amount($item[Tomato]) < 2) && have_skill($skill[Advanced Saucecrafting]))
+		if(in_community() && (item_amount($item[Tomato]) < 2) && have_skill($skill[Advanced Saucecrafting]))
 		{
 			retval._float = 59.4;
 		}
 		break;
 	case $location[The Skeleton Store]:
-		if((auto_my_path() == "Community Service") && have_skill($skill[Advanced Saucecrafting]) && ((item_amount($item[Cherry]) < 1) || (item_amount($item[Grapefruit]) < 1) || (item_amount($item[Lemon]) < 1)))
+		if(in_community() && have_skill($skill[Advanced Saucecrafting]) && ((item_amount($item[Cherry]) < 1) || (item_amount($item[Grapefruit]) < 1) || (item_amount($item[Lemon]) < 1)))
 		{	//No idea, should spade this for great justice.
 			retval._float = 33.0;
 		}
 		break;
 	case $location[The Secret Government Laboratory]:
-		if((auto_my_path() == "Community Service") && (item_amount($item[Experimental Serum G-9]) < 2))
+		if(in_community() && (item_amount($item[Experimental Serum G-9]) < 2))
 		{	//No idea, assume it is low.
 			retval._float = 10.0;
 		}
@@ -742,7 +742,7 @@ boolean zone_available(location loc)
 		}
 		break;
 	case $location[Super Villain\'s Lair]:
-		if((auto_my_path() == "License to Adventure") && (get_property("_villainLairProgress").to_int() < 999) && (get_property("_auto_bondBriefing") == "started"))
+		if(in_lta() && (get_property("_villainLairProgress").to_int() < 999) && (get_property("_auto_bondBriefing") == "started"))
 		{
 			retval = true;
 		}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -513,6 +513,10 @@ boolean LM_bhy();
 boolean L13_bhy_towerFinal();
 
 ########################################################################################################
+//Defined in autoscend/paths/bugbear_invasion.ash
+boolean in_bugbear();
+
+########################################################################################################
 //Defined in autoscend/paths/casual.ash
 boolean inAftercore();
 boolean inPostRonin();
@@ -524,6 +528,7 @@ boolean LM_canInteract();
 
 ########################################################################################################
 //Defined in autoscend/paths/community_service.ash
+boolean in_community();
 boolean LA_cs_communityService();
 boolean cs_witchess();
 void cs_initializeDay(int day);
@@ -557,6 +562,7 @@ boolean tryBeachHeadBuff(int quest);
 
 ########################################################################################################
 //Defined in autoscend/paths/dark_gyffte.ash
+boolean in_darkGyffte();
 void bat_startAscension();
 void bat_initializeSettings();
 boolean bat_wantHowl(location loc);
@@ -666,6 +672,7 @@ boolean LM_kolhs();
 
 ########################################################################################################
 //Defined in autoscend/paths/license_to_adventure.ash
+boolean in_lta();
 void bond_initializeSettings();
 boolean bond_initializeDay(int day);
 boolean bond_buySkills();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -299,7 +299,7 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 	
 	//use latte iotm to restore 50% of max MP
-	if((!in_plumber() && my_class() != $class[Vampyre] && !in_zombieSlayer()) &&	//paths that do not use MP
+	if((!in_plumber() && !in_darkGyffte() && !in_zombieSlayer()) &&	//paths that do not use MP
 	canUse($skill[Gulp Latte]) &&
 	my_mp() * 2 < my_maxmp())		//gulp latte restores 50% of your MP. do not waste it.
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_license_to_adventure.ash
@@ -5,7 +5,7 @@ string auto_combatLicenseToAdventureStage4(int round, monster enemy, string text
 	// stage 4 = prekill. copy, sing along, flyer and other things that need to be done after delevel but before killing
 	
 	//each of the 3 items reduces minion count by 3. does NOT auto defeat current minion you are fighting
-	if((my_location() == $location[Super Villain\'s Lair]) && (auto_my_path() == "License to Adventure") && canSurvive(2.0) && (enemy == $monster[Villainous Minion]))
+	if((my_location() == $location[Super Villain\'s Lair]) && in_lta() && canSurvive(2.0) && (enemy == $monster[Villainous Minion]))
 	{
 		if(!get_property("_villainLairCanLidUsed").to_boolean() && (item_amount($item[Razor-Sharp Can Lid]) > 0))
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2013.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2013.ash
@@ -133,7 +133,7 @@ void oldPeoplePlantStuff()
 		return;
 	}
 
-	if(my_path() == "Community Service")
+	if(in_community())
 	{
 		if(my_location() == $location[The Velvet / Gold Mine])
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -99,7 +99,7 @@ boolean dna_startAcquire()
 	{
 		return false;
 	}
-	if(my_path() == "Community Service")
+	if(in_community())
 	{
 		return false;
 	}
@@ -178,7 +178,7 @@ boolean dna_generic()
 		default:		potion = $phylums[humanoid, construct, dude];		break;
 		}
 	}
-	else if(auto_my_path() == "Community Service")
+	else if(in_community())
 	{
 		switch(my_daycount())
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2015.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2015.ash
@@ -45,7 +45,7 @@ boolean auto_barrelPrayers()
 
 	boolean[string] prayers;
 
-	if(my_path() == "License to Adventure")
+	if(in_lta())
 	{
 		switch(my_daycount())
 		{
@@ -85,7 +85,7 @@ boolean auto_barrelPrayers()
 		case 4:				prayers = $strings[Protection, Glamour, Vigor];		break;
 		}
 	}
-	else if(my_path() == "Community Service")
+	else if(in_community())
 	{
 		switch(my_daycount())
 		{
@@ -145,7 +145,7 @@ boolean auto_barrelPrayers()
 		case 4:				prayers = $strings[Glamour, Vigor];					break;
 		}
 	}
-	else if(my_path() == "Actually Ed the Undying")
+	else if(isActuallyEd())
 	{
 		if((elementalPlanes_access($element[spooky])) && (get_property("edPoints").to_int() >= 2))
 		{
@@ -236,7 +236,7 @@ boolean auto_mayoItems()
 		case 4:				mayos = $items[Mayo Lance];							break;
 		}
 	}
-	else if(my_path() == "Community Service")
+	else if(in_community())
 	{
 		switch(my_daycount())
 		{
@@ -263,7 +263,7 @@ boolean auto_mayoItems()
 		default:			mayos = $items[none];								break;
 		}
 	}
-	else if(my_path() == "License to Adventure")
+	else if(in_lta())
 	{
 		switch(my_daycount())
 		{
@@ -991,11 +991,7 @@ boolean deck_useScheme(string action)
 			break;
 		}
 
-		if(in_nuclear())
-		{
-			cards["key"] = true;
-		}
-		if(my_path() == "License to Adventure")
+		if(in_nuclear() || in_lta())
 		{
 			cards["key"] = true;
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -45,14 +45,14 @@ boolean snojoFightAvailable()
 			standard[2] = "Moxie";
 			standard[3] = "Mysticality";
 		}
-		if(my_path() == "Community Service")
+		if(in_community())
 		{
 			standard[0] = "Mysticality";
 			standard[1] = "Moxie";
 			standard[2] = "Muscle";
 			standard[3] = "Mysticality";
 		}
-		if(my_path() == "License to Adventure")
+		if(in_lta())
 		{
 			standard[0] = "Mysticality";
 			standard[1] = "Moxie";
@@ -536,7 +536,7 @@ int auto_advWitchessTargets(string target)
 
 boolean witchessFights()
 {
-	if(my_path() == "Community Service")
+	if(in_community())
 	{
 		return false;
 	}
@@ -553,20 +553,15 @@ boolean witchessFights()
 		return false;
 	}
 
-	if(in_gnoob())
+	if(in_gnoob() || in_lta())
 	{
 		return auto_advWitchess("ml");
 	}
-
-	if(auto_my_path() == "License to Adventure")
-	{
-		return auto_advWitchess("ml");
-	}
-
+	
 	switch(my_daycount())
 	{
 	case 1:
-		if((item_amount($item[Greek Fire]) == 0) && (my_path() != "Community Service"))
+		if((item_amount($item[Greek Fire]) == 0) && !in_community())
 		{
 			return auto_advWitchess("ml");
 		}
@@ -1018,7 +1013,7 @@ boolean LX_ghostBusting()
 	{
 		return false;
 	}
-	if(auto_my_path() == "Community Service" && my_daycount() == 1 && goal == $location[The Spooky Forest])
+	if(in_community() && my_daycount() == 1 && goal == $location[The Spooky Forest])
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -128,7 +128,7 @@ boolean mummifyFamiliar(familiar fam)
 boolean mummifyFamiliar()
 {
 	auto_hasMummingTrunk();
-	if (my_path() == "Community Service")
+	if (in_community())
 	{
 		return false;
 	}
@@ -307,7 +307,7 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	{
 		loveEffect = 3;
 	}
-	if((auto_my_path() == "Actually Ed the Undying") && ((my_mp() < 20) || (my_turncount() < 10)))
+	if(isActuallyEd() && ((my_mp() < 20) || (my_turncount() < 10)))
 	{
 		return false;
 	}
@@ -332,7 +332,7 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	int statValue = 4;
 	if(statItem == $stat[none])
 	{
-		if (my_class() == $class[Vampyre] && possessEquipment($item[Vampyric Cloake]))
+		if(in_darkGyffte() && possessEquipment($item[Vampyric Cloake]))
 		{
 			statItem = $stat[Muscle];
 		}
@@ -1848,7 +1848,7 @@ boolean makeGeniePocket()
 
 boolean spacegateVaccineAvailable()
 {
-	if(my_path() == "Kingdom of Exploathing") return false;
+	if(in_koe()) return false;
 
 	if(!get_property("spacegateAlways").to_boolean() || get_property("_spacegateToday").to_boolean())
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -1062,7 +1062,7 @@ boolean auto_latteRefill(string want1, string want2, string want3, boolean force
 		return true;
 	}
 
-	if(my_class() == $class[Vampyre])
+	if(in_darkGyffte())
 		tryAddWant("healing");
 
 	if(!haveWant("combat"))

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -109,7 +109,7 @@ boolean auto_sausageWanted()
 	int totalSausageToEat = ceil(progress * (totalSausageEstimated - sausageForBreakfast)) + sausageForBreakfast;
 	
 	// a reserve is kept for MP restoration
-	boolean noMP = my_class() == $class[Vampyre];
+	boolean noMP = in_darkGyffte();
 	int sausage_reserve_size = noMP ? 0 : 3;
 	
 	// no more reserve when close to full or when completely out of adventures
@@ -181,7 +181,7 @@ boolean auto_sausageGrind(int numSaus, boolean failIfCantMakeAll)
 	int pastesNeeded = 0;
 	int pastesAvail = item_amount($item[meat paste]);
 	int meatToSave = 1000 + meatReserve();
-	if(auto_my_path() == "Community Service")
+	if(in_community())
 		meatToSave = 500;
 	for i from 1 to numSaus
 	{
@@ -224,7 +224,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	if(item_amount($item[magical sausage]) < 1)
 		return false;
 
-	boolean noMP = my_class() == $class[Vampyre];
+	boolean noMP = in_darkGyffte();
 	int originalMp = my_maxmp();
 	if(!noMP)
 	{

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1,6 +1,6 @@
 boolean isActuallyEd()
 {
-	return (my_class() == $class[Ed] || my_path() == "Actually Ed the Undying");
+	return my_path() == "Actually Ed the Undying";
 }
 
 int ed_spleen_limit()

--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -120,7 +120,7 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		}
 		break;
 	case $class[Sauceror]:
-		if((my_level() >= 1) && (my_meat() >= 1250) && !have_skill($skill[Simmer]) && (auto_my_path() == "Community Service"))
+		if((my_level() >= 1) && (my_meat() >= 1250) && !have_skill($skill[Simmer]) && in_community())
 		{
 			visit_url("guild.php?action=buyskill&skillid=25", true);
 		}

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -1,6 +1,6 @@
 boolean is_boris()
 {
-	return my_class() == $class[Avatar of Boris];
+	return my_path() == "Avatar of Boris";
 }
 
 void borisTrusty()

--- a/RELEASE/scripts/autoscend/paths/avatar_of_jarlsberg.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_jarlsberg.ash
@@ -1,6 +1,6 @@
 boolean is_jarlsberg()
 {
-	return (my_class() == $class[Avatar of Jarlsberg] || my_path() == "Avatar of Jarlsberg");
+	return my_path() == "Avatar of Jarlsberg";
 }
 
 void jarlsberg_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_sneaky_pete.ash
@@ -1,6 +1,6 @@
 boolean is_pete()
 {
-	return (my_class() == $class[Avatar of Sneaky Pete] || my_path() == "Avatar of Sneaky Pete");
+	return my_path() == "Avatar of Sneaky Pete";
 }
 
 void pete_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/avatar_of_west_of_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_west_of_loathing.ash
@@ -1,6 +1,6 @@
 boolean in_awol()
 {
-	return (auto_my_path() == "Avatar of West of Loathing");
+	return my_path() == "Avatar of West of Loathing";
 }
 
 boolean awol_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
+++ b/RELEASE/scripts/autoscend/paths/bees_hate_you.ash
@@ -1,6 +1,6 @@
 boolean in_bhy()
 {
-	return (auto_my_path() == "Bees Hate You");
+	return my_path() == "Bees Hate You";
 }
 
 

--- a/RELEASE/scripts/autoscend/paths/bugbear_invasion.ash
+++ b/RELEASE/scripts/autoscend/paths/bugbear_invasion.ash
@@ -1,0 +1,4 @@
+boolean in_bugbear()
+{
+	return my_path() == "Bugbear Invasion";
+}

--- a/RELEASE/scripts/autoscend/paths/community_service.ash
+++ b/RELEASE/scripts/autoscend/paths/community_service.ash
@@ -14,9 +14,14 @@
 
 static int[int] auto_cs_fastQuestList;
 
+boolean in_community()
+{
+	return my_path() == "Community Service";
+}
+
 boolean LA_cs_communityService()
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return false;
 	}
@@ -2829,7 +2834,7 @@ boolean LA_cs_communityService()
 
 boolean cs_witchess()
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return false;
 	}
@@ -2882,7 +2887,7 @@ boolean cs_witchess()
 
 void cs_initializeDay(int day)
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return;
 	}
@@ -3146,7 +3151,7 @@ boolean do_chateauGoat()
 
 boolean cs_spendRests()
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return false;
 	}
@@ -3331,7 +3336,7 @@ void cs_make_stuff(int curQuest)
 
 boolean cs_eat_spleen()
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return false;
 	}
@@ -3363,7 +3368,7 @@ boolean cs_eat_spleen()
 
 boolean cs_eat_stuff(int quest)
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return false;
 	}
@@ -3503,7 +3508,7 @@ boolean cs_eat_stuff(int quest)
 
 void cs_dnaPotions()
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return;
 	}
@@ -3653,7 +3658,7 @@ int estimate_cs_questCost(int quest)
 int [int] get_cs_questList()
 {
 	int [int] questList;
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return questList;
 	}
@@ -3679,7 +3684,7 @@ int [int] get_cs_questList()
 
 int expected_next_cs_quest()
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return 0;
 	}
@@ -3726,7 +3731,7 @@ string what_cs_quest(int quest)
 
 int expected_next_cs_quest_internal()
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return 0;
 	}
@@ -3749,7 +3754,7 @@ int expected_next_cs_quest_internal()
 
 boolean do_cs_quest(int quest)
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return false;
 	}
@@ -3820,7 +3825,7 @@ int get_cs_questCost(int quest)
 	{
 		abort("Invalid quest value specified");
 	}
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return -1;
 	}
@@ -3836,7 +3841,7 @@ int get_cs_questCost(string input)
 
 int get_cs_questNum(string input)
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return -1;
 	}
@@ -3901,7 +3906,7 @@ void set_cs_questListFast(int[int] fast)
 
 boolean cs_preTurnStuff(int curQuest)
 {
-	if(my_path() != "Community Service")
+	if(!in_community())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
+++ b/RELEASE/scripts/autoscend/paths/dark_gyffte.ash
@@ -1,13 +1,19 @@
+boolean in_darkGyffte()
+{
+	return my_path() == "Dark Gyffte";
+}
+
 void bat_startAscension()
 {
-	if(my_path() == "Dark Gyffte") {
+	if(in_darkGyffte())
+	{
 		visit_url("choice.php?whichchoice=1343&option=1");
 		bat_reallyPickSkills(20);
 	}
 }
 void bat_initializeSettings()
 {
-	if(my_path() == "Dark Gyffte")
+	if(in_darkGyffte())
 	{
 		set_property("auto_getSteelOrgan", false);
 		set_property("auto_grimstoneFancyOilPainting", false);
@@ -45,7 +51,7 @@ boolean bat_wantHowl(location loc)
 
 boolean bat_formNone()
 {
-	if(my_class() != $class[Vampyre]) return false;
+	if(!in_darkGyffte()) return false;
 	if(get_property("auto_bat_desiredForm") != "")
 	{
 		set_property("auto_bat_desiredForm", "");
@@ -55,7 +61,7 @@ boolean bat_formNone()
 
 boolean bat_formWolf(boolean speculative)
 {
-	if(my_class() != $class[Vampyre]) return false;
+	if(!in_darkGyffte()) return false;
 	set_property("auto_bat_desiredForm", "wolf");
 	return bat_switchForm($effect[Wolf Form], speculative);
 }
@@ -67,7 +73,7 @@ boolean bat_formWolf()
 
 boolean bat_formMist(boolean speculative)
 {
-	if(my_class() != $class[Vampyre]) return false;
+	if(!in_darkGyffte()) return false;
 	set_property("auto_bat_desiredForm", "mist");
 	return bat_switchForm($effect[Mist Form], speculative);
 }
@@ -79,7 +85,7 @@ boolean bat_formMist()
 
 boolean bat_formBats(boolean speculative)
 {
-	if(my_class() != $class[Vampyre]) return false;
+	if(!in_darkGyffte()) return false;
 	set_property("auto_bat_desiredForm", "bats");
 	return bat_switchForm($effect[Bats Form], speculative);
 }
@@ -126,7 +132,7 @@ boolean bat_switchForm(effect form)
 
 boolean bat_formPreAdventure()
 {
-	if(my_class() != $class[Vampyre]) return false;
+	if(!in_darkGyffte()) return false;
 
 	string desiredForm = get_property("auto_bat_desiredForm");
 	effect form;
@@ -150,7 +156,7 @@ boolean bat_formPreAdventure()
 
 void bat_initializeSession()
 {
-	if(my_class() == $class[Vampyre])
+	if(in_darkGyffte())
 	{
 		set_property("auto_mpAutoRecovery", get_property("mpAutoRecovery"));
 		set_property("auto_mpAutoRecoveryTarget", get_property("mpAutoRecoveryTarget"));
@@ -161,7 +167,7 @@ void bat_initializeSession()
 
 void bat_terminateSession()
 {
-	if(my_class() == $class[Vampyre])
+	if(in_darkGyffte())
 	{
 		set_property("mpAutoRecovery", get_property("auto_mpAutoRecovery"));
 		set_property("auto_mpAutoRecovery", 0.0);
@@ -172,7 +178,7 @@ void bat_terminateSession()
 
 void bat_initializeDay(int day)
 {
-	if(my_path() != "Dark Gyffte")
+	if(!in_darkGyffte())
 	{
 		return;
 	}
@@ -324,7 +330,7 @@ void bat_reallyPickSkills(int hpLeft, boolean[skill] requiredSkills)
 {
 	// Why Astral Spirit? When entering a DG run, before exiting the initial
 	// noncombat and Torpor, that's what KoLmafia thinks you are.
-	if(my_class() != $class[Vampyre] && to_string(my_class()) != "Astral Spirit")
+	if(!in_darkGyffte() && to_string(my_class()) != "Astral Spirit")
 	{
 		return;
 	}
@@ -378,7 +384,7 @@ phylum bat_ensorceledMonster() //returns phylum of current Ensorceled Monster (i
 
 boolean bat_shouldEnsorcel(monster m)
 {
-	if(my_class() != $class[Vampyre] || !auto_have_skill($skill[Ensorcel]))
+	if(!in_darkGyffte() || !auto_have_skill($skill[Ensorcel]))
 		return false;
 
 	// until we have a way to tell what we already have as an ensorcelee, just ensorcel goblins
@@ -393,7 +399,7 @@ boolean bat_shouldEnsorcel(monster m)
 
 int bat_creatable_amount(item desired)
 {
-	if(my_class() != $class[Vampyre])
+	if(!in_darkGyffte())
 		return 0;
 	if(item_amount($item[blood bag]) == 0)
 		return 0;
@@ -422,7 +428,7 @@ int bat_creatable_amount(item desired)
 
 boolean bat_multicraft(string mode, boolean [item] options)
 {
-	if(my_class() != $class[Vampyre])
+	if(!in_darkGyffte())
 		return false;
 	if(item_amount($item[blood bag]) == 0)
 		return false;
@@ -441,7 +447,7 @@ boolean bat_multicraft(string mode, boolean [item] options)
 
 boolean bat_cook(item desired)
 {
-	if(my_class() != $class[Vampyre])
+	if(!in_darkGyffte())
 		return false;
 	if(item_amount($item[blood bag]) == 0)
 		return false;
@@ -470,7 +476,7 @@ boolean bat_cook(item desired)
 
 boolean bat_consumption()
 {
-	if(my_class() != $class[Vampyre])
+	if(!in_darkGyffte())
 		return false;
 
 	if(possessOutfit("War Hippy Fatigues") && is_accessible($coinmaster[Dimemaster]))
@@ -589,7 +595,7 @@ boolean bat_skillValid(skill sk)
 	if($skills[Piercing Gaze, Perceive Soul, Ensorcel, Spectral Awareness] contains sk && have_effect($effect[Wolf Form]) + have_effect($effect[Mist Form]) > 0)
 		return false;
 
-	if((mp_cost(sk) > 0) && (my_class() == $class[Vampyre]))
+	if((mp_cost(sk) > 0) && in_darkGyffte())
 		return false;
 
 	return true;
@@ -610,7 +616,7 @@ boolean bat_tryBloodBank()
 
 boolean LM_batpath()
 {
-	if(my_class() != $class[Vampyre])
+	if(!in_darkGyffte())
 		return false;
 
 	if(bat_remainingBaseHP() >= 70 && bat_shouldPickSkills(20))

--- a/RELEASE/scripts/autoscend/paths/disguises_delimit.ash
+++ b/RELEASE/scripts/autoscend/paths/disguises_delimit.ash
@@ -1,6 +1,6 @@
 boolean in_disguises()
 {
-	return auto_my_path() == "Disguises Delimit";
+	return my_path() == "Disguises Delimit";
 }
 
 void disguises_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -1,6 +1,6 @@
 boolean in_glover()
 {
-	return auto_my_path() == "G-Lover";
+	return my_path() == "G-Lover";
 }
 
 void glover_initializeDay(int day)

--- a/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
+++ b/RELEASE/scripts/autoscend/paths/gelatinous_noob.ash
@@ -1,6 +1,6 @@
 boolean in_gnoob()
 {
-	return my_class() == $class[Gelatinous Noob];
+	return my_path() == "Gelatinous Noob";
 }
 
 void gnoob_startAscension(string page)

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -1,6 +1,6 @@
 boolean in_ggoo()
 {
-	return auto_my_path() == "Grey Goo";
+	return my_path() == "Grey Goo";
 }
 
 void grey_goo_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -1,6 +1,6 @@
 boolean in_heavyrains()
 {
-	return auto_my_path() == "Heavy Rains";
+	return my_path() == "Heavy Rains";
 }
 
 void heavyrains_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -1,6 +1,6 @@
 boolean in_koe()
 {
-	return my_path() == "37" || my_path() == "Kingdom of Exploathing";
+	return my_path() == "Kingdom of Exploathing";
 }
 
 boolean koe_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/kolhs.ash
+++ b/RELEASE/scripts/autoscend/paths/kolhs.ash
@@ -1,6 +1,6 @@
 boolean in_kolhs()
 {
-	return auto_my_path() == "KOLHS";
+	return my_path() == "KOLHS";
 }
 
 boolean kolhs_mandatorySchool()

--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -1,6 +1,12 @@
+boolean in_lta()
+{
+	return my_path() == "License to Adventure";
+}
+
+
 void bond_initializeSettings()
 {
-	if(my_path() == "License to Adventure")
+	if(in_lta())
 	{
 		set_property("auto_getBeehive", true);
 		set_property("auto_wandOfNagamar", false);
@@ -74,7 +80,7 @@ void bond_initializeSettings()
 
 boolean bond_initializeDay(int day)
 {
-	if(my_path() != "License to Adventure")
+	if(!in_lta())
 	{
 		return false;
 	}
@@ -201,7 +207,7 @@ boolean bond_initializeDay(int day)
 
 boolean bond_buySkills()
 {
-	if(my_path() != "License to Adventure")
+	if(!in_lta())
 	{
 		return false;
 	}
@@ -344,7 +350,7 @@ boolean bond_buySkills()
 
 boolean LM_bond()
 {
-	if(my_path() != "License to Adventure")
+	if(!in_lta())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/live_ascend_repeat.ash
+++ b/RELEASE/scripts/autoscend/paths/live_ascend_repeat.ash
@@ -1,6 +1,6 @@
 boolean in_lar()
 {
-	return auto_my_path() == "Live. Ascend. Repeat.";
+	return my_path() == "Live. Ascend. Repeat.";
 }
 
 boolean lar_safeguard()

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -26,7 +26,7 @@ lowKeys[$item[Discarded bike lock key]] = $location[The Overgrown Lot];
 
 boolean in_lowkeysummer()
 {
-	return auto_my_path() == "Low Key Summer";
+	return my_path() == "Low Key Summer";
 }
 
 void lowkey_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/one_crazy_random_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/one_crazy_random_summer.ash
@@ -1,6 +1,6 @@
 boolean in_ocrs()
 {
-	return (auto_my_path() == "One Crazy Random Summer");
+	return my_path() == "One Crazy Random Summer";
 }
 
 boolean ocrs_postHelper()

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -1,7 +1,7 @@
 // This uses Ezandora's wonderful Helix Fossil script to handle building a team and combat.
 boolean in_pokefam()
 {
-	return auto_my_path() == "Pocket Familiars";
+	return my_path() == "Pocket Familiars";
 }
 
 void pokefam_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -1,6 +1,6 @@
 boolean in_quantumTerrarium()
 {
-	return auto_my_path() == "Quantum Terrarium";
+	return my_path() == "Quantum Terrarium";
 }
 
 boolean qt_currentFamiliar(familiar fam)

--- a/RELEASE/scripts/autoscend/paths/two_crazy_random_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/two_crazy_random_summer.ash
@@ -1,6 +1,6 @@
 boolean in_tcrs()
 {
-	return my_path() == "36" || my_path() == "Two Crazy Random Summer";
+	return my_path() == "Two Crazy Random Summer";
 }
 
 float tcrs_expectedAdvPerFill(string quality)

--- a/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
+++ b/RELEASE/scripts/autoscend/paths/way_of_the_surprising_fist.ash
@@ -1,4 +1,4 @@
 boolean in_wotsf()
 {
-	return auto_my_path() == "Way of the Surprising Fist";
+	return my_path() == "Way of the Surprising Fist";
 }

--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -1,6 +1,6 @@
 boolean in_wildfire()
 {
-	return auto_my_path() == "Wildfire";
+	return my_path() == "Wildfire";
 }
 
 void wildfire_initializeSettings()

--- a/RELEASE/scripts/autoscend/paths/you_robot.ash
+++ b/RELEASE/scripts/autoscend/paths/you_robot.ash
@@ -1,4 +1,4 @@
 boolean in_youRobot()
 {
-	return auto_my_path() == "You, Robot";
+	return my_path() == "You, Robot";
 }

--- a/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
@@ -1,4 +1,4 @@
 boolean in_zombieSlayer()
 {
-	return auto_my_path() == "Zombie Slayer";
+	return my_path() == "Zombie Slayer";
 }

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -595,7 +595,7 @@ boolean L9_aBooPeak()
 				}
 			}
 			acquireHP();
-			if ((my_hp() * 4) < my_maxhp() && item_amount($item[Scroll of Drastic Healing]) > 0 && (!isActuallyEd() || my_class() != $class[Vampyre]))
+			if ((my_hp() * 4) < my_maxhp() && item_amount($item[Scroll of Drastic Healing]) > 0 && (!isActuallyEd() || !in_darkGyffte()))
 			{
 				use(1, $item[Scroll of Drastic Healing]);
 			}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -774,7 +774,7 @@ boolean L12_startWar()
 		handleBjornify($familiar[Grimstone Golem]);
 	}
 	
-	if((my_path() != "Dark Gyffte") && (my_mp() > 50) && have_skill($skill[Incredible Self-Esteem]) && !get_property("_incredibleSelfEsteemCast").to_boolean())
+	if(!in_darkGyffte() && (my_mp() > 50) && have_skill($skill[Incredible Self-Esteem]) && !get_property("_incredibleSelfEsteemCast").to_boolean())
 	{
 		use_skill(1, $skill[Incredible Self-Esteem]);
 	}
@@ -1654,7 +1654,7 @@ boolean L12_themtharHills()
 	{
 		meat_need = meat_need - 200;
 	}
-	if((my_class() == $class[Vampyre]) && have_skill($skill[Wolf Form]) && (0 == have_effect($effect[Wolf Form])))
+	if(in_darkGyffte() && have_skill($skill[Wolf Form]) && (0 == have_effect($effect[Wolf Form])))
 	{
 		meat_need = meat_need - 150;
 	}
@@ -2102,7 +2102,7 @@ boolean L12_finalizeWar()
 	}
 
 	// Just in case we need the extra turngen to complete this day
-	if (my_class() == $class[Vampyre])
+	if (in_darkGyffte())
 	{
 		int have = item_amount($item[monstar energy beverage]) + item_amount($item[carbonated soy milk]);
 		if(have < 5)

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -407,7 +407,7 @@ boolean L13_towerNSContests()
 				string temp = visit_url("place.php?whichplace=monorail&action=monorail_lyle");
 			}
 			acquireMP(150); // only uses free rests or items on hand by default
-			if (my_class() == $class[Vampyre])
+			if (in_darkGyffte())
 			{
 				if(crowd_stat == $stat[muscle] && !have_skill($skill[Preternatural Strength]))
 				{
@@ -1473,7 +1473,7 @@ boolean L13_towerNSTower()
 		}
 		boolean confidence = get_property("auto_confidence").to_boolean();
 		// confidence really just means take the first choice, so it's necessary in vampyre
-		if(my_class() == $class[Vampyre])
+		if(in_darkGyffte())
 			confidence = true;
 		string choicenum = (confidence ? "1" : "2");
 		set_property("choiceAdventure1015", choicenum);
@@ -1574,7 +1574,7 @@ boolean L13_towerNSFinal()
 		acquireMP(200, 0);
 	}
 	
-	if(!($strings[Actually Ed the Undying, Avatar of Boris, Avatar of Jarlsberg, Avatar of Sneaky Pete, Bees Hate You, Bugbear Invasion, Community Service, The Source, Way of the Surprising Fist, Zombie Slayer] contains auto_my_path()))
+	if(!(isActuallyEd() || is_boris() || is_jarlsberg() || is_pete() || in_bhy() || in_bugbear() || in_community() || in_theSource() || in_wotsf() || in_zombieSlayer()))
 	{
 		//Only if the final boss does not unbuff us...
 		cli_execute("scripts/autoscend/auto_post_adv.ash");

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -213,7 +213,7 @@ boolean LX_steelOrgan()
 		set_property("auto_getSteelOrgan", false);
 		return false;
 	}
-	if(in_nuclear() || (auto_my_path() == "License to Adventure"))
+	if(in_nuclear() || in_lta())
 	{
 		auto_log_info("You could get a Steel Organ for aftercore, but why? We won't help with this deviant and perverse behavior. Turning off setting.", "blue");
 		set_property("auto_getSteelOrgan", false);
@@ -395,8 +395,7 @@ boolean LX_guildUnlock()
 	{
 		return false;
 	}
-	if (!($strings[Picky, Community Service, Low Key Summer] contains auto_my_path())
-		&& get_property('auto_skipUnlockGuild').to_boolean())
+	if(!(in_picky() || in_community() || in_lowkeysummer()) && get_property('auto_skipUnlockGuild').to_boolean())
 	{
 		return false;
 	}
@@ -614,7 +613,7 @@ void considerGalaktikSubQuest()
 	{
 		return;		//galaktik is unavailable in kingdom of exploathing
 	}
-	if(my_class() == $class[Vampyre] || in_plumber())
+	if(in_darkGyffte() || in_plumber())
 	{
 		return;		//these classes cannot use galaktik restorers.
 	}
@@ -1098,7 +1097,7 @@ boolean LX_NemesisQuest()
 void houseUpgrade()
 {
 	//function for upgrading your dwelling.
-	if(isActuallyEd() || my_class() == $class[Vampyre] || in_nuclear())
+	if(isActuallyEd() || in_darkGyffte() || in_nuclear())
 	{
 		return;		//paths where dwelling is locked
 	}


### PR DESCRIPTION
Use defined my_path() functions in each path for consistency and update throughout entire autoscend

# Description

Changed everything to use the boolean in_path() definitions for consistency

## How Has This Been Tested?

This validates

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
