### PR TITLE
in oxy path reduce pvp fites value to zero

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -230,7 +230,7 @@ float rollover_value(item it)
 		return 0.0;
 	}
 	float retval = numeric_modifier(it, "adventures");
-	if(hippy_stone_broken())
+	if(hippy_stone_broken() && my_path() != "Oxygenarian")
 	{
 		retval += get_property("auto_bedtime_pulls_pvp_multi").to_float() * numeric_modifier(it, "PvP Fights");
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -593,7 +593,7 @@ void equipRollover(boolean silent)
 	}
 
 	string to_max = "-tie,adv";
-	if(hippy_stone_broken() && get_property("auto_bedtime_pulls_pvp_multi").to_float() > 0)
+	if(hippy_stone_broken() && my_path() != "Oxygenarian" && get_property("auto_bedtime_pulls_pvp_multi").to_float() > 0)
 	{
 		to_max += "," +get_property("auto_bedtime_pulls_pvp_multi")+ "fites";
 	}


### PR DESCRIPTION
rollover adv are far too important in this path so override the user setting on this

## How Has This Been Tested?

tested in oxy

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
