### PR TITLE
fix aborting for lack of means to damage a ghost

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -84,11 +84,14 @@ void auto_ghost_prep(location place)
 	}
 	
 	//a few iconic spells per avatar is ok. no need to be too exhaustive
-	acquireMP(32, 1000);		//make sure we actually have the MP to cast spells
 	foreach sk in $skills[Saucestorm, saucegeyser,		//base classes
 	Storm of the Scarab,		//actually ed the undying
 	Boil]		//avatar of jarlsberg
 	{
+		if(auto_have_skill(sk))
+		{
+			acquireMP(32, 1000);		//make sure we actually have the MP to cast spells
+		}
 		if(canUse(sk)) return;	//we can kill them with a spell
 	}
 	


### PR DESCRIPTION
fix aborting for lack of means to damage a ghost when the reason we can not damage it is because we do not have the MP to cast our spells, but in fact we have enough meat to restore our MP before battle.
the fix is to attempt to restore MP before that

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
