### PR TITLE
Wildfire: do not always hose hidden temple

### DIFF
--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -430,8 +430,8 @@ boolean LX_wildfire_water()
 	//use water in a variety of ways to reduce fire levels. putting it in pre-adv is problematic since we need to spend adventures here
 	//individual location watering first
 	
-	//for stone wool. needed at level 11 but we acquire it early using [Baa'baa'bu'ran]. no qualifiers since this is always needed
-	if(LX_wildfire_hose($location[The Hidden Temple])) return true;
+	//for stone wool. needed at level 11 but we acquire it early using [Baa'baa'bu'ran].
+	if(internalQuestStatus("questL11Worship") < 3 && LX_wildfire_hose($location[The Hidden Temple])) return true;
 	
 	if(!inKnollSign())		//knoll sign does not need to farm components for bitchin meatcar
 	{

--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -430,7 +430,7 @@ boolean LX_wildfire_water()
 	//use water in a variety of ways to reduce fire levels. putting it in pre-adv is problematic since we need to spend adventures here
 	//individual location watering first
 	
-	//for stone wool. needed at level 11 but we acquire it early using [Baa'baa'bu'ran].
+	//for stone wool. needed at level 11 but we acquire it early using [Baa'baa'bu'ran]. Skip if we've somehow already progressed past that stage
 	if(internalQuestStatus("questL11Worship") < 3 && LX_wildfire_hose($location[The Hidden Temple])) return true;
 	
 	if(!inKnollSign())		//knoll sign does not need to farm components for bitchin meatcar

--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -431,6 +431,11 @@ boolean LX_wildfire_water()
 	//individual location watering first
 	
 	//for stone wool. needed at level 11 but we acquire it early using [Baa'baa'bu'ran]. Skip if we've somehow already progressed past that stage
+	if(internalQuestStatus("questL11Worship") < 3)
+	{
+		if(LX_wildfire_hose($location[The Hidden Temple])) return true;
+	}
+	
 	if(internalQuestStatus("questL11Worship") < 3 && LX_wildfire_hose($location[The Hidden Temple])) return true;
 	
 	if(!inKnollSign())		//knoll sign does not need to farm components for bitchin meatcar

--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -436,8 +436,6 @@ boolean LX_wildfire_water()
 		if(LX_wildfire_hose($location[The Hidden Temple])) return true;
 	}
 	
-	if(internalQuestStatus("questL11Worship") < 3 && LX_wildfire_hose($location[The Hidden Temple])) return true;
-	
 	if(!inKnollSign())		//knoll sign does not need to farm components for bitchin meatcar
 	{
 		if(LX_wildfire_hose($location[The Degrassi Knoll Garage])) return true;


### PR DESCRIPTION
# Description

If the player has already progressed pass hidden temple, there's no need to force a hose down of the area in wildfire path.

## How Has This Been Tested?

Hasn't

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
