### PR TITLE
If already banished, don't look for a way to banish

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -355,6 +355,12 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "";
 	}
 
+	//If it's already banished, banishing it again isn't going to do much.
+	if(is_banished(enemy))
+	{
+		return "";
+	}
+
 	//Check that we actually want to banish this thing.
 	if(!auto_wantToBanish(enemy, loc))
 		return "";


### PR DESCRIPTION
# Description

Stops looking for a way to banish a monster that's already banished.

May need testing? But I'd be surprised if anything breaks from this, other than niche behavior that relied on this buggy behavior.

## How Has This Been Tested?

Ran it locally for Fantasy Airship in Ed Undying, and it no longer tried to banish the Mecha for the 4th time after encountering it in the NC

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
