### PR TITLE
hotfix inf loop when buying clovers

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -460,6 +460,18 @@ boolean acquireTotem()
 	return false;
 }
 
+boolean auto_hermit(int amt, item it)
+{
+	//workaround for this bug https://kolmafia.us/threads/27105/
+	if(it != $item[11-Leaf Clover])
+	{
+		return hermit(amt, it);
+	}
+	int initial = item_amount(it);
+	hermit(amt, it);
+	return item_amount(it) == initial + amt;
+}
+
 boolean acquireHermitItem(item it)
 {
 	if(!isHermitAvailable())
@@ -492,7 +504,7 @@ boolean acquireHermitItem(item it)
 	{
 		if((item_amount($item[Worthless Trinket]) + item_amount($item[Worthless Gewgaw]) + item_amount($item[Worthless Knick-knack])) > 0)
 		{
-			if(!hermit(1, it))
+			if(!auto_hermit(1, it))
 			{
 				return false;
 			}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1121,6 +1121,7 @@ boolean buyUpTo(int num, item it, int maxprice);
 float npcStoreDiscountMulti();
 boolean acquireGumItem(item it);
 boolean acquireTotem();
+boolean auto_hermit(int amt, item it);
 boolean acquireHermitItem(item it);
 boolean pull_meat(int target);
 int handlePulls(int day);


### PR DESCRIPTION
workaround for https://kolmafia.us/threads/27105/
if we end up trying to buy clover when already bought them all it will hit an infinite loop due to a mafia bug.
I think autoscend would only ecnounter it when breaking ronin or dropping a path. but not sure, maybe it happens more often.

## How Has This Been Tested?

ash calls

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
