### PR TITLE
Swallow hermit exception

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -478,7 +478,7 @@ boolean auto_hermit(int amt, item it)
 		return hermit(amt, it);
 	}
 	int initial = item_amount(it);
-	hermit(amt, it);
+	catch hermit(amt, it);
 	return item_amount(it) == initial + amt;
 }
 


### PR DESCRIPTION
# Description

Prevent any errors from hermit being out of clovers from affecting subsequent code. Does not silently swallow exception, don't think it's possible.


```
    catch hermit(1, $item[11-leaf clover]);
    print("Yes!");
```

Without the catch, the "Yes!" will not print.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
