### PR TITLE
Moon spoon combat skill

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -325,6 +325,7 @@ int auto_saberChargesAvailable();
 string auto_combatSaberBanish();
 string auto_combatSaberCopy();
 string auto_combatSaberYR();
+skill auto_spoonCombatSkill();
 string auto_spoonGetDesiredSign();
 void auto_spoonTuneConfirm();
 boolean auto_spoonReadyToTuneMoon();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_community_service.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_community_service.ash
@@ -229,7 +229,7 @@ string cs_combatNormal(int round, monster enemy, string text)
 		return useSkill(auto_spoonCombatSkill());
 	}
 
-	if(have_skill($skill[Saucegeyser]) && (my_mp() >= mp_cost($skill[Saucegeyser])) && (my_class() == $class[Sauceror]))
+	if(canUse($skill[Saucegeyser], false) && my_class() == $class[Sauceror])
 	{
 		return useSkill($skill[Saucegeyser], false);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_community_service.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_community_service.ash
@@ -224,7 +224,12 @@ string cs_combatNormal(int round, monster enemy, string text)
 		return useItem($item[Time-Spinner]);
 	}
 
-	if(canUse($skill[Saucegeyser], false) && my_class() == $class[Sauceror])
+	if(canUse(auto_spoonCombatSkill()))
+	{
+		return useSkill(auto_spoonCombatSkill());
+	}
+
+	if(have_skill($skill[Saucegeyser]) && (my_mp() >= mp_cost($skill[Saucegeyser])) && (my_class() == $class[Sauceror]))
 	{
 		return useSkill($skill[Saucegeyser], false);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_community_service.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_community_service.ash
@@ -224,7 +224,7 @@ string cs_combatNormal(int round, monster enemy, string text)
 		return useItem($item[Time-Spinner]);
 	}
 
-	if(canUse(auto_spoonCombatSkill()))
+	if((my_class() != $class[Sauceror]) && canUse(auto_spoonCombatSkill()))
 	{
 		return useSkill(auto_spoonCombatSkill());
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -123,7 +123,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		return useSkill($skill[Candyblast]);
 	}
 	
-	if(canUse(auto_spoonCombatSkill()))
+	if((my_class() != $class[Sauceror]) && canUse(auto_spoonCombatSkill()))
 	{
 		return useSkill(auto_spoonCombatSkill());
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -123,6 +123,11 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		return useSkill($skill[Candyblast]);
 	}
 	
+	if(canUse(auto_spoonCombatSkill()))
+	{
+		return useSkill(auto_spoonCombatSkill());
+	}
+    
 	//mortar shell is amazing. it really should not be limited to sauceror only.
 	if(canUse($skill[Stuffed Mortar Shell]) && (my_class() == $class[Sauceror]) && canSurvive(2.0) && (currentFlavour() != monster_element(enemy) || currentFlavour() == $element[none]))
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -721,6 +721,11 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 	}
 
 	// Actually killing stuff starts here
+	if(canUse(auto_spoonCombatSkill()))
+	{
+		return useSkill(auto_spoonCombatSkill());
+	}
+    
 	if (my_location() == $location[The Secret Government Laboratory] && canUse($skill[Roar of the Lion], false))
 	{
 		if (canUse($skill[Storm Of The Scarab], false) && my_buffedstat($stat[Mysticality]) >= 60)

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -461,7 +461,7 @@ skill auto_spoonCombatSkill()
 			return $skill[Festoon Buffoon];
 		default:
 			abort("Invalid mainstat, what?");
-			return "butts"; // needed or mafia complains about missing return value
+			return $skill[none]; // needed or mafia complains about missing return value
 	}
 }
 

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -449,6 +449,22 @@ string auto_combatSaberYR()
 	return "skill " + $skill[Use the Force];
 }
 
+skill auto_spoonCombatSkill()
+{
+	switch(my_primestat())
+	{
+		case $stat[Muscle]:
+			return $skill[Dragoon Platoon];
+		case $stat[Mysticality]:
+			return $skill[Spittoon Monsoon];
+		case $stat[Moxie]:
+			return $skill[Festoon Buffoon];
+		default:
+			abort("Invalid mainstat, what?");
+			return "butts"; // needed or mafia complains about missing return value
+	}
+}
+
 string auto_spoonGetDesiredSign()
 {
 	string spoonsign = get_property("auto_spoonsign").to_lower_case();


### PR DESCRIPTION
# Description

Utilizes the combat skill granted by https://kol.coldfront.net/thekolwiki/index.php/Hewn_moon-rune_spoon when possible.

The skills are free, does decent damage and will stagger. Little reason not to use them.

## How Has This Been Tested?

Run `autoscend` while in ed undying. Also in G-Lover

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
