### PR TITLE
Chaos butterfly cannot be used by g-lover

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -20,7 +20,7 @@ War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:
 Possessed Wine Rack
 Blue Oyster cultist
 Dirty Old Lihc	prop:cyrptNicheEvilness>28
-Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
+Possibility Giant	!path:G-Lover;!path:Pocket Familiars;!path:Bees Hate You;prop:chaosButterflyThrown=false;item:chaos butterfly<1
 Serialbus	item:bus pass<5
 CH Imp	item:imp air<5
 Camel Toe	!sniffed:Skinflute

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -132,7 +132,7 @@ sniff	18	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;
 sniff	19	Possessed Wine Rack
 sniff	20	Blue Oyster cultist
 sniff	21	Dirty Old Lihc	prop:cyrptNicheEvilness>28
-sniff	22	Possibility Giant	prop:chaosButterflyThrown=false;item:chaos butterfly<1
+sniff	22	Possibility Giant	!path:G-Lover;!path:Pocket Familiars;!path:Bees Hate You;prop:chaosButterflyThrown=false;item:chaos butterfly<1
 sniff	23	Serialbus	item:bus pass<5
 sniff	24	CH Imp	item:imp air<5
 sniff	25	Camel Toe	!sniffed:Skinflute

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -205,7 +205,7 @@ int auto_estimatedAdventuresForDooks()
 	advCost -= $location[McMillicancuddy's Other Back 40].turns_spent;
 	
 	//these paths cannot use butterfly
-	if(in_bhy() || in_pokefam())
+	if(in_bhy() || in_pokefam() || in_glover())
 	{
 		return advCost;
 	}
@@ -1766,7 +1766,7 @@ boolean L12_themtharHills()
 
 boolean LX_obtainChaosButterfly()
 {
-	if(in_bhy() || in_pokefam())
+	if(in_bhy() || in_pokefam() || in_glover())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Prevents autoscend from trying to acquire and use a chaos butterfly for the ducks sidequest on the island war.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [master branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/master) or have a good reason not to.
