### PR TITLE
Revert "fix: use forked version of Ezandora's script broken due to mo…

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -1,6 +1,6 @@
 github Ezandora/Detective-Solver Release
+github Ezandora/Helix-Fossil Release
 github Ezandora/Far-Future Release
 github gausie/excavator
-github midgleyc/Helix-Fossil Release
 github midgleyc/Voting-Booth
 github Loathing-Associates-Scripting-Society/combo release

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -100,7 +100,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(in_pokefam())
 	{
-		if(git_exists("midgleyc-Helix-Fossil-Release"))
+		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
 		{
 		auto_log_info("Combat via Ezandora:", "green");
 		boolean ignore = cli_execute("Pocket Familiars");

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -36,7 +36,7 @@ boolean pokefam_makeTeam()
 	if(in_pokefam())
 	{
 		// Choose "strongest 2" in order to allow a middle spot for a pocket familiar to level up and earn pokebucks.
-		if(git_exists("midgleyc-Helix-Fossil-Release"))
+		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
 		{
 		auto_log_info("Setting our team via Ezandora:", "green");
 		boolean ignore = cli_execute("PocketFamiliarsAutoSelect Strongest 2;");


### PR DESCRIPTION
…difiers change (#1328)"

This reverts commit b15b8725ab7a6551e434f37c7424ea811046ba06.

# Description

[Helix-Fossil](https://github.com/Ezandora/Helix-Fossil/), along with a lot of other scripts of Ezandora's, were fixed last week after the modifiers change. As such, this can now use Ezandora's script over my fork again.

The git / svn issue hasn't been fixed (and isn't relevant to Helix-Fossil), but given this one was fixed only when something broke, perhaps the SVN issue will also be fixed after GitHub starts browning out SVN? I hope so. 

## How Has This Been Tested?

It hasn't.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
