### PR TITLE
Update auto_combat_default_stage5.ash

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -191,7 +191,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 				}
 			}
 		}
-
 		break;
 	case $class[Turtle Tamer]:
 		attackMinor = "attack with weapon";
@@ -221,7 +220,20 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			attackMajor = useSkill($skill[Saucestorm], false);
 			costMajor = mp_cost($skill[Saucestorm]);
 		}
-
+		if(enemy.physical_resistance > 80)
+		{
+			foreach sk in $skills[Saucestorm, Saucegeyser]
+			{
+				if(canUse(sk, false))
+				{
+					attackMinor = useSkill(sk, false);
+					attackMajor = useSkill(sk, false);
+					costMinor = mp_cost(sk);
+					costMajor = mp_cost(sk);
+					break;
+				}
+			}
+		}
 		break;
 	case $class[Pastamancer]:
 		if(canUse($skill[Cannelloni Cannon], false))
@@ -312,7 +324,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 				return useSkill($skill[Salsaball], false);
 			}
 		}
-		
 		break;
 
 	case $class[Avatar of Boris]:
@@ -458,7 +469,6 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 				costMajor = mp_cost($skill[Grill]);
 			}
 		}
-
 		break;
 
 	case $class[Avatar of Sneaky Pete]:
@@ -507,14 +517,20 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			costMajor = mp_cost($skill[Saucestorm]);
 		}
 
-		if(enemy.physical_resistance > 80 && canUse($skill[Saucestorm], false))
+		if(enemy.physical_resistance > 80)
 		{
-			attackMinor = useSkill($skill[Saucestorm], false);
-			attackMajor = useSkill($skill[Saucestorm], false);
-			costMinor = mp_cost($skill[Saucestorm]);
-			costMajor = mp_cost($skill[Saucestorm]);
+			foreach sk in $skills[Saucestorm, Saucegeyser]
+			{
+				if(canUse(sk, false))
+				{
+					attackMinor = useSkill(sk, false);
+					attackMajor = useSkill(sk, false);
+					costMinor = mp_cost(sk);
+					costMajor = mp_cost(sk);
+					break;
+				}
+			}
 		}
-
 		break;
 
 	case $class[Disco Bandit]:
@@ -540,14 +556,20 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			costMajor = mp_cost($skill[Saucestorm]);
 		}
 
-		if(enemy.physical_resistance > 80 && canUse($skill[Saucestorm], false))
+		if(enemy.physical_resistance > 80)
 		{
-			attackMinor = useSkill($skill[Saucestorm], false);
-			attackMajor = useSkill($skill[Saucestorm], false);
-			costMinor = mp_cost($skill[Saucestorm]);
-			costMajor = mp_cost($skill[Saucestorm]);
+			foreach sk in $skills[Saucestorm, Saucegeyser]
+			{
+				if(canUse(sk, false))
+				{
+					attackMinor = useSkill(sk, false);
+					attackMajor = useSkill(sk, false);
+					costMinor = mp_cost(sk);
+					costMajor = mp_cost(sk);
+					break;
+				}
+			}
 		}
-
 		break;
 
 	case $class[Cow Puncher]:


### PR DESCRIPTION
# Description
TT's combat suite did not properly have a way to deal with physical immune enemies and did not identify it needed to cast Saucestorm on them, so it would exit out on enemies such as the Chalkdust Wraith if regular attacks were not deemed to do enough damage. Seal Clubber had a module for this that TT lacked, so that has been copied over (minus the Northern Explosion portion). hippoking also mentioned that the Moxie classes should be updated too, as their module was less robust and only included a case for Saucestorm use, so the Northern Explosion-free module was ported over for them too, to replace their old Saucestorm-only module with one that can cast Saucestorm and Saucegeyser when detecting a physical immune enemy.

Fixes # (issue)
Arguably might help address issue #230 I guess? I didn't file an independent issue for this problem when I discovered it though.

## How Has This Been Tested?
Ran autoscend in HC LoL with TT today and Ancient Protector Spirit was correctly identified as a unit to use Saucestorm on, while when running without this, enemies such as the Chalkdust Wraith resulted in autoscend exiting due to not knowing how to damage enemy.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
