### PR TITLE
Softcore Legacy of Loathing L12 fix

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -618,7 +618,7 @@ boolean L12_getOutfit()
 	}
 	// if you reached this point you are either in hardcore or are in softcore but ran out of pulls
 	// if really in softcore and out of pulls then returning false here lets you skip it until tomorrow
-	if(!in_hardcore())
+	if(!in_hardcore() && in_lol())
 	{
 		return false;
 	}
@@ -654,7 +654,7 @@ boolean L12_preOutfit()
 	}
 	
 	// in softcore you will pull the war outfit, no need to get pre outfit
-	if(!in_hardcore())
+	if(!in_hardcore() && in_lol())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -618,7 +618,7 @@ boolean L12_getOutfit()
 	}
 	// if you reached this point you are either in hardcore or are in softcore but ran out of pulls
 	// if really in softcore and out of pulls then returning false here lets you skip it until tomorrow
-	if(!in_hardcore() && in_lol())
+	if(!in_hardcore() && !in_lol())
 	{
 		return false;
 	}
@@ -654,7 +654,7 @@ boolean L12_preOutfit()
 	}
 	
 	// in softcore you will pull the war outfit, no need to get pre outfit
-	if(!in_hardcore() && in_lol())
+	if(!in_hardcore() && !in_lol())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Fixes an issue where softcore legacy of loathing runs fail to acquire the pre-war hippy/frat outfits and from there the war hippy/frat outfits and thus do not start the war.

## How Has This Been Tested?

Without these changes autoscend is perpetually stuck in a loop of powerlevelling when it finishes doing everything other than the war or quitting when it reaches level 13. With these changes it starts the war. I've only tested it on 1 run so far.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
