### PR TITLE
AoWoL Ghost Fighting support

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -102,7 +102,7 @@ void auto_ghost_prep(location place)
 		Smoke Break,				//avatar of sneaky pete
 		Fireball Toss,				//path of the plumber
 		Chill of the Tomb,			//dark gyffte
-		Lavafava,					//avatar of west of loathing
+		Lavafava, Pungent Mung, Beanstorm,			  //avatar of west of loathing
 		Hot Foot, Emmental Elemental, Sax of Violence //avatar of shadow over loathing
 		]
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -617,7 +617,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 			costMinor = mp_cost($skill[Beanstorm]);
 		}
 
-		if(canUse($skill[Fan Hammer], false))
+		if(canUse($skill[Fan Hammer], false) && (enemy.physical_resistance < 80))
 		{
 			attackMajor = useSkill($skill[Fan Hammer], false);
 			attackMinor = useSkill($skill[Fan Hammer], false);


### PR DESCRIPTION
# Description

Should fix #1342.

Adds pungent mung and beanstorm from AoWoL to valid spells for fighting ghosts.
Requires enemy physical resistance to be under 80 to use fan hammer.

## How Has This Been Tested?

Untested, please test.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
