### PR TITLE
Red Rocket Fix

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -350,9 +350,7 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 
 	// use red rocket from Clan VIP Lounge to get 5x stats from next food item consumed. Does not stagger on use
-	// consumeStuff fills liver first up to 10 or 15 before eating, pending if billiards room if completed. Gives confidence that we will eat within 100 turns.
-	boolean billiards_check = my_inebriety() >= 10 || !can_drink() || hasSpookyravenLibraryKey();
-	if(canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) && my_adventures() < 100 && billiards_check)
+	if(canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) && my_adventures() < 100)
 	{
 		if(in_plumber())
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -350,7 +350,7 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 
 	// use red rocket from Clan VIP Lounge to get 5x stats from next food item consumed. Does not stagger on use
-	if(canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) && my_adventures() < 100)
+	if(fullness_left() > 0 && canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) && my_adventures() < 100)
 	{
 		if(in_plumber())
 		{


### PR DESCRIPTION
# Description

Red rocket support was made when we always consumed drinks then food. This is no longer true. The removed `billiards_check` conditional isn't valid anymore due to this. Point of it was to delay using red rocket until we had confidence we would be eating something soon.

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
