### PR TITLE
Fixes for Red Rocket, 2002 Store, and Wishing

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -350,9 +350,7 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	}
 
 	// use red rocket from Clan VIP Lounge to get 5x stats from next food item consumed. Does not stagger on use
-	// consumeStuff fills liver first up to 10 or 15 before eating, pending if billiards room if completed. Gives confidence that we will eat within 100 turns.
-	boolean billiards_check = my_inebriety() >= 10 || !can_drink() || hasSpookyravenLibraryKey();
-	if(canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) && my_adventures() < 100 && billiards_check)
+	if(fullness_left() > 0 && canUse($item[red rocket]) && have_effect($effect[Everything Looks Red]) <= 0 && have_effect($effect[Ready to Eat]) <= 0 && canSurvive(5.0) && my_adventures() < 100)
 	{
 		if(in_plumber())
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1804,6 +1804,12 @@ boolean canGenieCombat(monster mon)
 	{
 		return false;
 	}
+	// Per wiki page these can't be wished. Didn't bother to add other crypt monsters as we don't summon them
+	// https://kol.coldfront.net/thekolwiki/index.php/Rubbed_it_the_Right_Way
+	if ($monsters[Fantasy Bandit, Ninja Snowman Assassin, Modern Zmobie] contains mon)
+	{
+		return false;
+	}
 	if (failedWishMonsters contains mon)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -309,7 +309,8 @@ int remainingCatalogCredits()
 	}
 	if(!get_property("_2002MrStoreCreditsCollected").to_boolean())
 	{
-		//todo - collect credits
+		// using item collects credits
+		use($item[2002 Mr. Store Catalog]);
 	}
 	return get_property("availableMrStore2002Credits").to_int();
 }


### PR DESCRIPTION
# Description

Couple fixes for red rocket usage
1 Remove check for billiards. This relied on always consuming booze before food. This is no longer true.
2 Added fullness check. Only need to use red rocket if we can still eat today. Save some meat

Misc Fixes
1 Gather 2002 store credits
2 Can't wish for fantasy bandit, ninja snowman assassin, modern zmobie

Also using this PR to try out making a branch in the main repo rather my fork

## How Has This Been Tested?

- [x] Remove check for billiards allows red rocket usage sooner
- [x] Added fullness check prevents buying red rockets when full
- [x] 2002 store credits are gathers when mafia hasn't done breakfast
- [x] Can't wish for some monsters

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
