### PR TITLE
hotfix latest path (A Shrunken Adventurer Am I) failing if you bought latest IOTM (book of facts) failing due to fantasy bandit is copyable but not genie wishable

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1804,6 +1804,10 @@ boolean canGenieCombat(monster mon)
 	{
 		return false;
 	}
+	if ($monster[fantasy bandit] == mon)
+	{
+		return false;		//these monsters are copyable except for when using genie
+	}
 	if (failedWishMonsters contains mon)
 	{
 		return false;


### PR DESCRIPTION
Book of Facts gives 3 genie wishes a day. Which result in trying to wish for a [fantasy bandit] and failing.
There is actually a whole list of unwishable monsters. but mafia does not track it

## How Has This Been Tested?

I was stuck and this unstuck it.
sauceror normal run of A shrunken adventurer am I

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
