### PR TITLE
auto_pre_adv.ash reports negative stat modifiers for stats as +-

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -25,12 +25,18 @@ void print_footer()
 	}
 	auto_log_info(next_line, "blue");
 	
+	string stat_sign(int s)
+	{
+		if(s >= 0) return "+" +s;
+		else return s;
+	}
+	
 	int bonus_mus = my_buffedstat($stat[muscle]) - my_basestat($stat[muscle]);
 	int bonus_mys = my_buffedstat($stat[mysticality]) - my_basestat($stat[mysticality]);
 	int bonus_mox = my_buffedstat($stat[moxie]) - my_basestat($stat[moxie]);
-	auto_log_info("mus: " +my_basestat($stat[muscle])+ " + " +bonus_mus+
-	". mys: " +my_basestat($stat[mysticality])+ " + " +bonus_mys+
-	". mox: " +my_basestat($stat[moxie])+ " + " +bonus_mox, "blue");
+	auto_log_info("mus: " +my_basestat($stat[muscle])+stat_sign(bonus_mus)+
+	". mys: " +my_basestat($stat[mysticality])+stat_sign(bonus_mys)+
+	". mox: " +my_basestat($stat[moxie])+stat_sign(bonus_mox), "blue");
 	
 	next_line = "";
 	if(pathHasFamiliar())


### PR DESCRIPTION
Small graphical fix. pre adventure was reporting +- when the bonus was negative. ex:
`[INFO] mus: 83 + -55. mys: 138 + -113. mox: 92 + -56`
fixed to only add a + if it is a positive value that need sit.

## Testing
tested with negative values.
`[INFO] mus: 83-55. mys: 138-113. mox: 92-56`

tested with positive mods
`[INFO] mus: 1430+287. mys: 1947+1850. mox: 1430+644`

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
