### PR TITLE
generic infinite loop detection & better L8_trapperGroar() problem detection and handling

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -1077,10 +1077,17 @@ boolean auto_post_adventure()
 	//works with code found in auto_pre_adv.ash
 	if(my_session_adv() == get_property("_auto_inf_session_adv").to_int())
 	{
-		auto_log_debug("auto_post_adv.ash detected that no adventure was spent");
+		auto_log_debug("auto_post_adv.ash detected that no adventure was spent since last auto_pre_adv.ash");
 		
 		//count how many times in a row we went with no adv spent
 		set_property("_auto_inf_counter", get_property("_auto_inf_counter").to_int()+1);
+		
+		//if last monster changed it means we are doing free combats
+		if(get_property("_auto_inf_last_monster").to_monster() != last_monster())
+		{
+			remove_property("_auto_inf_counter");		//reset counter
+		}
+		set_property("_auto_inf_last_monster", last_monster());
 		
 		if(get_property("_auto_inf_counter").to_int() >= 30)
 		{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -1073,6 +1073,31 @@ boolean auto_post_adventure()
 	remove_property("auto_combatDirective");
 	remove_property("auto_digitizeDirective");
 	
+	//try to catch infinite loop where we repeatedly try to do the same thing.
+	//works with code found in auto_pre_adv.ash
+	if(my_session_adv() == get_property("_auto_inf_session_adv").to_int())
+	{
+		auto_log_debug("auto_post_adv.ash detected that no adventure was spent");
+		
+		//count how many times in a row we went with no adv spent
+		set_property("_auto_inf_counter", get_property("_auto_inf_counter").to_int()+1);
+		
+		if(get_property("_auto_inf_counter").to_int() >= 30)
+		{
+			auto_log_error("no adventure was spent " +get_property("_auto_inf_counter")+ " times in a row which suggests we are stuck in an infinite loop. Stopping autoscend");
+			remove_property("_auto_inf_counter");
+			set_property("auto_interrupt", true);
+		}
+		else if(get_property("_auto_inf_counter").to_int() > 10)
+		{
+			auto_log_warning("no adventure was spent " +get_property("_auto_inf_counter")+ " times in a row");
+		}
+	}
+	else		//clear values
+	{
+		remove_property("_auto_inf_counter");
+	}
+	
 	auto_log_info("Post Adventure done, beep.", "purple");
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -917,6 +917,10 @@ boolean auto_pre_adventure()
 	set_property("auto_priorLocation", place);
 	auto_log_info("Pre Adventure at " + place + " done, beep.", "blue");
 	
+	//try to catch infinite loop where we repeatedly try to do the same thing.
+	//works with code found in auto_post_adv.ash
+	set_property("_auto_inf_session_adv", my_session_adv());
+	
 	//to avoid constant flipping on the MCD. change it right before adventuring
 	int mcd_target = get_property("auto_mcd_target").to_int();
 	if(current_mcd() != mcd_target)

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -686,6 +686,11 @@ boolean L8_trapperGroar()
 	{
 		return false; // peak not yet unlocked or we are done with groar
 	}
+	if(get_property("_auto_skip_L8_trapperGroar").to_boolean())
+	{
+		auto_log_warning("Skipping L8_trapperGroar() today as per _auto_skip_L8_trapperGroar");
+		return false;
+	}
 	
 	// error catching for if we are actually on step5 and mafia did not notice.
 	if(item_amount($item[Groar\'s Fur]) > 0 || item_amount($item[Winged Yeti Fur]) > 0 || item_amount($item[Cursed Blanket]) > 0)
@@ -729,14 +734,40 @@ boolean L8_trapperGroar()
 	}
 	if(retval && initial_adv == my_session_adv())
 	{
-		// if mafia tracking failed to advance quest then it will get stuck in an inf loop of trying to adv in [Mist-shrouded Peak]
-		// which becomes an invalid zone after groar dies. being replaced with the new zone called [The Icy Peak]
+		//several inf loops can occur here
+		auto_log_debug("Adventured without spending an adv in [Mist-shrouded Peak]. Checking for problems", "blue");
+		
 		int initial_step = internalQuestStatus("questL08Trapper");
-		auto_log_debug("Adventured without spending adv in [Mist-shrouded Peak]. checking quest status", "blue");
+		string initial_s = get_property("questL08Trapper");
 		cli_execute("refresh quests");
-		if(initial_step == internalQuestStatus("questL08Trapper"))
+		int current_step = internalQuestStatus("questL08Trapper");
+		string current_s = get_property("questL08Trapper");
+		boolean track_error = initial_step != current_step;
+		
+		if(track_error)		//quest tracking was wrong and fixed.
 		{
-			auto_log_warning("questL08Trapper value was incorrect. This has been fixed", "blue");
+			if(current_step > 4)	//boss is actually dead now
+			{
+				// if boss is dead [Mist-shrouded Peak] becomes [The Icy Peak].
+				// common tracking issue which casue inf loop. already fixed by the quest refresh.
+				auto_log_warning("questL08Trapper value was incorrect. Boss is already dead. This has been fixed to prevent inf loop", "blue");
+			}
+			else auto_log_warning("questL08Trapper value was incorrect. This has been fixed", "blue");
+		}
+		else auto_log_debug("questL08Trapper value was correct despite oddity with adv spent");
+
+		if(current_step == 3 || current_step == 4)
+		{
+			// boss is still alive yet no adv was spent. most likely scenario is that our cold res was too low. maybe free combat?
+			if(get_property("_auto_inf_counter").to_int() > 5)
+			{
+				print("We are stuck trying to adventure in [Mist-shrouded Peak] and failing repeatedly","red");
+				print("Probably a problem with cold res. Please report this issue.","red");
+				print("Finish the peak yourself then run autoscend again","red");
+				print("If you wish to have autoscend ignore this and go do other stuff then enter in gCLI:","red");
+				print("set _auto_skip_L8_trapperGroar = true","red");
+				abort();
+			}
 		}
 	}
 	return retval;


### PR DESCRIPTION
# Description

* generic infinite loop catcher. warns if no adv was spent for 10 adv in a row. aborts once it reaches 30 in a row.
* boolean L8_trapperGroar() fixes
  * cleanup the code for checking for groar issues.
  * added potential catching of insufficient cold res causing inf loop
  * abort and inform player to finish it and report the issue.
  * added option to ignore it for rest of day and go do other stuff

## How Has This Been Tested?

I got my main stuck in inf loop at groar fight because kol bug where a recently added +3 cold res buff does not actually provide any cold res.
I tested it there and it correctly caught the infinite loop. Both reporting it and aborting once it reached 30 loops without spending an adv.

with the groar fixes added in. it aborted sooner and reported the issue specific to that problem.
the setting it instructs you to use to ignore it for rest of day works.

also multiple runs with no issue

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
