### PR TITLE
extra settings for [A Shrunken Adventurer Am I]

### DIFF
--- a/RELEASE/scripts/autoscend/paths/small.ash
+++ b/RELEASE/scripts/autoscend/paths/small.ash
@@ -10,6 +10,10 @@ void small_initializeSettings()
 		return;
 	}
 	set_property("auto_wandOfNagamar", true);		//wand  used in this path
+	set_property("auto_getBeehive", true);			//wall is too difficult without it
+	set_property("auto_getBoningKnife", true);		//wall is too difficult without it
+	set_property("auto_ignoreFlyer", true);			//having vastly lower stats means you always die from flyering
+	set_property("auto_getSteelOrgan", false);		//can only consume size 1 drinks
 }
 
 void auto_SmallPulls()

--- a/RELEASE/scripts/autoscend/paths/small.ash
+++ b/RELEASE/scripts/autoscend/paths/small.ash
@@ -12,8 +12,13 @@ void small_initializeSettings()
 	set_property("auto_wandOfNagamar", true);		//wand  used in this path
 	set_property("auto_getBeehive", true);			//wall is too difficult without it
 	set_property("auto_getBoningKnife", true);		//wall is too difficult without it
-	set_property("auto_ignoreFlyer", true);			//having vastly lower stats means you always die from flyering
 	set_property("auto_getSteelOrgan", false);		//can only consume size 1 drinks
+	if(in_hardcore())
+	{
+		//having vastly lower stats and no easy solutions in hardcore means you always die from flyering
+		//should be replaced with a more elegant solution where detailed estimation / calculation is done.
+		set_property("auto_ignoreFlyer", true);
+	}
 }
 
 void auto_SmallPulls()


### PR DESCRIPTION
* get beehive. wall is too difficult without it
* get boning knife. wall is too difficult without it
* ignore flyer in hardcore. being small means you very often die when using it. and in hardcore access to workarounds is restricted. Ideally this would be replaced with a more detailed check & fix in the future.
* do not get [steel margarita]. can only consume size 1 drinks
fixes #1350

## How Has This Been Tested?

validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/main) or have a good reason not to.
