### PR TITLE
Don't consider the arena if auto_ignoreFlyer is set.

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -317,6 +317,10 @@ WarPlan auto_bestWarPlan()
 	{
 		considerNuns = false;
 	}
+	if(get_property("auto_ignoreFlyer").to_boolean())
+	{
+		considerArena = false;
+	}
 	
 	// Calculate the adventure cost of doing each sidequest.
 	int advCostArena = 0;		//Arena actual cost is 0 adventures... unless you mess it up. TODO: check if messed up.


### PR DESCRIPTION
# Description
autoscend wouldn't start the battlefield since flyering in HC was disabled in the small.ash but the war plan didn't check to see if this preference was set.  I'm checking the preference directly instead of the path as I suspect this is also broken if someone were to manually set the preference or in paths where it's set but the path isn't subsequently checked in the war plan.

## How Has This Been Tested?

This was tested in a Hardcore A Shrunken Adventurer am I! run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
