### PR TITLE
Don't pull RO gear our class doesn't get a bonus for

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -316,7 +316,7 @@ void bedtime_pulls_rollover_equip(float desirability)
 			if(!possessEquipment(it) && !canPull(it,true)) continue;		//do not have it and can not pull it.
 			if(!auto_can_equip(it)) continue;		//we can not equip it
 			string bonusOnlyForClass = string_modifier(it,"Class");
-			if(bonusOnlyForClass != "" && bonusOnlyForClass != my_class()) continue;		//can't get benefit of it
+			if(bonusOnlyForClass != "" && bonusOnlyForClass != my_class()) continue;	//can't get benefit of it
 			
 			if($slot[familiar] == sl && !pathHasFamiliar())
 			{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -315,6 +315,8 @@ void bedtime_pulls_rollover_equip(float desirability)
 			if(!($slots[hat, weapon, off-hand, back, shirt, pants, acc1, familiar] contains sl)) continue;	//exotic slot or not equip
 			if(!possessEquipment(it) && !canPull(it,true)) continue;		//do not have it and can not pull it.
 			if(!auto_can_equip(it)) continue;		//we can not equip it
+			string bonusOnlyForClass = string_modifier(it,"Class");
+			if(bonusOnlyForClass != "" && bonusOnlyForClass != my_class()) continue;		//can't get benefit of it
 			
 			if($slot[familiar] == sl && !pathHasFamiliar())
 			{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -316,7 +316,7 @@ void bedtime_pulls_rollover_equip(float desirability)
 			if(!possessEquipment(it) && !canPull(it,true)) continue;		//do not have it and can not pull it.
 			if(!auto_can_equip(it)) continue;		//we can not equip it
 			string bonusOnlyForClass = string_modifier(it,"Class");
-			if(bonusOnlyForClass != "" && bonusOnlyForClass != my_class()) continue;	//can't get benefit of it
+			if(bonusOnlyForClass != "" && bonusOnlyForClass != my_class().to_string()) continue;	//can't get benefit of it
 			
 			if($slot[familiar] == sl && !pathHasFamiliar())
 			{


### PR DESCRIPTION
# Description

I'm a seal clubber. Noticed Drunkula's Cape was pulled for RO advs. Problem is only sauce gets that bonus

![image](https://github.com/loathers/autoscend/assets/4781473/841a5415-2946-4b48-9604-0244d208a0fa)

## How Has This Been Tested?

Works
![image](https://github.com/loathers/autoscend/assets/4781473/1b4e1c72-90ce-4123-b60e-3cacce3bbdde)


## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
