### PR TITLE
Add exception for Small path when checking if we can use free rests when restoring cinch.

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -233,10 +233,11 @@ boolean auto_getCinch(int goal)
 		// don't have enough cinch and don't have any free rests left
 		return false;
 	}
-	if(!haveAnyIotmAlternativeRestSiteAvailable() && get_dwelling() == $item[big rock])
+	if(!haveAnyIotmAlternativeRestSiteAvailable() && (get_dwelling() == $item[big rock] && !in_small()))
 	{
 		// don't have anywhere to rest
 		// get dwelling returns big rock when no place to rest in campsite
+		// exception for Small path as you can't use housing in-run so you will always have a big rock.
 		return false;
 	}
 	// use free rests until have enough cinch or out of rests


### PR DESCRIPTION
# Description

Noticed my free rests weren't being used in small. Turns out we're always stuck on a big rock to rest in/on (how does that work anyway?). The only time free rests are used otherwise is by the restore code (when we have used some cinch).
Personally I think the clause itself should be removed completely as it will block using rests to charge Cincho before hitting level 9 and the extra 40 HP & MP from having the Frobozz House isn't going to be that important but I'll have to test that separately in a Standard run.

Current run without this change has used:
![image](https://github.com/loathers/autoscend/assets/50261170/39601045-ad0b-4ec9-90ab-c180c20cf8dc)

## How Has This Been Tested?

In progress. My test account just finished day 1 of a Normal Small run so I'll let it run day 2 after rollover & then jump back into another run to test it properly.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
