### PR TITLE
Refactor clover handling and save clovers in hardcore for wand

### DIFF
--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -163,21 +163,21 @@ item	42	Flaming Gravy Fairy
 item	43	Frozen Gravy Fairy
 item	44	Spooky Gravy Fairy
 # Physical damage fairy
-item	44	Bowlet
-item	45	Crimbo Elf
+item	45	Bowlet
+item	46	Crimbo Elf
 # Barely special fairies
-item	46	Mechanical Songbird
-item	47	Grouper Groupie
-item	48	Peppermint Rhino
+item	47	Mechanical Songbird
+item	48	Grouper Groupie
+item	49	Peppermint Rhino
 # Fairy that if fed equipment will regen MP and give extra drops. Since we do not make use of this functionality it is just a fairy.
-item	49	Slimeling
+item	50	Slimeling
 # Turtles are cute
-item	50	Syncopated Turtle
+item	51	Syncopated Turtle
 # The original
-item	51	Baby Gravy Fairy
+item	52	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
-item	52	Mutant Fire Ant
+item	53	Mutant Fire Ant
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -514,6 +514,9 @@ boolean acquireHermitItem(item it)
 	{
 		return false;
 	}
+	if (it == $item[11-leaf clover] && get_property("_cloversPurchased") >= 3) {
+		return false;
+	}
 	if(!isGeneralStoreAvailable())
 	{
 		return false;
@@ -776,19 +779,9 @@ int handlePulls(int day)
 			}
 		}
 
-		if(get_property("auto_dickstab").to_boolean())
-		{
-			pullXWhenHaveY($item[Shore Inc. Ship Trip Scrip], 3, 0);
-		}
-
 		if(auto_is_valid($item[Infinite BACON Machine]))
 		{
 			pullXWhenHaveY($item[Infinite BACON Machine], 1, 0);
-		}
-
-		if(is_unrestricted($item[Bastille Battalion control rig]))
-		{
-			string temp = visit_url("storage.php?action=pull&whichitem1=" + to_int($item[Bastille Battalion Control Rig]) + "&howmany1=1&pwd");
 		}
 
 		if(!in_pokefam() && auto_is_valid($item[Replica Bat-oomerang]))

--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -60,6 +60,28 @@ boolean autoAdv(location loc, string option)
 	return autoAdv(1, loc, option);
 }
 
+boolean autoLuckyAdv(location loc, boolean override)
+{
+	boolean gotLucky = false;
+	if (cloversAvailable(override) > 0)
+	{
+		cloverUsageInit(override);
+		gotLucky = autoAdv(loc);
+		if (cloverUsageRestart()) 
+		{
+			gotLucky = autoAdv(loc);
+		}
+		cloverUsageFinish();
+	}
+	return gotLucky;
+}
+
+boolean autoLuckyAdv(location loc)
+{
+	// overload to not override clover usage by default as this is the general case
+	return autoLuckyAdv(loc, false);
+}
+
 
 // autoAdvBypass is used to automate adventuring *once* in non-adventure.php zones
 // it will (should?) handle the complete adventure from start to finish regardless of

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1413,41 +1413,21 @@ int cloversAvailable()
 
 boolean cloverUsageInit(boolean override)
 {
-	if(cloversAvailable(override) == 0)
+	if (cloversAvailable(override) == 0)
 	{
 		abort("Called cloverUsageInit but have no clovers");
 	}
 	//do we already have Lucky!?
-	if(have_effect($effect[Lucky!]) > 0)
+	if (have_effect($effect[Lucky!]) > 0)
 	{
 		return true;
 	}
 
-	//use a clover if we have one in inventory or closet
-	if(item_amount($item[11-Leaf Clover]) < 1)
-	{
-		//try to get one out of closet, catch to avoid an error being thrown
-		catch retrieve_item(1, $item[11-Leaf Clover]);	
-	}
-	if(item_amount($item[11-Leaf Clover]) > 0)
-	{
-		use(1, $item[11-Leaf Clover]);
-		if(have_effect($effect[Lucky!]) > 0)
-		{
-			auto_log_info("Clover usage initialized");
-			return true;
-		}
-		else
-		{
-			auto_log_warning("Did not acquire Lucky! after using an 11-Leaf Clover");
-		}
-	}
-
 	//Use August Scepter skill if we can
-	if(auto_haveAugustScepter() && get_property("_augSkillsCast").to_int() < 5 && !get_property("_aug2Cast").to_boolean())
+	if (auto_haveAugustScepter() && get_property("_augSkillsCast").to_int() < 5 && !get_property("_aug2Cast").to_boolean())
 	{
 		use_skill($skill[Aug. 2nd: Find an Eleven-Leaf Clover Day]);
-		if(have_effect($effect[Lucky!]) > 0)
+		if (have_effect($effect[Lucky!]) > 0)
 		{
 			auto_log_info("Clover usage initialized");
 			return true;
@@ -1458,18 +1438,38 @@ boolean cloverUsageInit(boolean override)
 		}
 	}
 	
-	//use Astral Energy Drinks if we have room
-	if(spleen_left() >= 5)
+	//use a clover if we have one in inventory or closet
+	if (item_amount($item[11-Leaf Clover]) < 1)
 	{
-		if(item_amount($item[[10883]Astral Energy Drink]) < 1)
+		//try to get one out of closet, catch to avoid an error being thrown
+		catch retrieve_item(1, $item[11-Leaf Clover]);	
+	}
+	if (item_amount($item[11-Leaf Clover]) > 0)
+	{
+		use(1, $item[11-Leaf Clover]);
+		if (have_effect($effect[Lucky!]) > 0)
+		{
+			auto_log_info("Clover usage initialized");
+			return true;
+		}
+		else
+		{
+			auto_log_warning("Did not acquire Lucky! after using an 11-Leaf Clover");
+		}
+	}
+	
+	//use Astral Energy Drinks if we have room
+	if (spleen_left() >= 5)
+	{
+		if (item_amount($item[[10883]Astral Energy Drink]) < 1)
 		{
 			//try to get one out of closet
 			retrieve_item(1, $item[[10883]Astral Energy Drink]);		
 		}
-		if(item_amount($item[[10883]Astral Energy Drink]) > 0)
+		if (item_amount($item[[10883]Astral Energy Drink]) > 0)
 		{
 			chew(1, $item[[10883]Astral Energy Drink]);
-			if(have_effect($effect[Lucky!]) > 0)
+			if (have_effect($effect[Lucky!]) > 0)
 			{
 				auto_log_info("Clover usage initialized");
 				return true;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1237,6 +1237,10 @@ boolean autoAdv(int num, location loc, string option);		//num is ignored
 boolean autoAdv(int num, location loc);						//num is ignored
 boolean autoAdv(location loc);
 boolean autoAdv(location loc, string option);
+
+boolean autoLuckyAdv(location loc, boolean override);
+boolean autoLuckyAdv(location loc);
+
 boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string option);
 boolean autoAdvBypass(string url, location loc);
 boolean autoAdvBypass(string url, location loc, string option);
@@ -1650,7 +1654,9 @@ item whatHiMein();
 boolean ovenHandle();
 boolean isGhost(monster mon);
 boolean isProtonGhost(monster mon);
+int cloversAvailable(boolean override);
 int cloversAvailable();
+boolean cloverUsageInit(boolean override);
 boolean cloverUsageInit();
 boolean cloverUsageRestart();
 boolean cloverUsageFinish();

--- a/RELEASE/scripts/autoscend/paths/you_robot.ash
+++ b/RELEASE/scripts/autoscend/paths/you_robot.ash
@@ -950,12 +950,10 @@ boolean LX_robot_powerlevel()
 					whereTo = $location[The Haunted Ballroom];
 					break;
 			}
-
-			cloverUsageInit();
-			boolean adv_spent = autoAdv(whereTo);
-			if(cloverUsageRestart()) adv_spent = autoAdv(whereTo);
-			cloverUsageFinish();
-			if(adv_spent) return true;
+			if(autoLuckyAdv(whereTo))
+			{
+				return true;
+			}
 		}
 		
 		//buy 5 primestats from statbot 5000.

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -327,21 +327,8 @@ boolean L8_getMineOres()
 	}
 	
 	// try to clover for the ore
-	int numCloversKeep = 0;
-	if(get_property("auto_wandOfNagamar").to_boolean())
+	if (autoLuckyAdv($location[Itznotyerzitz Mine]))
 	{
-		numCloversKeep = 1;
-		if(isAboutToPowerlevel())
-		{
-			numCloversKeep = 0;
-		}
-	}
-	if(cloversAvailable() > numCloversKeep)
-	{
-		cloverUsageInit();
-		autoAdvBypass(270, $location[Itznotyerzitz Mine]);
-		if(cloverUsageRestart()) autoAdvBypass(270, $location[Itznotyerzitz Mine]);
-		cloverUsageFinish();
 		return true;
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -394,17 +394,11 @@ boolean L9_aBooPeak()
 	boolean clueCheck = ((clueAmt > 0) || (get_property("auto_aboopending").to_int() != 0));
 	if (get_property("auto_abooclover").to_boolean() && get_property("booPeakProgress").to_int() >= 30 && booCloversOk)
 	{
-		cloverUsageInit();
-		autoAdvBypass(296, $location[A-Boo Peak]);
-		if(cloverUsageRestart())
-		{
-			autoAdvBypass(296, $location[A-Boo Peak]);
-		}
-		if(cloverUsageFinish())
+		if (autoLuckyAdv($location[A-Boo Peak]))
 		{
 			set_property("auto_abooclover", false);
+			return true;
 		}
-		return true;
 	}
 	else if (clueCheck && (get_property("booPeakProgress").to_int() > 2))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1369,11 +1369,7 @@ boolean L11_unlockHiddenCity()
 		if(item_amount($item[Stone Wool]) == 0 && have_effect($effect[Stone-Faced]) == 0 && cloversAvailable() > 0) 
 		{
 			//use clover to get 2x Stone Wool
-			cloverUsageInit();
-			boolean retval = autoAdv($location[The Hidden Temple]);
-			if(cloverUsageRestart()) retval = autoAdv($location[The Hidden Temple]);
-			cloverUsageFinish();
-			return retval;
+			return autoLuckyAdv($location[The Hidden Temple]);
 		}
 		if(item_amount($item[Stone Wool]) == 0 && have_effect($effect[Stone-Faced]) == 0)
 		{
@@ -2419,11 +2415,7 @@ boolean L11_redZeppelin()
 			{
 				set_property("choiceAdventure866", 3);
 			}
-			cloverUsageInit();
-			boolean retval = autoAdv(1, $location[A Mob of Zeppelin Protesters]);
-			if(cloverUsageRestart()) retval = autoAdv(1, $location[A Mob of Zeppelin Protesters]);
-			cloverUsageFinish();
-			return retval;
+			return autoLuckyAdv($location[A Mob of Zeppelin Protesters]);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1873,11 +1873,7 @@ boolean L12_themtharHills()
 	if(have_effect($effect[Sinuses For Miles]) <= 0 && item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]) && cloversAvailable() > 0 && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]))
 	{
 		//use clover to get inhaler
-		cloverUsageInit();
-		boolean retval = autoAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
-		if(cloverUsageRestart()) retval = autoAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
-		cloverUsageFinish();
-		return retval;
+		return autoLuckyAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
 	}
 
 	buffMaintain($effect[Disco Leer], 10, 1, 1);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1855,13 +1855,8 @@ boolean L13_towerNSNagamar()
 		return autoAdv($location[The VERY Unquiet Garves]);
 	}
 	
-	if(cloversAvailable() > 0)
-	{
-		cloverUsageInit();
-		autoAdv($location[The Castle in the Clouds in the Sky (Basement)]);
-		if(cloverUsageRestart()) autoAdv($location[The Castle in the Clouds in the Sky (Basement)]);
-		cloverUsageFinish();
-		if(creatable_amount($item[Wand Of Nagamar]) > 0)
+	if (autoLuckyAdv($location[The Castle in the Clouds in the Sky (Basement)], true)) {
+		if (creatable_amount($item[Wand Of Nagamar]) > 0)
 		{
 			return create(1, $item[Wand Of Nagamar]);
 		}


### PR DESCRIPTION
# Description

Had most of this kicking around for a while and been meaning to put it up for review so it's been pretty well tested but I will give it one more run since I cleaned up the code a bit for this PR.

This will now cause us to hold on to an 11-leaf clover in hardcore in paths which we are required to get the Wand of Nagamar.
It will only do this from day 2 onwards so day 1 clovers can all be used. If anyone manages to get the script to do 1 day Unrestricted runs, more power to them but it's not the remit of this script.
We don't need to do this in Normal runs because we already pull the components of the wand we don't already have (which I guess it could be all of them but that is still just 2 pulls and we would pull a clover if we are still able to before attempting to pull the components anyway).

## How Has This Been Tested?

Ran a lot of runs with (most of) this code. Will run 1 final Normal run in Small to double check everything is all good.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
