### PR TITLE
Eat each legendary pizza once per life

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -906,6 +906,9 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			if(!value_allowed)	continue;
 			if((it == $item[astral pilsner] || it == $item[Cold One] || it == $item[astral hot dog]) && my_level() < 11) continue;
 			if((it == $item[Spaghetti Breakfast]) && (my_level() < 11 || my_fullness() > 0 || get_property("_spaghettiBreakfastEaten").to_boolean())) continue;
+			if(it == $item[Pizza of Legend] && get_property("pizzaOfLegendEaten").to_boolean()) continue;
+			if(it == $item[Calzone of Legend] && get_property("calzoneOfLegendEaten").to_boolean()) continue;
+			if(it == $item[Deep Dish of Legend] && get_property("deepDishOfLegendEaten").to_boolean()) continue;
 
 			int howmany = (it.inebriety > 0) ? 1 : 0;	//can consider a drink action past inebriety limit. but not food past fullness limit
 			howmany += organLeft()/organCost(it);


### PR DESCRIPTION
# Description

HC small was first path to allow eating legendary pizzas. This should have been added then

## How Has This Been Tested?

Old behavior:
```
ash import<autoscend.ash> auto_autoConsumeOneSimulation("eat").name

Updating inventory...
Preference _concoctionDatabaseRefreshes changed from 14 to 15
Returned: Pizza of Legend
```

New behavior:
```
ash import<autoscend.ash> auto_autoConsumeOneSimulation("eat").name

Updating inventory...
Preference _concoctionDatabaseRefreshes changed from 15 to 16
Returned: Calzone of Legend
```

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
