### PR TITLE
Don't double-use waffles

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -233,7 +233,6 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		else
 		{
 			auto_log_warning("Wanted a replacer but we can not find one.", "red");
-			abort("Didn't find a replacer");
 		}
 		combat_status_add("replacercheck");
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -214,9 +214,9 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(combatAction, "item") == 0)
 			{
-				if(contains_text(combatAction, ","))
+				if(contains_text(combatAction, ", none"))
 				{
-					int commapos = index_of(combatAction, ",");
+					int commapos = index_of(combatAction, ", none");
 					handleTracker(enemy, to_item(substring(combatAction, 5, commapos)), "auto_replaces");
 				}
 				else

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -214,8 +214,15 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(combatAction, "item") == 0)
 			{
-				handleTracker(enemy, to_item(substring(combatAction, 5)), "auto_replaces");
-				abort("Used item " + to_item(substring(combatAction, 5)));
+				if(contains_text(combatAction, ","))
+				{
+					int commapos = index_of(combatAction, ",");
+					handleTracker(enemy, to_item(substring(combatAction, 5, commapos)), "auto_replaces");
+				}
+				else
+				{
+					handleTracker(enemy, to_item(substring(combatAction, 5)), "auto_replaces");
+				}
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -216,6 +216,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			{
 				handleTracker(enemy, to_item(substring(combatAction, 5)), "auto_replaces");
 				abort("Used item " + to_item(substring(combatAction, 5)));
+			}
 			else
 			{
 				auto_log_warning("Unable to track replacer behavior: " + combatAction, "red");

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -203,7 +203,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		string combatAction = replaceMonsterCombatString(enemy, true);
 		if(combatAction != "")
 		{
-			//combat_status_add("replacer");
+			combat_status_add("replacer");
 			if(index_of(combatAction, "skill") == 0)
 			{
 				if (to_skill(substring(combatAction, 6)) == $skill[CHEAT CODE: Replace Enemy])

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -214,6 +214,10 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(combatAction, "item") == 0)
 			{
+				if (to_item(substring(combatAction, 5)) == $item[waffle])
+				{
+					handleTracker(enemy, $item[waffle],"auto_replaces");
+				}
 				handleTracker(enemy, to_item(substring(combatAction, 5)), "auto_replaces");
 			}
 			else
@@ -225,6 +229,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		else
 		{
 			auto_log_warning("Wanted a replacer but we can not find one.", "red");
+			abort("Didn't find a replacer");
 		}
 		combat_status_add("replacercheck");
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -214,13 +214,8 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(combatAction, "item") == 0)
 			{
-				if (to_item(substring(combatAction, 5)) == $item[waffle])
-				{
-					handleTracker(enemy, $item[waffle],"auto_replaces");
-					abort("used a waffle");
-				}
 				handleTracker(enemy, to_item(substring(combatAction, 5)), "auto_replaces");
-			}
+				abort("Used item " + to_item(substring(combatAction, 5)));
 			else
 			{
 				auto_log_warning("Unable to track replacer behavior: " + combatAction, "red");

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -198,12 +198,12 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		combat_status_add("freeruncheck");
 	}
 
-	if (!combat_status_check("replacercheck") && canReplace(enemy) && auto_wantToReplace(enemy, my_location()))
+	if (!combat_status_check("replacercheck") && auto_wantToReplace(enemy, my_location()))
 	{
 		string combatAction = replaceMonsterCombatString(enemy, true);
 		if(combatAction != "")
 		{
-			combat_status_add("replacer");
+			//combat_status_add("replacer");
 			if(index_of(combatAction, "skill") == 0)
 			{
 				if (to_skill(substring(combatAction, 6)) == $skill[CHEAT CODE: Replace Enemy])
@@ -217,6 +217,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 				if (to_item(substring(combatAction, 5)) == $item[waffle])
 				{
 					handleTracker(enemy, $item[waffle],"auto_replaces");
+					abort("used a waffle");
 				}
 				handleTracker(enemy, to_item(substring(combatAction, 5)), "auto_replaces");
 			}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -375,7 +375,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		combat_status_add("banishercheck");
 	}
 
-	if (!combat_status_check("replacercheck") && canReplace(enemy) && auto_wantToReplace(enemy, my_location()))
+	if (!combat_status_check("replacercheck") && auto_wantToReplace(enemy, my_location()))
 	{
 		string combatAction = replaceMonsterCombatString(enemy, true);
 		if(combatAction != "")

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -862,7 +862,7 @@ string replaceMonsterCombatString(monster target, boolean inCombat)
 	}
 	if(item_amount($item[waffle]) > 0 && !haveUsed($item[waffle]) && auto_is_valid($item[waffle]))
 	{
-		return "item " + $item[waffle];
+		useItem($item[waffle]);
 	}
 	return "";
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -862,7 +862,7 @@ string replaceMonsterCombatString(monster target, boolean inCombat)
 	}
 	if(item_amount($item[waffle]) > 0 && !haveUsed($item[waffle]) && auto_is_valid($item[waffle]))
 	{
-		useItem($item[waffle]);
+		return useItem($item[waffle], false);
 	}
 	return "";
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -860,9 +860,9 @@ string replaceMonsterCombatString(monster target, boolean inCombat)
 	{
 		return "skill " + $skill[CHEAT CODE: Replace Enemy];
 	}
-	if(item_amount($item[waffle]) > 0 && !haveUsed($item[waffle]) && auto_is_valid($item[waffle]))
+	if(canUse($item[waffle]))
 	{
-		return useItem($item[waffle], false);
+		return useItem($item[waffle]);
 	}
 	return "";
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -862,7 +862,7 @@ string replaceMonsterCombatString(monster target, boolean inCombat)
 	}
 	if(canUse($item[waffle]))
 	{
-		return useItem($item[waffle]);
+		return useItems($item[waffle], $item[none]);
 	}
 	return "";
 }


### PR DESCRIPTION
# Description

Currently double-use waffles. Trying to update code so that it doesn't do that.

## How Has This Been Tested?

Running through normal Standard Sauceror for as quick a run as possible.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
