### PR TITLE
Don't assume we have a mosquito when searching for a default familiar

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1663,7 +1663,7 @@ boolean doTasks()
 	if(my_familiar() == $familiar[Stooper] && pathAllowsChangingFamiliar())
 	{
 		auto_log_info("Avoiding stooper stupor...", "blue");
-		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[Mosquito]);
+		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : findNonRockFamiliarInTerrarium());
 		use_familiar(fam);
 	}
 	if(my_inebriety() > inebriety_limit())
@@ -1970,7 +1970,7 @@ void auto_begin()
 	if(my_familiar() == $familiar[Stooper] && pathAllowsChangingFamiliar())
 	{
 		auto_log_info("Avoiding stooper stupor...", "blue");
-		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : $familiar[Mosquito]);
+		familiar fam = (is100FamRun() ? get_property("auto_100familiar").to_familiar() : findNonRockFamiliarInTerrarium());
 		use_familiar(fam);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -2064,7 +2064,7 @@ void consumeStuff()
 		if (my_familiar() == $familiar[Stooper] && to_familiar(get_property("auto_100familiar")) != $familiar[Stooper] 
 		&& pathAllowsChangingFamiliar()) //check path allows changing of familiars
 		{
-			use_familiar($familiar[Mosquito]);
+			use_familiar(findNonRockFamiliarInTerrarium());
 		}
 
 		ConsumeAction bestAction = auto_findBestConsumeAction();

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -1043,8 +1043,14 @@ void equipRollover(boolean silent)
 		to_max += ",switch Trick-or-Treating Tot";
 	if(auto_have_familiar($familiar[Left-Hand Man]))
 		to_max += ",switch Left-Hand Man";
-	if(my_familiar() == $familiar[none] && auto_have_familiar($familiar[Mosquito]))
-		to_max += ",switch Mosquito";
+	if(my_familiar() == $familiar[none])
+	{
+		familiar anyFam = findNonRockFamiliarInTerrarium();
+		if(anyFam != $familiar[none])
+		{
+			to_max += ",switch " + anyFam.to_string();
+		}
+	}
 
 	maximize(to_max, false);
 

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -250,6 +250,32 @@ boolean canChangeToFamiliar(familiar target)
 	return true;
 }
 
+familiar findNonRockFamiliarInTerrarium()
+{
+	static boolean[familiar] blacklistFamiliars = $familiars[pet rock,
+		toothsome rock,
+		bulky buddy box,
+		holiday log,
+		software bug,
+		bad vibe,
+		pet coral,
+		synthetic rock,
+		pixel rock];
+
+	foreach fam in $familiars[]
+	{
+		if(blacklistFamiliars contains fam)
+		{
+			continue;
+		}
+		if(in_terrarium(fam) && auto_have_familiar(fam))
+		{
+			return fam;
+		}
+	}
+	return $familiar[none];
+}
+
 familiar lookupFamiliarDatafile(string type)
 {
 	//This function looks through /data/autoscend_familiars.txt for the matching "type" in order and selects the first match whose conditions are met. Said conditions typically include path exclusions and a check to see if that familiar dropped something today.

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1385,6 +1385,7 @@ boolean pathAllowsChangingFamiliar();
 boolean auto_have_familiar(familiar fam);
 boolean canChangeFamiliar();
 boolean canChangeToFamiliar(familiar target);
+familiar findNonRockFamiliarInTerrarium();
 familiar lookupFamiliarDatafile(string type);
 boolean handleFamiliar(string type);
 boolean handleFamiliar(familiar fam);

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -432,7 +432,7 @@ void auto_scepterSkills()
 		{
 			if(!is100FamRun())
 			{
-				use_familiar($familiar[Mosquito]); //equipping Mosquito so we don't get a big rock
+				use_familiar(findNonRockFamiliarInTerrarium()); //equipping any non-rock fam so we don't get a big rock
 			}
 			use_skill($skill[Aug. 28th: Race Your Mouse Day!]); //Fam equipment
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -432,7 +432,7 @@ void auto_scepterSkills()
 		{
 			if(!is100FamRun())
 			{
-				use_familiar(findNonRockFamiliarInTerrarium()); //equipping any non-rock fam so we don't get a big rock
+				use_familiar(findNonRockFamiliarInTerrarium()); //equip non-rock fam to ensure we get tiny gold medal
 			}
 			use_skill($skill[Aug. 28th: Race Your Mouse Day!]); //Fam equipment
 		}


### PR DESCRIPTION
# Description

Reported in discord that LoL doesn't have a mosquito. This fixes that by instead of hardcoding a familiar we expect to have, instead search for an actually available familiar

## How Has This Been Tested?

Did a normal standard run without issue

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
