### PR TITLE
Coal lumber mill at lvl 11 instead of 13

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -727,10 +727,8 @@ void auto_checkTrainSet()
 	int two;
 	int three;
 	int four;
-	if(my_level() < 13) //check if we need more stats. There is no check for disregard instant karma because
+	if(my_level() < 11) //check if we need more stats. There is no check for disregard instant karma because
 	//if we do check, we will never double lumber mill, which is more beneficial than continuing to double mainstat.
-	//Do we want the next line's if statement instead because this will still generate so many stats
-	//if(my_level() < 12) //Double mainstat until we reach L12
 	{
 		if(my_primestat() == $stat[Muscle])
 		{


### PR DESCRIPTION
# Description

Trainset gives lots of xp. Don't need to double mainstat until level 13. This changes makes it so we double lumber mill at level 11 instead of 13. With the hopes of getting more CMC consults D1 since we will finish building the bridge sooner

## How Has This Been Tested?

D1 of normal standard run went well. Still only got 1 consult in, homebodyl. However I got unlucky with bridge part drops. Had a 30/47 split. Change worked as intended - when I hit 11, train set was confgured to double lumber mill instead of mainstat. Still got to level 14 end of D1, so leveling isn't an issue on a shiny account

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
