### PR TITLE
pull breath

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -872,6 +872,10 @@ void auto_CMCconsult()
 		}
 		return notAboutToDoNuns();
 	}
+	if(shouldChewBreathitin() && !isActuallyEd() && !haveSpleenFamiliar() && !can_interact())
+	{
+		pullXWhenHaveY($item[Breathitin&trade;],1,0);
+	}
 	if(item_amount($item[Breathitin&trade;]) > 0 && shouldChewBreathitin() && !can_interact())
 	{
 		autoChew(1,$item[Breathitin&trade;]);


### PR DESCRIPTION
# Description

Pull breathitins. We have extra spleen in standard, let's use it. For out of standard, put conditional to not pull if we have spleen fam or can interact. Figure we have better choices then?

## How Has This Been Tested?

Going to do a small normal run. D1 went well. Pulled at start and used right away, no charges wasted on other free outdoor fights

D2 went well too. 
![image](https://github.com/loathers/autoscend/assets/4781473/223e78ed-0c70-430d-92b0-5f708908fecc)


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
