### PR TITLE
summon and backup grops into delay

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1991,6 +1991,12 @@ boolean LX_summonMonster()
 		if(summonMonster($monster[Astronomer])) return true;
 	}
 
+	// summon grops to start copy chain. Goal is to copy into delay zones and get war progress at same time. Bonus if we get smoke bombs
+	if(get_property("lastCopyableMonster") != $monster[Green Ops Soldier].to_string() && get_property("hippiesDefeated") > 399 && !in_koe())
+	{
+		if(summonMonster($monster[Green Ops Soldier])) return true;
+	}
+
 	// summon additional monsters in heavy rains with rain man when available
 	if(have_skill($skill[Rain Man]) && my_rain() >= 50)
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1992,7 +1992,7 @@ boolean LX_summonMonster()
 	}
 
 	// summon grops to start copy chain. Goal is to copy into delay zones and get war progress at same time. Bonus if we get smoke bombs
-	if(get_property("lastCopyableMonster") != $monster[Green Ops Soldier].to_string() && get_property("hippiesDefeated") > 399 && !in_koe())
+	if(!summonedMonsterToday($monster[Green Ops Soldier]) && get_property("hippiesDefeated") > 399 && !in_koe())
 	{
 		if(summonMonster($monster[Green Ops Soldier])) return true;
 	}
@@ -2099,6 +2099,15 @@ boolean summonMonster(monster mon, boolean speculative)
 	}
 
 	return false;
+}
+
+boolean summonedMonsterToday(monster mon)
+{
+	string copiedMonsters = get_property("auto_copies");
+	string searchString = "(" + my_daycount() + ":" + mon.to_string();
+	//"(" + my_daycount() + ":" + safeString(used) + ":" + my_turncount() + ")";
+	return contains_text(copiedMonsters, searchString);
+	//`({my_daycount()}:{mon.to_string()}`;
 }
 
 boolean handleCopiedMonster(item itm)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1992,7 +1992,7 @@ boolean LX_summonMonster()
 	}
 
 	// summon grops to start copy chain. Goal is to copy into delay zones and get war progress at same time. Bonus if we get smoke bombs
-	if(!summonedMonsterToday($monster[Green Ops Soldier]) && get_property("hippiesDefeated") > 399 && get_property("hippiesDefeated") < 1000 && !in_koe())
+	if(!summonedMonsterToday($monster[Green Ops Soldier]) && get_property("hippiesDefeated").to_int() > 399 && get_property("hippiesDefeated").to_int() < 1000 && !in_koe())
 	{
 		if(summonMonster($monster[Green Ops Soldier])) return true;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1992,7 +1992,7 @@ boolean LX_summonMonster()
 	}
 
 	// summon grops to start copy chain. Goal is to copy into delay zones and get war progress at same time. Bonus if we get smoke bombs
-	if(!summonedMonsterToday($monster[Green Ops Soldier]) && get_property("hippiesDefeated") > 399 && !in_koe())
+	if(!summonedMonsterToday($monster[Green Ops Soldier]) && get_property("hippiesDefeated") > 399 && get_property("hippiesDefeated") < 1000 && !in_koe())
 	{
 		if(summonMonster($monster[Green Ops Soldier])) return true;
 	}
@@ -2105,9 +2105,7 @@ boolean summonedMonsterToday(monster mon)
 {
 	string copiedMonsters = get_property("auto_copies");
 	string searchString = "(" + my_daycount() + ":" + mon.to_string();
-	//"(" + my_daycount() + ":" + safeString(used) + ":" + my_turncount() + ")";
 	return contains_text(copiedMonsters, searchString);
-	//`({my_daycount()}:{mon.to_string()}`;
 }
 
 boolean handleCopiedMonster(item itm)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1686,6 +1686,7 @@ boolean LX_summonMonster();
 boolean canSummonMonster(monster mon);
 boolean summonMonster(monster mon);
 boolean summonMonster(monster mon, boolean speculative);
+boolean summonedMonsterToday(monster mon);
 boolean handleCopiedMonster(item itm);
 boolean handleCopiedMonster(item itm, string option);
 int maxSealSummons();

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -355,7 +355,7 @@ boolean auto_backupTarget()
 				return true;
 			break;
 		case $monster[Green Ops Soldier]:
-			if(get_property("hippiesDefeated") > 399 && get_property("hippiesDefeated") < 1000 && !in_koe())
+			if(get_property("hippiesDefeated").to_int() > 399 && get_property("hippiesDefeated").to_int() < 1000 && !in_koe())
 				return true;
 			break;
 		default: break;

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -355,7 +355,7 @@ boolean auto_backupTarget()
 				return true;
 			break;
 		case $monster[Green Ops Soldier]:
-			if(get_property("hippiesDefeated") > 399 && !in_koe())
+			if(get_property("hippiesDefeated") > 399 && get_property("hippiesDefeated") < 1000 && !in_koe())
 				return true;
 			break;
 		default: break;

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -354,6 +354,10 @@ boolean auto_backupTarget()
 			if(!acquiredFantasyRealmToken() && auto_backupUsesLeft() >= (5 - fantasyBanditsFought()))
 				return true;
 			break;
+		case $monster[Green Ops Soldier]:
+			if(get_property("hippiesDefeated") > 399 && !in_koe())
+				return true;
+			break;
 		default: break;
     }
 


### PR DESCRIPTION
# Description

Summon and backup green ops soldiers. They progress L12 war regardless of where killed plus have a chance to drop smoke bombs for free runs. Smoke bombs are already supported

## How Has This Been Tested?

Normal small run. D1 it used locket to summon grops and then backed up until out of charges, as expected. 3 backups in this case. In days past it would have been 4. Some variability is expected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
