### PR TITLE
make sure CMG is equipped when burning delay and pre-charge it for subsequent days.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1779,16 +1779,6 @@ boolean doTasks()
 	auto_checkTrainSet();
 	prioritizeGoose();
 
-	// TODO: tidy this up into a function somewhere. Can't go in handlePulls though as that's called before we switch workshed to trainset.
-	// worksheds are swapped in LX_setWorkshed() which is called in task order
-	if (get_workshed() == $item[model train set] && canPull($item[smut orc keepsake box]) && lumberCount() < 26 && fastenerCount() < 26)
-	{
-		if (pullXWhenHaveY($item[smut orc keepsake box], 1, 0))
-		{
-			use(1, $item[smut orc keepsake box]);
-		}
-	}
-
 	ocrs_postCombatResolve();
 	beatenUpResolution();
 	lar_safeguard();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -362,9 +362,7 @@ boolean LX_burnDelay()
 	boolean wannaDigitize = isOverdueDigitize();
 	boolean wannaSausage = auto_sausageGoblin();
 	boolean wannaBackup = auto_backupTarget();
-	// Cursed Magnifying Glass gives a void monster combat every 13 turns. The first 5 are free fights
-	// _voidFreeFights counts up from 0 and stays at 5 once all free fights are completed for the day
-	boolean voidMonsterNext = (get_property("_voidFreeFights").to_int() < 5) && (get_property("cursedMagnifyingGlassCount").to_int() == 13);
+	boolean voidMonsterNext = auto_voidMonster();
 
 	// if we're a plumber and we're still stuck doing a flat 15 damage per attack
 	// then a scaling monster is probably going to be a bad time
@@ -426,12 +424,10 @@ boolean LX_burnDelay()
 		if(voidMonsterNext)
 		{
 			auto_log_info("Burn some delay somewhere (cursed magnifying glass), if we found a place!", "green");
-			set_property("auto_nextEncounter","void guy");	//which of the 3 is random, but they're all same phylum and free under same conditions
-			if(autoAdv(burnZone))
+			if(auto_voidMonster(burnZone))
 			{
 				return true;
 			}
-			set_property("auto_nextEncounter","");
 		}
 	}
 	else if(wannaVote || wannaDigitize || wannaSausage || voidMonsterNext)
@@ -1782,6 +1778,16 @@ boolean doTasks()
 	auto_CMCconsult();
 	auto_checkTrainSet();
 	prioritizeGoose();
+
+	// TODO: tidy this up into a function somewhere. Can't go in handlePulls though as that's called before we switch workshed to trainset.
+	// worksheds are swapped in LX_setWorkshed() which is called in task order
+	if (get_workshed() == $item[model train set] && canPull($item[smut orc keepsake box]) && lumberCount() < 26 && fastenerCount() < 26)
+	{
+		if (pullXWhenHaveY($item[smut orc keepsake box], 1, 0))
+		{
+			use(1, $item[smut orc keepsake box]);
+		}
+	}
 
 	ocrs_postCombatResolve();
 	beatenUpResolution();

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -688,25 +688,21 @@ void finalizeMaximize(boolean speculative)
 			addToMaximize("-equip " + wrap_item($item[Kramco Sausage-o-Matic&trade;]).to_string());
 		}
 	}
-	if (possessEquipment($item[Cursed Magnifying Glass]))
+	if (auto_haveCursedMagnifyingGlass())
 	{
 		if (get_property("cursedMagnifyingGlassCount").to_int() == 13)
 		{
-			if(get_property("mappingMonsters").to_boolean() || auto_backupTarget() || (get_property("_voidFreeFights").to_int() >= 5 && !in_hardcore()))
+			if(get_property("mappingMonsters").to_boolean() || auto_backupTarget() || (get_property("_voidFreeFights").to_int() >= 5 && get_property("cursedMagnifyingGlassCount").to_int() >= 13 && !in_hardcore()))
 			{
 				// don't equip for non free fights in softcore? (pending allowed conditions like delay zone && none of the monsters in the zone is a sniff/YR target?)
 				// don't interfere with backups or Map the Monsters
 				addToMaximize("-equip " + $item[Cursed Magnifying Glass].to_string());
 			}
-			else if(get_property("_voidFreeFights").to_int() < 5)
-			{
-				// add bonus if next fight is a free void monster
-				addBonusToMaximize($item[Cursed Magnifying Glass], 1000);
-			}
 		}
-		else if(!nextMonsterIsFree && get_property("_voidFreeFights").to_int() < 5 && solveDelayZone() != $location[none])
+		else if(!nextMonsterIsFree && (get_property("_voidFreeFights").to_int() < 5 || (get_property("_voidFreeFights").to_int() >= 5 && get_property("cursedMagnifyingGlassCount").to_int() < 13)) && solveDelayZone() != $location[none])
 		{
 			// add bonus to charge free fights. charge is added when completing nonfree fights only
+			// also we can pre-charge it for the next day once we have used our 5 free fights.
 			addBonusToMaximize($item[Cursed Magnifying Glass], 200);
 		}
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -456,6 +456,9 @@ void auto_CMCconsult();
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2022.ash
+boolean auto_haveCursedMagnifyingGlass();
+boolean auto_voidMonster();
+boolean auto_voidMonster(location loc);
 boolean auto_haveCosmicBowlingBall();
 string auto_bowlingBallCombatString(location place, boolean speculation);
 boolean auto_haveCombatLoversLocket();

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -1,5 +1,47 @@
 # This is meant for items that have a date of 2022
 
+boolean auto_haveCursedMagnifyingGlass()
+{
+	if (possessEquipment($item[cursed magnifying glass]) && auto_can_equip($item[cursed magnifying glass])) {
+		return true;
+	}
+	return false;
+}
+
+boolean auto_voidMonster()
+{
+	return auto_voidMonster($location[none]);
+}
+
+boolean auto_voidMonster(location loc)
+{
+	// Cursed Magnifying Glass gives a void monster combat every 13 turns. The first 5 are free fights
+	// _voidFreeFights counts up from 0 and stays at 5 once all free fights are completed for the day
+	if (!auto_haveCursedMagnifyingGlass())
+	{
+		return false;
+	}
+
+	// return false if we've fought the 5 free void monsters already today or we're still charging up the counter
+	if (get_property("_voidFreeFights").to_int() >= 5 || get_property("cursedMagnifyingGlassCount").to_int() != 13)
+	{
+		return false;
+	}
+
+	if (loc == $location[none])
+	{
+		return true;
+	}
+
+	if (autoEquip($item[cursed magnifying glass]))
+	{
+		set_property("auto_nextEncounter","void guy");	//which of the 3 is random, but they're all same phylum and free under same conditions
+		return autoAdv(loc);
+	}
+	set_property("auto_nextEncounter","");
+	return false;
+}
+
 boolean auto_haveCosmicBowlingBall()
 {
 	// ensure we not only own one but it's in allowed in path and also in inventory for us to do stuff with.


### PR DESCRIPTION
# Description

Fixing a minor issue with delay burning using the CMG. I checked my log from my current run to see how it was handling using the 8bit zones to burn delay & noticed it failed to fight a void monster 3 times in a row in Vanya's Castle. Once the bonus zone changed to Megalo-City it equipped the CMG correctly & fought the void monster.
This change forces the CMG to be equipped in the off-hand slot when burning delay fighting a free void monster rather than relying on the maximizers weighting.

I also added a small change to when the CMG is equipped to charge it as we can pre-charge it for the next day when we still have delay to burn.

## How Has This Been Tested?

Hasn't yet. My test account is in Small but has finished day 1. I'll have it run day 2 after rollover then start a new day 1 to verify it's all as expected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
