### PR TITLE
Only need 1 led candle for jill

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -5,7 +5,7 @@
 Steam-Powered Cheerleader	path:KOLHS
 # Fairies with a multiplier
 # 1.5x multiplier fairy
-Jill-of-All-Trades	item:LED candle>1
+Jill-of-All-Trades	item:LED candle>0
 # 1.4x multiplier fairy
 Steam-Powered Cheerleader	prop:_cheerleaderSteam>150
 # 1.3x multiplier fairy

--- a/BUILD/familiars/meat.dat
+++ b/BUILD/familiars/meat.dat
@@ -17,7 +17,7 @@ Adventurous Spelunker	prop:_spelunkingTalesDrops<1
 Blavious Kloop	prop:_kloopDrops<3
 # Leprechauns with a >1 multiplier
 # 1.5x multiplier leprechaun
-Jill-of-All-Trades	item:LED candle>1
+Jill-of-All-Trades	item:LED candle>0
 #Mutant Cactus Bud	grimdark:0
 Hobo Monkey
 #Mutant Cactus Bud	grimdark:1

--- a/BUILD/familiars/stat.dat
+++ b/BUILD/familiars/stat.dat
@@ -7,7 +7,7 @@ Hovering Sombrero	ML:>=120
 # Can be tuned to give pure mainstat, so it's better than other volleyballs
 Crimbo Shrub
 # Volleyballs with a multiplier
-Jill-of-All-Trades	item:LED candle>1
+Jill-of-All-Trades	item:LED candle>0
 #Baby Mutant Rattlesnake	grimdark:0
 #Baby Mutant Rattlesnake	grimdark:1
 # Fairyeverything

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -108,7 +108,7 @@ init	3	Happy Medium
 item	0	Steam-Powered Cheerleader	path:KOLHS
 # Fairies with a multiplier
 # 1.5x multiplier fairy
-item	1	Jill-of-All-Trades	item:LED candle>1
+item	1	Jill-of-All-Trades	item:LED candle>0
 # 1.4x multiplier fairy
 item	2	Steam-Powered Cheerleader	prop:_cheerleaderSteam>150
 # 1.3x multiplier fairy
@@ -206,7 +206,7 @@ meat	8	Adventurous Spelunker	prop:_spelunkingTalesDrops<1
 meat	9	Blavious Kloop	prop:_kloopDrops<3
 # Leprechauns with a >1 multiplier
 # 1.5x multiplier leprechaun
-meat	10	Jill-of-All-Trades	item:LED candle>1
+meat	10	Jill-of-All-Trades	item:LED candle>0
 #Mutant Cactus Bud	grimdark:0
 meat	11	Hobo Monkey
 #Mutant Cactus Bud	grimdark:1
@@ -321,7 +321,7 @@ stat	4	Hovering Sombrero	ML:>=120
 # Can be tuned to give pure mainstat, so it's better than other volleyballs
 stat	5	Crimbo Shrub
 # Volleyballs with a multiplier
-stat	6	Jill-of-All-Trades	item:LED candle>1
+stat	6	Jill-of-All-Trades	item:LED candle>0
 #Baby Mutant Rattlesnake	grimdark:0
 #Baby Mutant Rattlesnake	grimdark:1
 # Fairyeverything


### PR DESCRIPTION
# Description

Previously was incorrectly requiring 2 candles to prioritize Jill's extra 50% bonus's. Actually just need 1

## How Has This Been Tested?

CLI. Have 1 LED candle in inventory. `autorun` is my alias to easily import and run autoscend commands

Before
```
> autorun lookupFamiliarDatafile("meat")

[DEBUG] lookupFamiliarDatafile is checking for type [meat]
Returned: Hobo Monkey
```

After
```
> autorun lookupFamiliarDatafile("meat")

[DEBUG] lookupFamiliarDatafile is checking for type [meat]
Returned: Jill-of-All-Trades
```


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
