### PR TITLE
Uncap PreAdv MP Restore Spending

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -918,7 +918,7 @@ boolean auto_pre_adventure()
 	borisWastedMP();
 	borisTrusty();
 
-	acquireMP(32, 1000);
+	acquireMP(32, 0);
 
 	if(in_hardcore() && (my_class() == $class[Sauceror]) && (my_mp() < 32))
 	{

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1544,7 +1544,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 		if(metadata.type == "skill")
 		{
 			skill s = to_skill(metadata.name);
-			if(my_mp() < mp_cost(s) && !acquireMP(mp_cost(s), meat_reserve, useFreeRests))
+			if(my_mp() < mp_cost(s) && !acquireMP(mp_cost(s), 0, useFreeRests))
 			{
 				auto_log_warning("Couldnt acquire enough MP to cast " + s, "red");
 				return false;

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -162,7 +162,7 @@ void prepareForSmutOrcs()
 		// so let's not waste time and console spam when we're a class or path that can't do any of this.
 		boolean useSpellsInOrcCamp = false;
 		
-		acquireMP(32, 1000);	//pre_adv will always do this later, but waiting for it may fail checks of ability to cast spells here
+		acquireMP(32, 0);	//pre_adv will always do this later, but waiting for it may fail checks of ability to cast spells here
 		if(setFlavour($element[cold]) && canUse($skill[Stuffed Mortar Shell]))
 		{
 			useSpellsInOrcCamp = true;

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1673,7 +1673,7 @@ boolean L11_hiddenCity()
 	if(!in_robot() &&
 	!in_darkGyffte() &&
 	weapon_ghost_dmg < 20 &&				//we can not rely on melee/ranged weapon to kill the ghost
-	!acquireMP(30))							//try getting some MP, relying on a spell to kill them instead. TODO verify we have a spell
+	!acquireMP(30, 0))						//try getting some MP, relying on a spell to kill them instead. TODO verify we have a spell
 	{
 		auto_log_warning("We can not reliably kill Specters in hidden city due to a shortage of MP and elemental weapon dmg. Delaying zone", "red");
 		return false;


### PR DESCRIPTION
# Description
This commit makes autoscend more aggressive about spending meat on combat MP. Specifically, it changes the meat_reserve param for many locations of pre-adventure MP logic to 0, allowing autoscend to spend all available meat to ensure there is MP before adventuring. "Pre-adventure" MP in this context means MP acquired after buffing and immediately before adventuring, mainly, combat MP.

- Removes hardcoded 1k meat reserve for acquireMP in auto_pre_adv
- Removes meat_reserve check when restoring MP to use skills to restore HP in auto_restore
- Updates early acquireMP in level_09 when checking for orc overkill to match pre_adv
- Removes meat_reserve check when restoring MP to kill specters in level_11

Fixes loathers/autoscend#842
Impacts loathers/autoscend#743: more spending on combat MP slightly alleviates issue

## How Has This Been Tested?

1. **Condition Testing:** Ran autoscend without changes until aborting due to one of the above conditions. Applied changes. Observe autoscend restoring mp and continuing to run normally.
2. **Limit Testing:** Observed behavior with the new meat limit (0) working as expected - autoscend spends meat to restore MP until it can't find a restorer it can afford.
3. **General Testing:** Ran for a few thousand turns across various resource limited accounts: hardcore standard, casual, softcore standard, softcore smol. Observed autoscend working as expected at low and high meat & mp values.

If anybody can think of a more important use for the 1000 meat that was being set aside, please feel free to discuss. I couldn't think of anything more important than making sure we have MP to survive the next adv.

I am on LASS Discord as Synaptic Misfire if anybody wants to chat there. Out of town until next week but will check out any feedback when I get back!

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
