### PR TITLE
early exit for ultra-hydrated bofa wait

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1307,7 +1307,7 @@ boolean L11_aridDesert()
 			return autoadv(1, $location[The Arid\, Extra-Dry Desert]);
 		}
 
-		if(auto_haveBofa())
+		if(auto_haveBofa() && !isAboutToPowerlevel())
 		{
 			// wait for a monster to give us ultrahydrated
 			return false;


### PR DESCRIPTION
# Description

Standard HC run ran out of stuff to do. Stuck at 10 desert left to explore and didn't find any monsters with ultrahydrated. This lets us continue if we finish everything else

## How Has This Been Tested?

Ran out of stuff to do in HC. Made this change, autoscend continued run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
