### PR TITLE
fix: check if a player is online before trying consults

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1115,7 +1115,7 @@ boolean dailyEvents()
 		use_skill(1, $skill[That\'s Not a Knife]);
 	}
 
-	while(zataraClanmate(""));
+	while(zataraClanmate());
 
 	if(item_amount($item[Genie Bottle]) > 0 && auto_is_valid($item[genie bottle]) && auto_is_valid($item[pocket wish]) && !in_glover())
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -62,7 +62,7 @@ boolean drinkSpeakeasyDrink(item drink);
 boolean drinkSpeakeasyDrink(string drink);
 boolean zataraAvailable();
 boolean zataraSeaside(string who);
-boolean zataraClanmate(string who);
+boolean zataraClanmate();
 boolean eatFancyDog(string dog);
 boolean auto_floundryUse();
 boolean auto_floundryAction();

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -427,6 +427,22 @@ boolean zataraClanmate()
 #	}
 #	set_property("_clanFortuneConsultUses", get_property("_clanFortuneConsultUses").to_int() + 1);
 
+	int attempts = 0;
+	int player = 3038166;
+	string consultOverrideName = get_property("auto_consultChoice");
+	string name = get_player_name(player);
+	if (consultOverrideName != "")
+	{
+		name = consultOverrideName;
+		player = get_player_id(consultOverrideName).to_int();
+	}
+
+	if (!is_online(name))
+	{
+		// consult will not return in reasonable timeframe
+		return false;
+	}
+
 	int oldClan = get_clan_id();
 	string clanName = get_property("auto_consultClan");
 	if (clanName != "")
@@ -441,22 +457,6 @@ boolean zataraClanmate()
 	if(get_clan_name() != clanName)
 	{
 		set_property("_clanFortuneConsultUses", 42069);
-		return false;
-	}
-
-	int attempts = 0;
-	int player = 3038166;
-	string consultOverrideName = get_property("auto_consultChoice");
-	string name = get_player_name(player);
-	if (consultOverrideName != "")
-	{
-		name = consultOverrideName;
-		player = get_player_id(consultOverrideName).to_int();
-	}
-
-	if (!is_online(name))
-	{
-		// consult will not return in reasonable timeframe
 		return false;
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -397,9 +397,8 @@ boolean zataraSeaside(string who)
 	return true;
 }
 
-boolean zataraClanmate(string who)
+boolean zataraClanmate()
 {
-	# who is ignored.
 	if(item_amount($item[Clan VIP Lounge Key]) == 0)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -455,6 +455,12 @@ boolean zataraClanmate(string who)
 		player = get_player_id(consultOverrideName).to_int();
 	}
 
+	if (!is_online(name))
+	{
+		// consult will not return in reasonable timeframe
+		return false;
+	}
+
 	boolean needWait = true;
 
 	while(attempts < 5)


### PR DESCRIPTION
# Description

Should fix the issues with cheesefax being offline, as reported in Discord.

## How Has This Been Tested?

I ran `ash import <autoscend> ; zataraClanmate()` and confirmed it returned false.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
