### PR TITLE
equip LED Candle and some CMC tweaks

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -807,11 +807,12 @@ void preAdvUpdateFamiliar(location place)
 		}
 	}
 
-	if(my_familiar() == $familiar[Jill-of-All-Trades] && item_amount($item[LED candle]) > 0)
+	if (my_familiar() == $familiar[Jill-of-All-Trades] && possessEquipment($item[LED candle]))
 	{
 		// maximizer uses whatever mode LED candle is in, won't change it
 		// so ensure in correct mode prior to maximizing
 		auto_handleJillOfAllTrades();
+		autoEquip($item[LED Candle]); // force maximizer to equip it when we have it.
 	}
 	
 	if(auto_checkFamiliarMummery(my_familiar()))

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -923,14 +923,17 @@ void auto_CMCconsult()
 		bestOption = 5;
 		consumableBought = $item[Breathitin&trade;];
 	}
-	else if(contains_text(page, "Homebodyl") && freeCrafts() < 5)
+	else if (!(auto_is_valid($familiar[cookbookbat]) && have_familiar($familiar[cookbookbat]) && knoll_available()) && contains_text(page, "Homebodyl") && freeCrafts() < 5)
 	{
+		// don't need free crafts if we have the Cookbookbat in knoll signs.
+		// Cookbookbat gives us 5 free cooks every day & we only use free crafting on cooking in knoll signs
 		auto_log_info("Buying Homebodyl pill from CMC", "blue");
 		bestOption = 5;
 		consumableBought = $item[Homebodyl&trade;];
 	}
-	else if(contains_text(page, "ice crown"))
+	else if ((!in_small() || in_hardcore()) && contains_text(page, "ice crown"))
 	{
+		// don't need the ice crown in Normal Small as we pull hats.
 		auto_log_info("Buying ice crown from CMC", "blue");
 		bestOption = 1;
 	}
@@ -940,7 +943,7 @@ void auto_CMCconsult()
 		bestOption = 5;
 		consumableBought = $item[Fleshazole&trade;];
 	}
-	else if(auto_CMCconsultsLeft() > 2 && !can_interact())
+	else if (auto_CMCconsultsLeft() > 2 && !can_interact() && !in_small())
 	{
 		//reserve the last 2 consults for something more valuable than booze/food
 		//consume logic will drink/eat later

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -943,7 +943,8 @@ void auto_CMCconsult()
 		bestOption = 5;
 		consumableBought = $item[Fleshazole&trade;];
 	}
-	else if (auto_CMCconsultsLeft() > 2 && !can_interact() && !in_small())
+	else if (auto_CMCconsultsLeft() > 2 && !can_interact() && !in_small() && !in_kolhs())
+
 	{
 		//reserve the last 2 consults for something more valuable than booze/food
 		//consume logic will drink/eat later


### PR DESCRIPTION
# Description

Noticed LED Candle wasn't being equipped, was using the tiny gold medal instead. This should fix that.

Also tweaked some of the CMC item choices to try to get more Breathitins. 
- Homebodyl is a waste of a choice and 2 spleen if you have the CBB and are in a knoll sign. My logs show it only ever being used for cooking because its charges are used first before the CBB (and I have 7 charges left when I ascend so we only use 4 anyway).
- Don't take the ice crown in Normal Small. I actually think this isn't much use generally as the only time I've seen it worn is for Aboo Peak & it's not actually needed there it's just the maximizer using it because it's available.
- Don't take food or booze in Small path. This might need better conditions in hardcore but for now lets not waste a use.

## How Has This Been Tested?

Run Normal Small day 1 on 2 accounts. Will run day 2 on both after rollover & get them into new day 1's to double check everything is good.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
