### PR TITLE
Remove some more unnecessary prefs and related functions

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -9,7 +9,6 @@ auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a strin
 auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
 auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
 auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
 auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
 auto_limitConsume	boolean	When true will not eat or drink anything automatically.
 auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day

--- a/BUILD/settings_extra/any.dat
+++ b/BUILD/settings_extra/any.dat
@@ -1,7 +1,6 @@
 auto_abooclover	boolean	Are we considering using a clover at A-Boo Peak?
 auto_aboopending	integer	The last turn of a pending A-Boo Clue. 0 if no clue active.
 auto_clanstuff	string	What was the last day we did 'end of day' clan stuff.
-auto_noSleepingDog	boolean	When true do not eat a Sleeping Dog.
 auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (default 2500)
 _auto_ignoreRestoreFailureToday	boolean	if true we will for today only ignore failure to restore MP or HP and just continue playing
 auto_aosol_dontUnCurse	boolean	Avatar of Shadows Over Loathing: if true will keep all cursed items.

--- a/BUILD/settings_extra/post.dat
+++ b/BUILD/settings_extra/post.dat
@@ -1,5 +1,4 @@
 auto_chasmBusted	boolean	Has the orc chasm bridge been 'trolled yet? Ed only.
-auto_cookie	integer	HCCS Only: Tracks fortune cookie.
 auto_day1_dna	string	'finished' if we have hybridized ourselves at the start of Ascension.
 auto_day_init	string	Current daycount if we finished initializing today.
 auto_getBoningKnife	boolean	Do we want Boning Knife this ascension?
@@ -25,7 +24,5 @@ _auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is actuall
 auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
 auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
 auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
-auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
-auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
 auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
 auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.

--- a/BUILD/task_order/A Shrunken Adventurer am I.dat
+++ b/BUILD/task_order/A Shrunken Adventurer am I.dat
@@ -5,10 +5,7 @@ catBurglarHeist
 auto_breakfastCounterVisit
 chateauPainting
 LX_setWorkshed
-LX_artistQuest
 LX_galaktikSubQuest
-LX_armorySideQuest
-LX_meatsmithSubQuest
 L9_leafletQuest
 L5_findKnob
 L12_sonofaPrefix

--- a/BUILD/task_order/Avatar of Jarlsberg.dat
+++ b/BUILD/task_order/Avatar of Jarlsberg.dat
@@ -5,10 +5,7 @@ LX_unlockPirateRealm
 auto_breakfastCounterVisit
 chateauPainting
 LX_setWorkshed
-LX_artistQuest
 LX_galaktikSubQuest
-LX_armorySideQuest
-LX_meatsmithSubQuest
 L9_leafletQuest
 L5_findKnob
 L12_sonofaPrefix

--- a/BUILD/task_order/Legacy of Loathing.dat
+++ b/BUILD/task_order/Legacy of Loathing.dat
@@ -5,10 +5,7 @@ catBurglarHeist
 auto_breakfastCounterVisit
 chateauPainting
 LX_setWorkshed
-LX_artistQuest
 LX_galaktikSubQuest
-LX_armorySideQuest
-LX_meatsmithSubQuest
 L9_leafletQuest
 L5_findKnob
 L12_sonofaPrefix

--- a/BUILD/task_order/Quantum Terrarium.dat
+++ b/BUILD/task_order/Quantum Terrarium.dat
@@ -5,10 +5,7 @@ catBurglarHeist
 auto_breakfastCounterVisit
 chateauPainting
 LX_setWorkshed
-LX_artistQuest
 LX_galaktikSubQuest
-LX_armorySideQuest
-LX_meatsmithSubQuest
 L9_leafletQuest
 L5_findKnob
 L12_sonofaPrefix

--- a/BUILD/task_order/Zombie Slayer.dat
+++ b/BUILD/task_order/Zombie Slayer.dat
@@ -5,10 +5,7 @@ LX_freeCombatsTask
 auto_breakfastCounterVisit
 chateauPainting
 LX_setWorkshed
-LX_artistQuest
 LX_galaktikSubQuest
-LX_armorySideQuest
-LX_meatsmithSubQuest
 L9_leafletQuest
 L5_findKnob
 L12_sonofaPrefix

--- a/BUILD/task_order/default.dat
+++ b/BUILD/task_order/default.dat
@@ -5,10 +5,7 @@ catBurglarHeist
 auto_breakfastCounterVisit
 chateauPainting
 LX_setWorkshed
-LX_artistQuest
 LX_galaktikSubQuest
-LX_armorySideQuest
-LX_meatsmithSubQuest
 L9_leafletQuest
 L5_findKnob
 L12_sonofaPrefix

--- a/RELEASE/data/autoscend_properties.txt
+++ b/RELEASE/data/autoscend_properties.txt
@@ -90,7 +90,6 @@
 89	auto_day1_skills
 90	auto_allowSharingData
 91	auto_backup_
-92	auto_cookie
 93	auto_gremlins
 94	auto_haveoven
 95	auto_hideAdultery
@@ -123,7 +122,6 @@
 124	auto_saveMargarita
 125	auto_pauseForWitchess
 126	auto_saveVintage
-127	auto_noSleepingDog
 128	auto_saveSausage
 129	auto_diag_round
 130	auto_stayInRun

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -20,45 +20,44 @@ any	7	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a
 any	8	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
 any	9	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
 any	10	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	11	auto_doArtistQuest	boolean	If set, we will try to do the artist quest. If the artist is not-accessible, the setting will silently disable.
-any	12	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	13	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
-any	14	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
-any	15	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	16	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
-any	17	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	18	auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
-any	19	auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
-any	20	auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
-any	21	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	22	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	23	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	24	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	25	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	26	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	27	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	28	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	29	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	30	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	31	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	32	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	33	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
-any	34	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	35	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
-any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	37	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	38	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle. Setting to -1 will cause the lowest possible ML to be equipped, including going negative if possible - this can cause non-optimal gear to be equipped.
-any	39	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	40	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	41	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 2 (info).
-any	42	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
-any	43	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	44	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	45	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
-any	46	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
-any	47	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
-any	48	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
-any	49	auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?
+any	11	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	12	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
+any	13	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
+any	14	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	15	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
+any	16	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	17	auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
+any	18	auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
+any	19	auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
+any	20	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	21	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	22	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	23	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	24	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	25	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	26	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	27	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	28	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	29	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	30	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	31	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	32	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
+any	33	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	34	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
+any	35	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	36	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	37	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle. Setting to -1 will cause the lowest possible ML to be equipped, including going negative if possible - this can cause non-optimal gear to be equipped.
+any	38	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	39	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	40	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 2 (info).
+any	41	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
+any	42	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	43	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	44	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	45	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+any	46	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
+any	47	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
+any	48	auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -10,42 +10,38 @@ action	2	auto_combatDirective	string	An action to execute at the start of next c
 any	0	auto_abooclover	boolean	Are we considering using a clover at A-Boo Peak?
 any	1	auto_aboopending	integer	The last turn of a pending A-Boo Clue. 0 if no clue active.
 any	2	auto_clanstuff	string	What was the last day we did 'end of day' clan stuff.
-any	3	auto_noSleepingDog	boolean	When true do not eat a Sleeping Dog.
-any	4	auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (default 2500)
-any	5	_auto_ignoreRestoreFailureToday	boolean	if true we will for today only ignore failure to restore MP or HP and just continue playing
-any	6	auto_aosol_dontUnCurse	boolean	Avatar of Shadows Over Loathing: if true will keep all cursed items.
+any	3	auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (default 2500)
+any	4	_auto_ignoreRestoreFailureToday	boolean	if true we will for today only ignore failure to restore MP or HP and just continue playing
+any	5	auto_aosol_dontUnCurse	boolean	Avatar of Shadows Over Loathing: if true will keep all cursed items.
 
 post	0	auto_chasmBusted	boolean	Has the orc chasm bridge been 'trolled yet? Ed only.
-post	1	auto_cookie	integer	HCCS Only: Tracks fortune cookie.
-post	2	auto_day1_dna	string	'finished' if we have hybridized ourselves at the start of Ascension.
-post	3	auto_day_init	string	Current daycount if we finished initializing today.
-post	4	auto_getBoningKnife	boolean	Do we want Boning Knife this ascension?
-post	5	auto_gnasirUnlocked	boolean	Have we found gnasir in the Desert?
-post	6	auto_grimstoneFancyOilPainting	boolean	do grimstone for fancy oil painting this ascension?
-post	7	auto_grimstoneOrnateDowsingRod	boolean	do grimstone for ornate dowsing rod this ascension?
-post	8	auto_hedge	string	'fast' or 'slow', determining how quickly we want to finish the Hedge Maze.
-post	9	auto_powerLevelLastLevel	string	Last Level that we had nothing to do.
-post	10	auto_powerLevelAdvCount	string	Adventures count of times we had nothing to do.
-post	11	auto_powerLevelLastAttempted	string	Last adventure that we did nothing on.
-post	12	auto_skipNuns	boolean	Skip nuns quest this ascension?
-post	13	auto_waitingArrowAlcove	integer	If we arrowed a modern zmobie, this tells us when to return to the Alcove (cyrptAlcoveEvilness value).
-post	14	auto_100familiar	string	If a familiar type, do not allow familiar switching (for 100% runs). Otherwise, can be none or blank.
-post	15	auto_beatenUpCount	integer	How many times were we beaten up this ascension. Affects ML and whether we try to heal or abort when we get beaten up.
-post	16	auto_doneInitialize	integer	Indicates last ascension that we initialized with the script.
-post	17	auto_noSnakeOil	integer	Last day that we could no longer Extract Oil.
-post	18	auto_renenutetBought	integer	Number of Talisman of Renenutet's bought on last tracking.
-post	19	auto_batoomerangDay	integer	Part of Replica Bat-oomerang Tracker
-post	20	auto_batoomerangUse	integer	Part of Replica Bat-oomerang Tracker
-post	21	_auto_lastABooConsider	integer	Last turn that we considered doing A-Boo Peak
-post	22	_auto_lastABooCycleFix	integer	Tracker to prevent us infinitely looping on A-Boo Peak
-post	23	_auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is actually needed).
-post	24	auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
-post	25	auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
-post	26	auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
-post	27	auto_doArmory	boolean	Do Lending a Hand (and a Foot) optional sidequest this ascension to unlock madeline baking supply?
-post	28	auto_doMeatsmith	boolean	Do Meatsmith optional sidequest this ascension?
-post	29	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
-post	30	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
+post	1	auto_day1_dna	string	'finished' if we have hybridized ourselves at the start of Ascension.
+post	2	auto_day_init	string	Current daycount if we finished initializing today.
+post	3	auto_getBoningKnife	boolean	Do we want Boning Knife this ascension?
+post	4	auto_gnasirUnlocked	boolean	Have we found gnasir in the Desert?
+post	5	auto_grimstoneFancyOilPainting	boolean	do grimstone for fancy oil painting this ascension?
+post	6	auto_grimstoneOrnateDowsingRod	boolean	do grimstone for ornate dowsing rod this ascension?
+post	7	auto_hedge	string	'fast' or 'slow', determining how quickly we want to finish the Hedge Maze.
+post	8	auto_powerLevelLastLevel	string	Last Level that we had nothing to do.
+post	9	auto_powerLevelAdvCount	string	Adventures count of times we had nothing to do.
+post	10	auto_powerLevelLastAttempted	string	Last adventure that we did nothing on.
+post	11	auto_skipNuns	boolean	Skip nuns quest this ascension?
+post	12	auto_waitingArrowAlcove	integer	If we arrowed a modern zmobie, this tells us when to return to the Alcove (cyrptAlcoveEvilness value).
+post	13	auto_100familiar	string	If a familiar type, do not allow familiar switching (for 100% runs). Otherwise, can be none or blank.
+post	14	auto_beatenUpCount	integer	How many times were we beaten up this ascension. Affects ML and whether we try to heal or abort when we get beaten up.
+post	15	auto_doneInitialize	integer	Indicates last ascension that we initialized with the script.
+post	16	auto_noSnakeOil	integer	Last day that we could no longer Extract Oil.
+post	17	auto_renenutetBought	integer	Number of Talisman of Renenutet's bought on last tracking.
+post	18	auto_batoomerangDay	integer	Part of Replica Bat-oomerang Tracker
+post	19	auto_batoomerangUse	integer	Part of Replica Bat-oomerang Tracker
+post	20	_auto_lastABooConsider	integer	Last turn that we considered doing A-Boo Peak
+post	21	_auto_lastABooCycleFix	integer	Tracker to prevent us infinitely looping on A-Boo Peak
+post	22	_auto_witchessBattles	integer	Tracker for Witchess Combats (yes, this is actually needed).
+post	23	auto_needLegs	boolean	In Ed, do we require getting legs before trying to Ka farm?
+post	24	auto_haveoven	boolean	Track oven status. If you have an oven this should be true. But we can't always check the campground.
+post	25	auto_doGalaktik	boolean	Do Galaktik optional sidequest this ascension?
+post	26	auto_L8_ninjaAssassinFail	boolean	True means we think we cannot defeat ninja snowmen assassins and are thus avoiding them this ascension. We will not copy them nor adventure in the lair of the ninja snowmen
+post	27	auto_L8_extremeInstead	boolean	True means we want to adventure in the extreme slope path instead of the ninja snowmen lair this ascension.
 
 pre	0	auto_doGalaktik_initialize	boolean	When we initialize an ascension this will be copied to auto_doGalaktik
 

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -11,94 +11,91 @@ A Shrunken Adventurer am I	3	catBurglarHeist
 A Shrunken Adventurer am I	4	auto_breakfastCounterVisit
 A Shrunken Adventurer am I	5	chateauPainting
 A Shrunken Adventurer am I	6	LX_setWorkshed
-A Shrunken Adventurer am I	7	LX_artistQuest
-A Shrunken Adventurer am I	8	LX_galaktikSubQuest
-A Shrunken Adventurer am I	9	LX_armorySideQuest
-A Shrunken Adventurer am I	10	LX_meatsmithSubQuest
-A Shrunken Adventurer am I	11	L9_leafletQuest
-A Shrunken Adventurer am I	12	L5_findKnob
-A Shrunken Adventurer am I	13	L12_sonofaPrefix
-A Shrunken Adventurer am I	14	LX_burnDelay
-A Shrunken Adventurer am I	15	LX_summonMonster
-A Shrunken Adventurer am I	16	LM_edTheUndying
-A Shrunken Adventurer am I	17	LX_bugbearInvasion
-A Shrunken Adventurer am I	18	LX_lowkeySummer
-A Shrunken Adventurer am I	19	resolveSixthDMT
-A Shrunken Adventurer am I	20	L11_aridDesert	L11_hasUltrahydrated
-A Shrunken Adventurer am I	21	L12_flyerFinish
-A Shrunken Adventurer am I	22	L12_getOutfit
-A Shrunken Adventurer am I	23	L12_startWar
-A Shrunken Adventurer am I	24	LX_loggingHatchet
-A Shrunken Adventurer am I	25	LX_guildUnlock
-A Shrunken Adventurer am I	26	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
-A Shrunken Adventurer am I	27	LX_unlockDesert
-A Shrunken Adventurer am I	28	handleRainDoh
-A Shrunken Adventurer am I	29	LX_spookyravenManorFirstFloor
-A Shrunken Adventurer am I	30	L6_friarsGetParts	LX_steelOrgan_condition_slow
-A Shrunken Adventurer am I	31	LX_steelOrgan	LX_steelOrgan_condition_slow
-A Shrunken Adventurer am I	32	L4_batCave
-A Shrunken Adventurer am I	33	L2_mosquito
-A Shrunken Adventurer am I	34	LX_unlockHiddenTemple
-A Shrunken Adventurer am I	35	L6_dakotaFanning
-A Shrunken Adventurer am I	36	LX_lockPicking
-A Shrunken Adventurer am I	37	LX_fatLootToken
-A Shrunken Adventurer am I	38	L5_slayTheGoblinKing
-A Shrunken Adventurer am I	39	LX_islandAccess
-A Shrunken Adventurer am I	40	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
-A Shrunken Adventurer am I	41	LX_spookyravenManorSecondFloor
-A Shrunken Adventurer am I	42	L3_tavern
-A Shrunken Adventurer am I	43	L6_friarsGetParts
-A Shrunken Adventurer am I	44	LX_steelOrgan	in_hardcore
-A Shrunken Adventurer am I	45	L7_crypt
-A Shrunken Adventurer am I	46	fancyOilPainting
-A Shrunken Adventurer am I	47	L8_trapperQuest
-A Shrunken Adventurer am I	48	LX_steelOrgan
-A Shrunken Adventurer am I	49	L10_plantThatBean
-A Shrunken Adventurer am I	50	L12_preOutfit
-A Shrunken Adventurer am I	51	L10_airship
-A Shrunken Adventurer am I	52	L10_basement
-A Shrunken Adventurer am I	53	L10_ground
-A Shrunken Adventurer am I	54	L11_blackMarket
-A Shrunken Adventurer am I	55	L11_forgedDocuments
-A Shrunken Adventurer am I	56	L11_mcmuffinDiary
-A Shrunken Adventurer am I	57	L10_topFloor
-A Shrunken Adventurer am I	58	L10_holeInTheSkyUnlock
-A Shrunken Adventurer am I	59	L9_chasmBuild
-A Shrunken Adventurer am I	60	L9_highLandlord
-A Shrunken Adventurer am I	61	L12_flyerBackup
-A Shrunken Adventurer am I	62	Lsc_flyerSeals
-A Shrunken Adventurer am I	63	L11_mauriceSpookyraven
-A Shrunken Adventurer am I	64	L11_unlockHiddenCity
-A Shrunken Adventurer am I	65	L11_hiddenCityZones
-A Shrunken Adventurer am I	66	LX_ornateDowsingRod
-A Shrunken Adventurer am I	67	L11_aridDesert
-A Shrunken Adventurer am I	68	L11_hiddenCity
-A Shrunken Adventurer am I	69	L11_talismanOfNam
-A Shrunken Adventurer am I	70	L11_palindome
-A Shrunken Adventurer am I	71	L11_unlockPyramid
-A Shrunken Adventurer am I	72	L11_unlockEd
-A Shrunken Adventurer am I	73	L11_defeatEd
-A Shrunken Adventurer am I	74	L12_gremlins
-A Shrunken Adventurer am I	75	L12_sonofaFinish
-A Shrunken Adventurer am I	76	L12_sonofaBeach
-A Shrunken Adventurer am I	77	L12_filthworms
-A Shrunken Adventurer am I	78	L12_orchardFinalize
-A Shrunken Adventurer am I	79	L12_themtharHills
-A Shrunken Adventurer am I	80	L12_farm
-A Shrunken Adventurer am I	81	L11_getBeehive
-A Shrunken Adventurer am I	82	L12_finalizeWar
-A Shrunken Adventurer am I	83	L12_clearBattlefield
-A Shrunken Adventurer am I	84	LX_koeInvaderHandler
-A Shrunken Adventurer am I	85	setSoftblockDelay	allowSoftblockDelay
-A Shrunken Adventurer am I	86	L12_lastDitchFlyer
-A Shrunken Adventurer am I	87	LX_bugbearInvasionFinale
-A Shrunken Adventurer am I	88	L13_towerNSContests
-A Shrunken Adventurer am I	89	L13_towerNSHedge
-A Shrunken Adventurer am I	90	L13_sorceressDoor
-A Shrunken Adventurer am I	91	L13_towerNSTower
-A Shrunken Adventurer am I	92	L13_towerNSNagamar
-A Shrunken Adventurer am I	93	L13_towerNSFinal
-A Shrunken Adventurer am I	94	LX_attemptPowerLevel
+A Shrunken Adventurer am I	7	LX_galaktikSubQuest
+A Shrunken Adventurer am I	8	L9_leafletQuest
+A Shrunken Adventurer am I	9	L5_findKnob
+A Shrunken Adventurer am I	10	L12_sonofaPrefix
+A Shrunken Adventurer am I	11	LX_burnDelay
+A Shrunken Adventurer am I	12	LX_summonMonster
+A Shrunken Adventurer am I	13	LM_edTheUndying
+A Shrunken Adventurer am I	14	LX_bugbearInvasion
+A Shrunken Adventurer am I	15	LX_lowkeySummer
+A Shrunken Adventurer am I	16	resolveSixthDMT
+A Shrunken Adventurer am I	17	L11_aridDesert	L11_hasUltrahydrated
+A Shrunken Adventurer am I	18	L12_flyerFinish
+A Shrunken Adventurer am I	19	L12_getOutfit
+A Shrunken Adventurer am I	20	L12_startWar
+A Shrunken Adventurer am I	21	LX_loggingHatchet
+A Shrunken Adventurer am I	22	LX_guildUnlock
+A Shrunken Adventurer am I	23	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
+A Shrunken Adventurer am I	24	LX_unlockDesert
+A Shrunken Adventurer am I	25	handleRainDoh
+A Shrunken Adventurer am I	26	LX_spookyravenManorFirstFloor
+A Shrunken Adventurer am I	27	L6_friarsGetParts	LX_steelOrgan_condition_slow
+A Shrunken Adventurer am I	28	LX_steelOrgan	LX_steelOrgan_condition_slow
+A Shrunken Adventurer am I	29	L4_batCave
+A Shrunken Adventurer am I	30	L2_mosquito
+A Shrunken Adventurer am I	31	LX_unlockHiddenTemple
+A Shrunken Adventurer am I	32	L6_dakotaFanning
+A Shrunken Adventurer am I	33	LX_lockPicking
+A Shrunken Adventurer am I	34	LX_fatLootToken
+A Shrunken Adventurer am I	35	L5_slayTheGoblinKing
+A Shrunken Adventurer am I	36	LX_islandAccess
+A Shrunken Adventurer am I	37	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
+A Shrunken Adventurer am I	38	LX_spookyravenManorSecondFloor
+A Shrunken Adventurer am I	39	L3_tavern
+A Shrunken Adventurer am I	40	L6_friarsGetParts
+A Shrunken Adventurer am I	41	LX_steelOrgan	in_hardcore
+A Shrunken Adventurer am I	42	L7_crypt
+A Shrunken Adventurer am I	43	fancyOilPainting
+A Shrunken Adventurer am I	44	L8_trapperQuest
+A Shrunken Adventurer am I	45	LX_steelOrgan
+A Shrunken Adventurer am I	46	L10_plantThatBean
+A Shrunken Adventurer am I	47	L12_preOutfit
+A Shrunken Adventurer am I	48	L10_airship
+A Shrunken Adventurer am I	49	L10_basement
+A Shrunken Adventurer am I	50	L10_ground
+A Shrunken Adventurer am I	51	L11_blackMarket
+A Shrunken Adventurer am I	52	L11_forgedDocuments
+A Shrunken Adventurer am I	53	L11_mcmuffinDiary
+A Shrunken Adventurer am I	54	L10_topFloor
+A Shrunken Adventurer am I	55	L10_holeInTheSkyUnlock
+A Shrunken Adventurer am I	56	L9_chasmBuild
+A Shrunken Adventurer am I	57	L9_highLandlord
+A Shrunken Adventurer am I	58	L12_flyerBackup
+A Shrunken Adventurer am I	59	Lsc_flyerSeals
+A Shrunken Adventurer am I	60	L11_mauriceSpookyraven
+A Shrunken Adventurer am I	61	L11_unlockHiddenCity
+A Shrunken Adventurer am I	62	L11_hiddenCityZones
+A Shrunken Adventurer am I	63	LX_ornateDowsingRod
+A Shrunken Adventurer am I	64	L11_aridDesert
+A Shrunken Adventurer am I	65	L11_hiddenCity
+A Shrunken Adventurer am I	66	L11_talismanOfNam
+A Shrunken Adventurer am I	67	L11_palindome
+A Shrunken Adventurer am I	68	L11_unlockPyramid
+A Shrunken Adventurer am I	69	L11_unlockEd
+A Shrunken Adventurer am I	70	L11_defeatEd
+A Shrunken Adventurer am I	71	L12_gremlins
+A Shrunken Adventurer am I	72	L12_sonofaFinish
+A Shrunken Adventurer am I	73	L12_sonofaBeach
+A Shrunken Adventurer am I	74	L12_filthworms
+A Shrunken Adventurer am I	75	L12_orchardFinalize
+A Shrunken Adventurer am I	76	L12_themtharHills
+A Shrunken Adventurer am I	77	L12_farm
+A Shrunken Adventurer am I	78	L11_getBeehive
+A Shrunken Adventurer am I	79	L12_finalizeWar
+A Shrunken Adventurer am I	80	L12_clearBattlefield
+A Shrunken Adventurer am I	81	LX_koeInvaderHandler
+A Shrunken Adventurer am I	82	setSoftblockDelay	allowSoftblockDelay
+A Shrunken Adventurer am I	83	L12_lastDitchFlyer
+A Shrunken Adventurer am I	84	LX_bugbearInvasionFinale
+A Shrunken Adventurer am I	85	L13_towerNSContests
+A Shrunken Adventurer am I	86	L13_towerNSHedge
+A Shrunken Adventurer am I	87	L13_sorceressDoor
+A Shrunken Adventurer am I	88	L13_towerNSTower
+A Shrunken Adventurer am I	89	L13_towerNSNagamar
+A Shrunken Adventurer am I	90	L13_towerNSFinal
+A Shrunken Adventurer am I	91	LX_attemptPowerLevel
 
 Avatar of Jarlsberg	0	LM_jarlsberg
 Avatar of Jarlsberg	1	LX_freeCombatsTask
@@ -107,58 +104,55 @@ Avatar of Jarlsberg	3	LX_unlockPirateRealm
 Avatar of Jarlsberg	4	auto_breakfastCounterVisit
 Avatar of Jarlsberg	5	chateauPainting
 Avatar of Jarlsberg	6	LX_setWorkshed
-Avatar of Jarlsberg	7	LX_artistQuest
-Avatar of Jarlsberg	8	LX_galaktikSubQuest
-Avatar of Jarlsberg	9	LX_armorySideQuest
-Avatar of Jarlsberg	10	LX_meatsmithSubQuest
-Avatar of Jarlsberg	11	L9_leafletQuest
-Avatar of Jarlsberg	12	L5_findKnob
-Avatar of Jarlsberg	13	L12_sonofaPrefix
-Avatar of Jarlsberg	14	LX_burnDelay
-Avatar of Jarlsberg	15	LX_summonMonster
-Avatar of Jarlsberg	16	L11_aridDesert	L11_hasUltrahydrated
-Avatar of Jarlsberg	17	handleRainDoh
-Avatar of Jarlsberg	18	L11_shenStartQuest
-Avatar of Jarlsberg	19	LX_guildUnlock
-Avatar of Jarlsberg	20	LX_unlockDesert
-Avatar of Jarlsberg	21	LX_lockPicking
-Avatar of Jarlsberg	22	LX_fatLootToken
-Avatar of Jarlsberg	23	L5_getEncryptionKey
-Avatar of Jarlsberg	24	L5_findKnob
-Avatar of Jarlsberg	25	L2_mosquito
-Avatar of Jarlsberg	26	LX_unlockHiddenTemple
-Avatar of Jarlsberg	27	L6_dakotaFanning
-Avatar of Jarlsberg	28	LX_steelOrgan
-Avatar of Jarlsberg	29	L12_islandWar
-Avatar of Jarlsberg	30	LX_spookyravenManorFirstFloor
-Avatar of Jarlsberg	31	L11_blackMarket
-Avatar of Jarlsberg	32	L11_forgedDocuments
-Avatar of Jarlsberg	33	L11_mcmuffinDiary
-Avatar of Jarlsberg	34	L11_getBeehive
-Avatar of Jarlsberg	35	L11_unlockHiddenCity
-Avatar of Jarlsberg	36	L11_hiddenCityZones
-Avatar of Jarlsberg	37	L11_hiddenCity
-Avatar of Jarlsberg	38	LX_spookyravenManorSecondFloor
-Avatar of Jarlsberg	39	L11_mauriceSpookyraven
-Avatar of Jarlsberg	40	L11_talismanOfNam
-Avatar of Jarlsberg	41	L10_plantThatBean
-Avatar of Jarlsberg	42	L10_rainOnThePlains
-Avatar of Jarlsberg	43	L9_chasmBuild
-Avatar of Jarlsberg	44	L9_highLandlord
-Avatar of Jarlsberg	45	L8_trapperQuest
-Avatar of Jarlsberg	46	L6_friarsGetParts
-Avatar of Jarlsberg	47	L7_crypt
-Avatar of Jarlsberg	48	L11_palindome
-Avatar of Jarlsberg	49	L11_aridDesert
-Avatar of Jarlsberg	50	L11_unlockPyramid
-Avatar of Jarlsberg	51	L11_unlockEd
-Avatar of Jarlsberg	52	L11_defeatEd
-Avatar of Jarlsberg	53	L5_slayTheGoblinKing
-Avatar of Jarlsberg	54	L4_batCave
-Avatar of Jarlsberg	55	L3_tavern
-Avatar of Jarlsberg	56	setSoftblockDelay	allowSoftblockDelay
-Avatar of Jarlsberg	57	L13_towerAscent
-Avatar of Jarlsberg	58	LX_attemptPowerLevel
+Avatar of Jarlsberg	7	LX_galaktikSubQuest
+Avatar of Jarlsberg	8	L9_leafletQuest
+Avatar of Jarlsberg	9	L5_findKnob
+Avatar of Jarlsberg	10	L12_sonofaPrefix
+Avatar of Jarlsberg	11	LX_burnDelay
+Avatar of Jarlsberg	12	LX_summonMonster
+Avatar of Jarlsberg	13	L11_aridDesert	L11_hasUltrahydrated
+Avatar of Jarlsberg	14	handleRainDoh
+Avatar of Jarlsberg	15	L11_shenStartQuest
+Avatar of Jarlsberg	16	LX_guildUnlock
+Avatar of Jarlsberg	17	LX_unlockDesert
+Avatar of Jarlsberg	18	LX_lockPicking
+Avatar of Jarlsberg	19	LX_fatLootToken
+Avatar of Jarlsberg	20	L5_getEncryptionKey
+Avatar of Jarlsberg	21	L5_findKnob
+Avatar of Jarlsberg	22	L2_mosquito
+Avatar of Jarlsberg	23	LX_unlockHiddenTemple
+Avatar of Jarlsberg	24	L6_dakotaFanning
+Avatar of Jarlsberg	25	LX_steelOrgan
+Avatar of Jarlsberg	26	L12_islandWar
+Avatar of Jarlsberg	27	LX_spookyravenManorFirstFloor
+Avatar of Jarlsberg	28	L11_blackMarket
+Avatar of Jarlsberg	29	L11_forgedDocuments
+Avatar of Jarlsberg	30	L11_mcmuffinDiary
+Avatar of Jarlsberg	31	L11_getBeehive
+Avatar of Jarlsberg	32	L11_unlockHiddenCity
+Avatar of Jarlsberg	33	L11_hiddenCityZones
+Avatar of Jarlsberg	34	L11_hiddenCity
+Avatar of Jarlsberg	35	LX_spookyravenManorSecondFloor
+Avatar of Jarlsberg	36	L11_mauriceSpookyraven
+Avatar of Jarlsberg	37	L11_talismanOfNam
+Avatar of Jarlsberg	38	L10_plantThatBean
+Avatar of Jarlsberg	39	L10_rainOnThePlains
+Avatar of Jarlsberg	40	L9_chasmBuild
+Avatar of Jarlsberg	41	L9_highLandlord
+Avatar of Jarlsberg	42	L8_trapperQuest
+Avatar of Jarlsberg	43	L6_friarsGetParts
+Avatar of Jarlsberg	44	L7_crypt
+Avatar of Jarlsberg	45	L11_palindome
+Avatar of Jarlsberg	46	L11_aridDesert
+Avatar of Jarlsberg	47	L11_unlockPyramid
+Avatar of Jarlsberg	48	L11_unlockEd
+Avatar of Jarlsberg	49	L11_defeatEd
+Avatar of Jarlsberg	50	L5_slayTheGoblinKing
+Avatar of Jarlsberg	51	L4_batCave
+Avatar of Jarlsberg	52	L3_tavern
+Avatar of Jarlsberg	53	setSoftblockDelay	allowSoftblockDelay
+Avatar of Jarlsberg	54	L13_towerAscent
+Avatar of Jarlsberg	55	LX_attemptPowerLevel
 
 Legacy of Loathing	0	LX_freeCombatsTask
 Legacy of Loathing	1	woods_questStart
@@ -167,102 +161,99 @@ Legacy of Loathing	3	catBurglarHeist
 Legacy of Loathing	4	auto_breakfastCounterVisit
 Legacy of Loathing	5	chateauPainting
 Legacy of Loathing	6	LX_setWorkshed
-Legacy of Loathing	7	LX_artistQuest
-Legacy of Loathing	8	LX_galaktikSubQuest
-Legacy of Loathing	9	LX_armorySideQuest
-Legacy of Loathing	10	LX_meatsmithSubQuest
-Legacy of Loathing	11	L9_leafletQuest
-Legacy of Loathing	12	L5_findKnob
-Legacy of Loathing	13	L12_sonofaPrefix
-Legacy of Loathing	14	LX_burnDelay
-Legacy of Loathing	15	LX_summonMonster
-Legacy of Loathing	16	LM_edTheUndying
-Legacy of Loathing	17	LX_bugbearInvasion
-Legacy of Loathing	18	LX_lowkeySummer
-Legacy of Loathing	19	resolveSixthDMT
-Legacy of Loathing	20	L11_aridDesert	L11_hasUltrahydrated
-Legacy of Loathing	21	L12_flyerFinish
-Legacy of Loathing	22	L12_getOutfit
-Legacy of Loathing	23	L12_startWar
-Legacy of Loathing	24	LX_loggingHatchet
-Legacy of Loathing	25	LX_guildUnlock
-Legacy of Loathing	26	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
-Legacy of Loathing	27	LX_unlockDesert
-Legacy of Loathing	28	handleRainDoh
-Legacy of Loathing	29	LX_spookyravenManorFirstFloor
-Legacy of Loathing	30	L6_friarsGetParts	LX_steelOrgan_condition_slow
-Legacy of Loathing	31	LX_steelOrgan	LX_steelOrgan_condition_slow
+Legacy of Loathing	7	LX_galaktikSubQuest
+Legacy of Loathing	8	L9_leafletQuest
+Legacy of Loathing	9	L5_findKnob
+Legacy of Loathing	10	L12_sonofaPrefix
+Legacy of Loathing	11	LX_burnDelay
+Legacy of Loathing	12	LX_summonMonster
+Legacy of Loathing	13	LM_edTheUndying
+Legacy of Loathing	14	LX_bugbearInvasion
+Legacy of Loathing	15	LX_lowkeySummer
+Legacy of Loathing	16	resolveSixthDMT
+Legacy of Loathing	17	L11_aridDesert	L11_hasUltrahydrated
+Legacy of Loathing	18	L12_flyerFinish
+Legacy of Loathing	19	L12_getOutfit
+Legacy of Loathing	20	L12_startWar
+Legacy of Loathing	21	LX_loggingHatchet
+Legacy of Loathing	22	LX_guildUnlock
+Legacy of Loathing	23	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
+Legacy of Loathing	24	LX_unlockDesert
+Legacy of Loathing	25	handleRainDoh
+Legacy of Loathing	26	LX_spookyravenManorFirstFloor
+Legacy of Loathing	27	L6_friarsGetParts	LX_steelOrgan_condition_slow
+Legacy of Loathing	28	LX_steelOrgan	LX_steelOrgan_condition_slow
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	32	L4_batCave
-Legacy of Loathing	33	L2_mosquito
-Legacy of Loathing	34	LX_unlockHiddenTemple
-Legacy of Loathing	35	L6_dakotaFanning
-Legacy of Loathing	36	LX_lockPicking
-Legacy of Loathing	37	LX_fatLootToken
+Legacy of Loathing	29	L4_batCave
+Legacy of Loathing	30	L2_mosquito
+Legacy of Loathing	31	LX_unlockHiddenTemple
+Legacy of Loathing	32	L6_dakotaFanning
+Legacy of Loathing	33	LX_lockPicking
+Legacy of Loathing	34	LX_fatLootToken
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	38	L5_slayTheGoblinKing
+Legacy of Loathing	35	L5_slayTheGoblinKing
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	39	L8_trapperQuest
+Legacy of Loathing	36	L8_trapperQuest
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	40	L7_crypt
-Legacy of Loathing	41	LX_islandAccess
-Legacy of Loathing	42	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
-Legacy of Loathing	43	LX_spookyravenManorSecondFloor
-Legacy of Loathing	44	L3_tavern
-Legacy of Loathing	45	L6_friarsGetParts
-Legacy of Loathing	46	LX_steelOrgan	in_hardcore
-Legacy of Loathing	47	fancyOilPainting
-Legacy of Loathing	48	LX_steelOrgan
-Legacy of Loathing	49	L10_plantThatBean
-Legacy of Loathing	50	L12_preOutfit
-Legacy of Loathing	51	L10_airship
-Legacy of Loathing	52	L10_basement
-Legacy of Loathing	53	L10_ground
-Legacy of Loathing	54	L11_blackMarket
-Legacy of Loathing	55	L11_forgedDocuments
-Legacy of Loathing	56	L11_mcmuffinDiary
-Legacy of Loathing	57	L10_topFloor
-Legacy of Loathing	58	L10_holeInTheSkyUnlock
-Legacy of Loathing	59	L9_chasmBuild
-Legacy of Loathing	60	L9_highLandlord
-Legacy of Loathing	61	L12_flyerBackup
-Legacy of Loathing	62	Lsc_flyerSeals
+Legacy of Loathing	37	L7_crypt
+Legacy of Loathing	38	LX_islandAccess
+Legacy of Loathing	39	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
+Legacy of Loathing	40	LX_spookyravenManorSecondFloor
+Legacy of Loathing	41	L3_tavern
+Legacy of Loathing	42	L6_friarsGetParts
+Legacy of Loathing	43	LX_steelOrgan	in_hardcore
+Legacy of Loathing	44	fancyOilPainting
+Legacy of Loathing	45	LX_steelOrgan
+Legacy of Loathing	46	L10_plantThatBean
+Legacy of Loathing	47	L12_preOutfit
+Legacy of Loathing	48	L10_airship
+Legacy of Loathing	49	L10_basement
+Legacy of Loathing	50	L10_ground
+Legacy of Loathing	51	L11_blackMarket
+Legacy of Loathing	52	L11_forgedDocuments
+Legacy of Loathing	53	L11_mcmuffinDiary
+Legacy of Loathing	54	L10_topFloor
+Legacy of Loathing	55	L10_holeInTheSkyUnlock
+Legacy of Loathing	56	L9_chasmBuild
+Legacy of Loathing	57	L9_highLandlord
+Legacy of Loathing	58	L12_flyerBackup
+Legacy of Loathing	59	Lsc_flyerSeals
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	63	L11_mauriceSpookyraven
-Legacy of Loathing	64	L11_unlockHiddenCity
-Legacy of Loathing	65	L11_hiddenCityZones
-Legacy of Loathing	66	LX_ornateDowsingRod
-Legacy of Loathing	67	L11_aridDesert
+Legacy of Loathing	60	L11_mauriceSpookyraven
+Legacy of Loathing	61	L11_unlockHiddenCity
+Legacy of Loathing	62	L11_hiddenCityZones
+Legacy of Loathing	63	LX_ornateDowsingRod
+Legacy of Loathing	64	L11_aridDesert
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	68	L11_hiddenCity
-Legacy of Loathing	69	L11_talismanOfNam
+Legacy of Loathing	65	L11_hiddenCity
+Legacy of Loathing	66	L11_talismanOfNam
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	70	L11_palindome
-Legacy of Loathing	71	L11_unlockPyramid
-Legacy of Loathing	72	L11_unlockEd
-Legacy of Loathing	73	L11_defeatEd
-Legacy of Loathing	74	L12_gremlins
-Legacy of Loathing	75	L12_sonofaFinish
-Legacy of Loathing	76	L12_sonofaBeach
-Legacy of Loathing	77	L12_filthworms
-Legacy of Loathing	78	L12_orchardFinalize
-Legacy of Loathing	79	L12_themtharHills
-Legacy of Loathing	80	L12_farm
-Legacy of Loathing	81	L11_getBeehive
+Legacy of Loathing	67	L11_palindome
+Legacy of Loathing	68	L11_unlockPyramid
+Legacy of Loathing	69	L11_unlockEd
+Legacy of Loathing	70	L11_defeatEd
+Legacy of Loathing	71	L12_gremlins
+Legacy of Loathing	72	L12_sonofaFinish
+Legacy of Loathing	73	L12_sonofaBeach
+Legacy of Loathing	74	L12_filthworms
+Legacy of Loathing	75	L12_orchardFinalize
+Legacy of Loathing	76	L12_themtharHills
+Legacy of Loathing	77	L12_farm
+Legacy of Loathing	78	L11_getBeehive
 # *************Following task gives replica Mr A********************
-Legacy of Loathing	82	L12_finalizeWar
-Legacy of Loathing	83	L12_clearBattlefield
-Legacy of Loathing	84	LX_koeInvaderHandler
-Legacy of Loathing	85	setSoftblockDelay	allowSoftblockDelay
-Legacy of Loathing	86	L12_lastDitchFlyer
-Legacy of Loathing	87	LX_bugbearInvasionFinale
-Legacy of Loathing	88	L13_towerNSContests
-Legacy of Loathing	89	L13_towerNSHedge
-Legacy of Loathing	90	L13_sorceressDoor
-Legacy of Loathing	91	L13_towerNSTower
-Legacy of Loathing	92	L13_towerNSNagamar
-Legacy of Loathing	93	L13_towerNSFinal
-Legacy of Loathing	94	LX_attemptPowerLevel
+Legacy of Loathing	79	L12_finalizeWar
+Legacy of Loathing	80	L12_clearBattlefield
+Legacy of Loathing	81	LX_koeInvaderHandler
+Legacy of Loathing	82	setSoftblockDelay	allowSoftblockDelay
+Legacy of Loathing	83	L12_lastDitchFlyer
+Legacy of Loathing	84	LX_bugbearInvasionFinale
+Legacy of Loathing	85	L13_towerNSContests
+Legacy of Loathing	86	L13_towerNSHedge
+Legacy of Loathing	87	L13_sorceressDoor
+Legacy of Loathing	88	L13_towerNSTower
+Legacy of Loathing	89	L13_towerNSNagamar
+Legacy of Loathing	90	L13_towerNSFinal
+Legacy of Loathing	91	LX_attemptPowerLevel
 
 Quantum Terrarium	0	LX_freeCombatsTask
 Quantum Terrarium	1	woods_questStart
@@ -271,62 +262,59 @@ Quantum Terrarium	3	catBurglarHeist
 Quantum Terrarium	4	auto_breakfastCounterVisit
 Quantum Terrarium	5	chateauPainting
 Quantum Terrarium	6	LX_setWorkshed
-Quantum Terrarium	7	LX_artistQuest
-Quantum Terrarium	8	LX_galaktikSubQuest
-Quantum Terrarium	9	LX_armorySideQuest
-Quantum Terrarium	10	LX_meatsmithSubQuest
-Quantum Terrarium	11	L9_leafletQuest
-Quantum Terrarium	12	L5_findKnob
-Quantum Terrarium	13	L12_sonofaPrefix
-Quantum Terrarium	14	LX_burnDelay
-Quantum Terrarium	15	LX_summonMonster
-Quantum Terrarium	16	resolveSixthDMT
-Quantum Terrarium	17	L11_aridDesert	L11_hasUltrahydrated
-Quantum Terrarium	18	handleRainDoh
-Quantum Terrarium	19	LX_quantumTerrarium
-Quantum Terrarium	20	fancyOilPainting
-Quantum Terrarium	21	LX_ornateDowsingRod
-Quantum Terrarium	22	L11_shenStartQuest
-Quantum Terrarium	23	LX_guildUnlock
-Quantum Terrarium	24	LX_unlockDesert
-Quantum Terrarium	25	LX_lockPicking
-Quantum Terrarium	26	LX_fatLootToken
-Quantum Terrarium	27	L5_getEncryptionKey
-Quantum Terrarium	28	L5_findKnob
-Quantum Terrarium	29	L2_mosquito
-Quantum Terrarium	30	LX_unlockHiddenTemple
-Quantum Terrarium	31	L6_dakotaFanning
-Quantum Terrarium	32	LX_steelOrgan
-Quantum Terrarium	33	L12_islandWar
-Quantum Terrarium	34	LX_spookyravenManorFirstFloor
-Quantum Terrarium	35	L11_blackMarket
-Quantum Terrarium	36	L11_forgedDocuments
-Quantum Terrarium	37	L11_mcmuffinDiary
-Quantum Terrarium	38	L11_getBeehive
-Quantum Terrarium	39	L11_unlockHiddenCity
-Quantum Terrarium	40	L11_hiddenCityZones
-Quantum Terrarium	41	L11_hiddenCity
-Quantum Terrarium	42	LX_spookyravenManorSecondFloor
-Quantum Terrarium	43	L11_mauriceSpookyraven
-Quantum Terrarium	44	L11_talismanOfNam
-Quantum Terrarium	45	L10_plantThatBean
-Quantum Terrarium	46	L10_rainOnThePlains
-Quantum Terrarium	47	L9_chasmBuild
-Quantum Terrarium	48	L9_highLandlord
-Quantum Terrarium	49	L8_trapperQuest
-Quantum Terrarium	50	L6_friarsGetParts
-Quantum Terrarium	51	L7_crypt
-Quantum Terrarium	52	L11_palindome
-Quantum Terrarium	53	L11_aridDesert
-Quantum Terrarium	54	L11_unlockPyramid
-Quantum Terrarium	55	L11_unlockEd
-Quantum Terrarium	56	L11_defeatEd
-Quantum Terrarium	57	L5_slayTheGoblinKing
-Quantum Terrarium	58	L4_batCave
-Quantum Terrarium	59	L3_tavern
-Quantum Terrarium	60	setSoftblockDelay	allowSoftblockDelay
-Quantum Terrarium	61	L13_towerAscent
-Quantum Terrarium	62	LX_attemptPowerLevel
+Quantum Terrarium	7	LX_galaktikSubQuest
+Quantum Terrarium	8	L9_leafletQuest
+Quantum Terrarium	9	L5_findKnob
+Quantum Terrarium	10	L12_sonofaPrefix
+Quantum Terrarium	11	LX_burnDelay
+Quantum Terrarium	12	LX_summonMonster
+Quantum Terrarium	13	resolveSixthDMT
+Quantum Terrarium	14	L11_aridDesert	L11_hasUltrahydrated
+Quantum Terrarium	15	handleRainDoh
+Quantum Terrarium	16	LX_quantumTerrarium
+Quantum Terrarium	17	fancyOilPainting
+Quantum Terrarium	18	LX_ornateDowsingRod
+Quantum Terrarium	19	L11_shenStartQuest
+Quantum Terrarium	20	LX_guildUnlock
+Quantum Terrarium	21	LX_unlockDesert
+Quantum Terrarium	22	LX_lockPicking
+Quantum Terrarium	23	LX_fatLootToken
+Quantum Terrarium	24	L5_getEncryptionKey
+Quantum Terrarium	25	L5_findKnob
+Quantum Terrarium	26	L2_mosquito
+Quantum Terrarium	27	LX_unlockHiddenTemple
+Quantum Terrarium	28	L6_dakotaFanning
+Quantum Terrarium	29	LX_steelOrgan
+Quantum Terrarium	30	L12_islandWar
+Quantum Terrarium	31	LX_spookyravenManorFirstFloor
+Quantum Terrarium	32	L11_blackMarket
+Quantum Terrarium	33	L11_forgedDocuments
+Quantum Terrarium	34	L11_mcmuffinDiary
+Quantum Terrarium	35	L11_getBeehive
+Quantum Terrarium	36	L11_unlockHiddenCity
+Quantum Terrarium	37	L11_hiddenCityZones
+Quantum Terrarium	38	L11_hiddenCity
+Quantum Terrarium	39	LX_spookyravenManorSecondFloor
+Quantum Terrarium	40	L11_mauriceSpookyraven
+Quantum Terrarium	41	L11_talismanOfNam
+Quantum Terrarium	42	L10_plantThatBean
+Quantum Terrarium	43	L10_rainOnThePlains
+Quantum Terrarium	44	L9_chasmBuild
+Quantum Terrarium	45	L9_highLandlord
+Quantum Terrarium	46	L8_trapperQuest
+Quantum Terrarium	47	L6_friarsGetParts
+Quantum Terrarium	48	L7_crypt
+Quantum Terrarium	49	L11_palindome
+Quantum Terrarium	50	L11_aridDesert
+Quantum Terrarium	51	L11_unlockPyramid
+Quantum Terrarium	52	L11_unlockEd
+Quantum Terrarium	53	L11_defeatEd
+Quantum Terrarium	54	L5_slayTheGoblinKing
+Quantum Terrarium	55	L4_batCave
+Quantum Terrarium	56	L3_tavern
+Quantum Terrarium	57	setSoftblockDelay	allowSoftblockDelay
+Quantum Terrarium	58	L13_towerAscent
+Quantum Terrarium	59	LX_attemptPowerLevel
 
 Zombie Slayer	0	LM_zombieSlayer
 Zombie Slayer	1	woods_questStart
@@ -335,58 +323,55 @@ Zombie Slayer	3	LX_freeCombatsTask
 Zombie Slayer	4	auto_breakfastCounterVisit
 Zombie Slayer	5	chateauPainting
 Zombie Slayer	6	LX_setWorkshed
-Zombie Slayer	7	LX_artistQuest
-Zombie Slayer	8	LX_galaktikSubQuest
-Zombie Slayer	9	LX_armorySideQuest
-Zombie Slayer	10	LX_meatsmithSubQuest
-Zombie Slayer	11	L9_leafletQuest
-Zombie Slayer	12	L5_findKnob
-Zombie Slayer	13	L12_sonofaPrefix
-Zombie Slayer	14	LX_burnDelay
-Zombie Slayer	15	LX_summonMonster
-Zombie Slayer	16	L11_aridDesert	L11_hasUltrahydrated
-Zombie Slayer	17	handleRainDoh
-Zombie Slayer	18	L11_shenStartQuest
-Zombie Slayer	19	LX_guildUnlock
-Zombie Slayer	20	LX_unlockDesert
-Zombie Slayer	21	LX_lockPicking
-Zombie Slayer	22	LX_fatLootToken
-Zombie Slayer	23	L5_getEncryptionKey
-Zombie Slayer	24	L5_findKnob
-Zombie Slayer	25	L2_mosquito
-Zombie Slayer	26	LX_unlockHiddenTemple
-Zombie Slayer	27	L6_dakotaFanning
-Zombie Slayer	28	LX_steelOrgan
-Zombie Slayer	29	L12_islandWar
-Zombie Slayer	30	LX_spookyravenManorFirstFloor
-Zombie Slayer	31	L11_blackMarket
-Zombie Slayer	32	L11_forgedDocuments
-Zombie Slayer	33	L11_mcmuffinDiary
-Zombie Slayer	34	L11_getBeehive
-Zombie Slayer	35	L11_unlockHiddenCity
-Zombie Slayer	36	L11_hiddenCityZones
-Zombie Slayer	37	L11_hiddenCity
-Zombie Slayer	38	LX_spookyravenManorSecondFloor
-Zombie Slayer	39	L11_mauriceSpookyraven
-Zombie Slayer	40	L11_talismanOfNam
-Zombie Slayer	41	L10_plantThatBean
-Zombie Slayer	42	L10_rainOnThePlains
-Zombie Slayer	43	L9_chasmBuild
-Zombie Slayer	44	L9_highLandlord
-Zombie Slayer	45	L8_trapperQuest
-Zombie Slayer	46	L6_friarsGetParts
-Zombie Slayer	47	L7_crypt
-Zombie Slayer	48	L11_palindome
-Zombie Slayer	49	L11_aridDesert
-Zombie Slayer	50	L11_unlockPyramid
-Zombie Slayer	51	L11_unlockEd
-Zombie Slayer	52	L11_defeatEd
-Zombie Slayer	53	L5_slayTheGoblinKing
-Zombie Slayer	54	L4_batCave
-Zombie Slayer	55	L3_tavern
-Zombie Slayer	56	setSoftblockDelay	allowSoftblockDelay
-Zombie Slayer	57	L13_towerAscent
-Zombie Slayer	58	LX_attemptPowerLevel
+Zombie Slayer	7	LX_galaktikSubQuest
+Zombie Slayer	8	L9_leafletQuest
+Zombie Slayer	9	L5_findKnob
+Zombie Slayer	10	L12_sonofaPrefix
+Zombie Slayer	11	LX_burnDelay
+Zombie Slayer	12	LX_summonMonster
+Zombie Slayer	13	L11_aridDesert	L11_hasUltrahydrated
+Zombie Slayer	14	handleRainDoh
+Zombie Slayer	15	L11_shenStartQuest
+Zombie Slayer	16	LX_guildUnlock
+Zombie Slayer	17	LX_unlockDesert
+Zombie Slayer	18	LX_lockPicking
+Zombie Slayer	19	LX_fatLootToken
+Zombie Slayer	20	L5_getEncryptionKey
+Zombie Slayer	21	L5_findKnob
+Zombie Slayer	22	L2_mosquito
+Zombie Slayer	23	LX_unlockHiddenTemple
+Zombie Slayer	24	L6_dakotaFanning
+Zombie Slayer	25	LX_steelOrgan
+Zombie Slayer	26	L12_islandWar
+Zombie Slayer	27	LX_spookyravenManorFirstFloor
+Zombie Slayer	28	L11_blackMarket
+Zombie Slayer	29	L11_forgedDocuments
+Zombie Slayer	30	L11_mcmuffinDiary
+Zombie Slayer	31	L11_getBeehive
+Zombie Slayer	32	L11_unlockHiddenCity
+Zombie Slayer	33	L11_hiddenCityZones
+Zombie Slayer	34	L11_hiddenCity
+Zombie Slayer	35	LX_spookyravenManorSecondFloor
+Zombie Slayer	36	L11_mauriceSpookyraven
+Zombie Slayer	37	L11_talismanOfNam
+Zombie Slayer	38	L10_plantThatBean
+Zombie Slayer	39	L10_rainOnThePlains
+Zombie Slayer	40	L9_chasmBuild
+Zombie Slayer	41	L9_highLandlord
+Zombie Slayer	42	L8_trapperQuest
+Zombie Slayer	43	L6_friarsGetParts
+Zombie Slayer	44	L7_crypt
+Zombie Slayer	45	L11_palindome
+Zombie Slayer	46	L11_aridDesert
+Zombie Slayer	47	L11_unlockPyramid
+Zombie Slayer	48	L11_unlockEd
+Zombie Slayer	49	L11_defeatEd
+Zombie Slayer	50	L5_slayTheGoblinKing
+Zombie Slayer	51	L4_batCave
+Zombie Slayer	52	L3_tavern
+Zombie Slayer	53	setSoftblockDelay	allowSoftblockDelay
+Zombie Slayer	54	L13_towerAscent
+Zombie Slayer	55	LX_attemptPowerLevel
 
 default	0	LX_freeCombatsTask
 default	1	woods_questStart
@@ -395,92 +380,89 @@ default	3	catBurglarHeist
 default	4	auto_breakfastCounterVisit
 default	5	chateauPainting
 default	6	LX_setWorkshed
-default	7	LX_artistQuest
-default	8	LX_galaktikSubQuest
-default	9	LX_armorySideQuest
-default	10	LX_meatsmithSubQuest
-default	11	L9_leafletQuest
-default	12	L5_findKnob
-default	13	L12_sonofaPrefix
-default	14	LX_burnDelay
-default	15	LX_summonMonster
-default	16	LM_edTheUndying
-default	17	LX_bugbearInvasion
-default	18	LX_lowkeySummer
-default	19	resolveSixthDMT
-default	20	L11_aridDesert	L11_hasUltrahydrated
-default	21	L12_flyerFinish
-default	22	L12_getOutfit
-default	23	L12_startWar
-default	24	LX_loggingHatchet
-default	25	LX_guildUnlock
-default	26	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
-default	27	LX_unlockDesert
-default	28	handleRainDoh
-default	29	LX_spookyravenManorFirstFloor
-default	30	L6_friarsGetParts	LX_steelOrgan_condition_slow
-default	31	LX_steelOrgan	LX_steelOrgan_condition_slow
-default	32	L4_batCave
-default	33	L2_mosquito
-default	34	LX_unlockHiddenTemple
-default	35	L6_dakotaFanning
-default	36	LX_lockPicking
-default	37	LX_fatLootToken
-default	38	L5_slayTheGoblinKing
-default	39	LX_islandAccess
-default	40	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
-default	41	LX_spookyravenManorSecondFloor
-default	42	L3_tavern
-default	43	L6_friarsGetParts
-default	44	LX_steelOrgan	in_hardcore
-default	45	L7_crypt
-default	46	fancyOilPainting
-default	47	L8_trapperQuest
-default	48	LX_steelOrgan
-default	49	L10_plantThatBean
-default	50	L12_preOutfit
-default	51	L10_airship
-default	52	L10_basement
-default	53	L10_ground
-default	54	L11_blackMarket
-default	55	L11_forgedDocuments
-default	56	L11_mcmuffinDiary
-default	57	L10_topFloor
-default	58	L10_holeInTheSkyUnlock
-default	59	L9_chasmBuild
-default	60	L9_highLandlord
-default	61	L12_flyerBackup
-default	62	Lsc_flyerSeals
-default	63	L11_mauriceSpookyraven
-default	64	L11_unlockHiddenCity
-default	65	L11_hiddenCityZones
-default	66	LX_ornateDowsingRod
-default	67	L11_aridDesert
-default	68	L11_hiddenCity
-default	69	L11_talismanOfNam
-default	70	L11_palindome
-default	71	L11_unlockPyramid
-default	72	L11_unlockEd
-default	73	L11_defeatEd
-default	74	L12_gremlins
-default	75	L12_sonofaFinish
-default	76	L12_sonofaBeach
-default	77	L12_filthworms
-default	78	L12_orchardFinalize
-default	79	L12_themtharHills
-default	80	L12_farm
-default	81	L11_getBeehive
-default	82	L12_finalizeWar
-default	83	L12_clearBattlefield
-default	84	LX_koeInvaderHandler
-default	85	setSoftblockDelay	allowSoftblockDelay
-default	86	L12_lastDitchFlyer
-default	87	LX_bugbearInvasionFinale
-default	88	L13_towerNSContests
-default	89	L13_towerNSHedge
-default	90	L13_sorceressDoor
-default	91	L13_towerNSTower
-default	92	L13_towerNSNagamar
-default	93	L13_towerNSFinal
-default	94	LX_attemptPowerLevel
+default	7	LX_galaktikSubQuest
+default	8	L9_leafletQuest
+default	9	L5_findKnob
+default	10	L12_sonofaPrefix
+default	11	LX_burnDelay
+default	12	LX_summonMonster
+default	13	LM_edTheUndying
+default	14	LX_bugbearInvasion
+default	15	LX_lowkeySummer
+default	16	resolveSixthDMT
+default	17	L11_aridDesert	L11_hasUltrahydrated
+default	18	L12_flyerFinish
+default	19	L12_getOutfit
+default	20	L12_startWar
+default	21	LX_loggingHatchet
+default	22	LX_guildUnlock
+default	23	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
+default	24	LX_unlockDesert
+default	25	handleRainDoh
+default	26	LX_spookyravenManorFirstFloor
+default	27	L6_friarsGetParts	LX_steelOrgan_condition_slow
+default	28	LX_steelOrgan	LX_steelOrgan_condition_slow
+default	29	L4_batCave
+default	30	L2_mosquito
+default	31	LX_unlockHiddenTemple
+default	32	L6_dakotaFanning
+default	33	LX_lockPicking
+default	34	LX_fatLootToken
+default	35	L5_slayTheGoblinKing
+default	36	LX_islandAccess
+default	37	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
+default	38	LX_spookyravenManorSecondFloor
+default	39	L3_tavern
+default	40	L6_friarsGetParts
+default	41	LX_steelOrgan	in_hardcore
+default	42	L7_crypt
+default	43	fancyOilPainting
+default	44	L8_trapperQuest
+default	45	LX_steelOrgan
+default	46	L10_plantThatBean
+default	47	L12_preOutfit
+default	48	L10_airship
+default	49	L10_basement
+default	50	L10_ground
+default	51	L11_blackMarket
+default	52	L11_forgedDocuments
+default	53	L11_mcmuffinDiary
+default	54	L10_topFloor
+default	55	L10_holeInTheSkyUnlock
+default	56	L9_chasmBuild
+default	57	L9_highLandlord
+default	58	L12_flyerBackup
+default	59	Lsc_flyerSeals
+default	60	L11_mauriceSpookyraven
+default	61	L11_unlockHiddenCity
+default	62	L11_hiddenCityZones
+default	63	LX_ornateDowsingRod
+default	64	L11_aridDesert
+default	65	L11_hiddenCity
+default	66	L11_talismanOfNam
+default	67	L11_palindome
+default	68	L11_unlockPyramid
+default	69	L11_unlockEd
+default	70	L11_defeatEd
+default	71	L12_gremlins
+default	72	L12_sonofaFinish
+default	73	L12_sonofaBeach
+default	74	L12_filthworms
+default	75	L12_orchardFinalize
+default	76	L12_themtharHills
+default	77	L12_farm
+default	78	L11_getBeehive
+default	79	L12_finalizeWar
+default	80	L12_clearBattlefield
+default	81	LX_koeInvaderHandler
+default	82	setSoftblockDelay	allowSoftblockDelay
+default	83	L12_lastDitchFlyer
+default	84	LX_bugbearInvasionFinale
+default	85	L13_towerNSContests
+default	86	L13_towerNSHedge
+default	87	L13_sorceressDoor
+default	88	L13_towerNSTower
+default	89	L13_towerNSNagamar
+default	90	L13_towerNSFinal
+default	91	LX_attemptPowerLevel
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27637;	// support jill-of-all-trades
+since r27660;	// Fix Jill LED candle modifiers to be on candle, not Jill.
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -173,7 +173,6 @@ void initializeSettings() {
 	set_property("auto_chasmBusted", true);
 	set_property("auto_chewed", "");
 	set_property("auto_clanstuff", "0");
-	set_property("auto_cookie", -1);
 	set_property("auto_copies", "");
 	set_property("auto_dakotaFanning", false);
 	set_property("auto_day_init", 0);
@@ -199,8 +198,6 @@ void initializeSettings() {
 	set_property("auto_grimstoneOrnateDowsingRod", true);
 	set_property("auto_haveoven", false);
 	set_property("auto_doGalaktik", get_property("auto_doGalaktik_initialize"));
-	set_property("auto_doArmory", false);
-	set_property("auto_doMeatsmith", false);
 	set_property("auto_L8_ninjaAssassinFail", false);
 	set_property("auto_L8_extremeInstead", false);
 	set_property("auto_L9_smutOrcPervert", false);
@@ -275,7 +272,6 @@ void initializeSettings() {
 	plumber_initializeSettings();
 	lowkey_initializeSettings();
 	bhy_initializeSettings();
-	grey_goo_initializeSettings();
 	qt_initializeSettings();
 	jarlsberg_initializeSettings();
 	robot_initializeSettings();
@@ -742,7 +738,6 @@ void initializeDay(int day)
 	pete_initializeDay(day);
 	glover_initializeDay(day);
 	bat_initializeDay(day);
-	grey_goo_initializeDay(day);
 	jarlsberg_initializeDay(day);
 
 	// Bulk cache mall prices

--- a/RELEASE/scripts/autoscend/auto_settings.ash
+++ b/RELEASE/scripts/autoscend/auto_settings.ash
@@ -304,6 +304,11 @@ void auto_settingsDelete()
 	remove_property("auto_saveMagicalSausage"); // unnecessary. Resources on hand should be used to progress quests.
 	remove_property("auto_useWishes"); // unnecessary. Resources on hand should be used to progress quests.
 	remove_property("auto_doNotUseCMC"); // unnecessary. Predates 2023 ascension workshed changes & as above resources on hand should be used to progress quests.
+	remove_property("auto_doArtistQuest"); // irrelevant in-run.
+	remove_property("auto_noSleepingDog"); // old & unused since consumption was rewritten 3-4 years ago.
+	remove_property("auto_cookie"); // old & unused since the semirare & clover revamp.
+	remove_property("auto_doArmory"); // irrelevant in-run.
+	remove_property("auto_doMeatsmith"); // irrelevant in-run.
 }
 
 void defaultConfig(string prop, string val)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -706,8 +706,6 @@ boolean LM_gnoob();
 ########################################################################################################
 //Defined in autoscend/paths/grey_goo.ash
 boolean in_ggoo();
-void grey_goo_initializeSettings();
-void grey_goo_initializeDay(int day);
 boolean LA_grey_goo_tasks();
 
 ########################################################################################################
@@ -1175,7 +1173,6 @@ boolean LX_dronesOut();
 
 ########################################################################################################
 //Defined in autoscend/quests/optional.ash
-boolean LX_artistQuest();
 boolean LX_unlockThinknerdWarehouse(boolean spend_resources);
 boolean LX_melvignShirt();
 boolean LX_steelOrgan_condition_slow();
@@ -1183,14 +1180,12 @@ boolean LX_steelOrgan();
 boolean LX_guildUnlock();
 boolean startArmorySubQuest();
 boolean finishArmorySideQuest();
-boolean LX_armorySideQuest();
 void considerGalaktikSubQuest();
 boolean startGalaktikSubQuest();
 boolean finishGalaktikSubQuest();
 boolean LX_galaktikSubQuest();
 boolean startMeatsmithSubQuest();
 boolean finishMeatsmithSubQuest();
-boolean LX_meatsmithSubQuest();
 boolean LX_doingPirates();
 boolean LX_pirateOutfit();
 void piratesCoveChoiceHandler(int choice);

--- a/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_boris.ash
@@ -53,7 +53,6 @@ void boris_initializeSettings()
 		auto_log_info("Initializing Avatar of Boris settings", "blue");
 		set_property("auto_borisSkills", -1);
 		set_property("auto_wandOfNagamar", false);
-		set_property("auto_doArmory", true);
 
 		# Mafia r16876 does not see the Boris Helms in storage and will not pull them.
 		# We have to force the issue.

--- a/RELEASE/scripts/autoscend/paths/grey_goo.ash
+++ b/RELEASE/scripts/autoscend/paths/grey_goo.ash
@@ -3,23 +3,6 @@ boolean in_ggoo()
 	return my_path() == $path[Grey Goo];
 }
 
-void grey_goo_initializeSettings()
-{
-	if(!in_ggoo())
-	{
-		return;
-	}
-	set_property("auto_paranoia", 1);		//greygoo has broken tracking verified for questL02Larva && questM19Hippy. probably more things
-}
-
-void grey_goo_initializeDay(int day)
-{
-	if(!in_ggoo())
-	{
-		return;
-	}
-}
-
 boolean LA_grey_goo_tasks()
 {
 	if(!in_ggoo())
@@ -27,9 +10,6 @@ boolean LA_grey_goo_tasks()
 		return false;
 	}
 	
-	if(LX_galaktikSubQuest()) return true;			//only if user manually set auto_doGalaktik to true this ascension
-	if(LX_armorySideQuest()) return true;			//only if user manually set auto_doArmory to true this ascension
-
 	print("Adventuring in Grey Goo is not currently supported, or necessary. Have fun!");
 	if (my_daycount() >= 3)
 	{

--- a/RELEASE/scripts/autoscend/paths/you_robot.ash
+++ b/RELEASE/scripts/autoscend/paths/you_robot.ash
@@ -1510,7 +1510,6 @@ boolean LA_robot()
 	if(LX_freeCombats(true)) return true;
 	
 	if(LX_galaktikSubQuest()) return true;			//only if user manually set auto_doGalaktik to true this ascension
-	if(LX_armorySideQuest()) return true;			//only if user manually set auto_doArmory to true this ascension
 	
 	//get some levels early on
 	if(LX_robot_level()) return true;

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1,45 +1,5 @@
 // All prototypes for this code described in autoscend_header.ash
 
-boolean LX_artistQuest()
-{
-	if((get_property("auto_doArtistQuest").to_boolean()) && (get_property("questM02Artist") != "finished"))
-	{
-		if(get_property("questM02Artist") == "unstarted")
-		{
-			visit_url("place.php?whichplace=town_wrong&action=townwrong_artist_noquest");
-			visit_url("place.php?whichplace=town_wrong&action=townwrong_artist_noquest&getquest=1");
-			visit_url("place.php?whichplace=town_wrong&action=townwrong_artist_quest");
-		}
-		if(get_property("questM02Artist") == "started")
-		{
-			if(item_amount($item[Pretentious Paintbrush]) == 0)
-			{
-				autoAdv($location[The Outskirts of Cobb\'s Knob]);
-			}
-			else if(item_amount($item[Pretentious Palette]) == 0)
-			{
-				autoAdv($location[The Haunted Pantry]);
-			}
-			else if(item_amount($item[Pail of Pretentious Paint]) == 0)
-			{
-				autoAdv($location[The Sleazy Back Alley]);
-			}
-			else
-			{
-				visit_url("place.php?whichplace=town_wrong&action=townwrong_artist_quest");
-			}
-			return true;
-		}
-		else
-		{
-			auto_log_warning("Failed starting artist quest, rejecting completely.", "red");
-			set_property("auto_doArtistQuest", false);
-			return false;
-		}
-	}
-	return false;
-}
-
 boolean LX_unlockThinknerdWarehouse(boolean spend_resources)
 {
 	//unlocks [The Thinknerd Warehouse], returns true if successful or adv is spent
@@ -494,26 +454,6 @@ boolean finishArmorySideQuest()
 	return internalQuestStatus("questM25Armorer") > 4;
 }
 
-boolean LX_armorySideQuest()
-{
-	//do the quest [Lending a Hand (and a Foot)] and unlock [madeline's baking supply] store
-	//step2 = need to kill the cake lord
-	//step3 = killed the cake lord
-	//step4 = clicked through the mandatory noncombat pages after the cake lord was killed
-	startArmorySubQuest();							//always start the quest to unlock the zone. costs no adv
-	if(finishArmorySideQuest()) return true;		//always finish the quest if possible. unlocks a shop.
-
-	if(!get_property("auto_doArmory").to_boolean())		//post setting indicating we should do this quest this ascension
-	{
-		return false;
-	}	
-	if(internalQuestStatus("questM25Armorer") > -1 && internalQuestStatus("questM25Armorer") < 4)
-	{
-		return autoAdv($location[Madness Bakery]);
-	}
-	return false;
-}
-
 boolean startMeatsmithSubQuest()
 {
 	if(in_koe())
@@ -553,24 +493,6 @@ boolean finishMeatsmithSubQuest()
 		return true;
 	}
 	return false;
-}
-
-boolean LX_meatsmithSubQuest()
-{
-	//do meatsmith optional subquest.
-	if(startMeatsmithSubQuest()) return true;		//always start the quest if available
-	if(finishMeatsmithSubQuest()) return true;		//always turn the quest in if possible
-	
-	if(internalQuestStatus("questM23Meatsmith") != 0)
-	{
-		return false;	
-	}
-	if(!get_property("auto_doMeatsmith").to_boolean())
-	{
-		return false;		//by default we do not want to do this quest.
-	}
-	
-	return autoAdv($location[The Skeleton Store]);
 }
 
 void considerGalaktikSubQuest()
@@ -665,7 +587,6 @@ boolean finishGalaktikSubQuest()
 boolean LX_galaktikSubQuest()
 {
 	//do doc galaktik optional subquest.
-	if(startGalaktikSubQuest()) return true;	//always start the quest if available
 	if(finishGalaktikSubQuest()) return true;	//always turn the quest in if possible
 	considerGalaktikSubQuest();					//if allowed will automatically enable the quest in some cases
 	
@@ -678,10 +599,10 @@ boolean LX_galaktikSubQuest()
 	{
 		return false;		//by default we do not want to do this quest.
 	}
-	
+	if(startGalaktikSubQuest()) return true;	//always start the quest if available
+
 	return autoAdv($location[The Overgrown Lot]);
 }
-
 
 boolean LX_doingPirates() {
 	return in_lowkeysummer(); //we are only doing pirates in that path now
@@ -1097,23 +1018,23 @@ boolean LX_unlockKnobMenagerie()
 	return autoAdv(1, $location[Cobb\'s Knob Laboratory]);
 }
 
-item[class] epicWeapons;
-epicWeapons[$class[Seal Clubber]] = $item[Hammer of Smiting];
-epicWeapons[$class[Turtle Tamer]] = $item[Chelonian Morningstar];
-epicWeapons[$class[Pastamancer]] = $item[Greek Pasta Spoon of Peril];
-epicWeapons[$class[Sauceror]] = $item[17-alarm Saucepan];
-epicWeapons[$class[Disco Bandit]] = $item[Shagadelic Disco Banjo];
-epicWeapons[$class[Accordion Thief]] = $item[Squeezebox of the Ages];
-// usage: item epicWeapon = epicWeapons[my_class()];
+static item[class] epicWeapons = {
+	$class[Seal Clubber] : $item[Hammer of Smiting],
+	$class[Turtle Tamer] : $item[Chelonian Morningstar],
+	$class[Pastamancer] : $item[Greek Pasta Spoon of Peril],
+	$class[Sauceror] : $item[17-alarm Saucepan],
+	$class[Disco Bandit] : $item[Shagadelic Disco Banjo],
+	$class[Accordion Thief] : $item[Squeezebox of the Ages]
+}; // usage: item epicWeapon = epicWeapons[my_class()];
 
-item[class] starterWeapons;
-starterWeapons[$class[Seal Clubber]] = $item[seal-clubbing club];
-starterWeapons[$class[Turtle Tamer]] = $item[turtle totem];
-starterWeapons[$class[Pastamancer]] = $item[pasta spoon];
-starterWeapons[$class[Sauceror]] = $item[saucepan];
-starterWeapons[$class[Disco Bandit]] = $item[disco ball];
-starterWeapons[$class[Accordion Thief]] = $item[stolen accordion];
-// usage: item starterWeapon = starterWeapons[my_class()];
+static item[class] starterWeapons = {
+	$class[Seal Clubber] : $item[seal-clubbing club],
+	$class[Turtle Tamer] : $item[turtle totem],
+	$class[Pastamancer] : $item[pasta spoon],
+	$class[Sauceror] : $item[saucepan],
+	$class[Disco Bandit] : $item[disco ball],
+	$class[Accordion Thief] : $item[stolen accordion]
+}; // usage: item starterWeapon = starterWeapons[my_class()];
 
 boolean tomb_already_found()
 {


### PR DESCRIPTION
# Description

Removed some more preferences and their associated functions
- auto_doArtistQuest - unnecessary in-run.
- auto_noSleepingDog - unused since consumption was rewritten 3-4 years ago.
- auto_cookie - unused since the semirare & clover revamp, possibly even before that.
- auto_doArmory - unnecessary in-run.
- auto_doMeatsmith - unnecessary in-run.

Removed some unused Grey Goo functions that did nothing.

Changed a couple of maps I wrote for LKS to be static since I was in the file anyway.

Updated the minimum mafia version to r27660 as it has fixes for the maximizer when using the JoAT familiar.

## How Has This Been Tested?

Ran a few Normal Small runs on a couple of accounts. No issues.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
