### PR TITLE
Account for Smut Orc Keepsake Boxes in Bridge Part Counts

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -126,6 +126,7 @@ int fastenerCount()
 	base = base + item_amount($item[Thick Caulk]);
 	base = base + item_amount($item[Long Hard Screw]);
 	base = base + item_amount($item[Messy Butt Joint]);
+	base = base + 5 * item_amount($item[Smut Orc Keepsake Box]);
 
 	return base;
 }
@@ -136,6 +137,7 @@ int lumberCount()
 	base = base + item_amount($item[Morningwood Plank]);
 	base = base + item_amount($item[Raging Hardwood Plank]);
 	base = base + item_amount($item[Weirdwood Plank]);
+	base = base + 5 * item_amount($item[Smut Orc Keepsake Box]);
 
 	return base;
 }


### PR DESCRIPTION
# Description

Inspired by Stacey's SDQ PR, Smut Orc Keepsake Boxes haven't been accounted for in fastener or lumber count. This fixes that, without needing to use them, which was only done in L9_chasmBuild, which is currently towards the end of the task orders.

## How Has This Been Tested?

Bought a keepsake box in aftercore and called fastenerCount and lumberCount from the cli.
![image](https://github.com/loathers/autoscend/assets/21962115/84d5e68e-a36e-4978-8dc5-30f435fd16a2)

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
