### PR TITLE
Add MP Handling < 32

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -1,5 +1,7 @@
 import<autoscend.ash>
 
+void low_mp_handler(); //Calculates MP to acquire at low max mp levels
+
 void print_footer()
 {
 	auto_log_info("[" +my_class()+ "] @ path of [" +my_path().name+ "]", "blue");
@@ -108,7 +110,9 @@ void auto_ghost_prep(location place)
 	{
 		if(auto_have_skill(sk))
 		{
-			acquireMP(32, 1000);		//make sure we actually have the MP to cast spells
+			if(my_maxmp() >= 32)
+				acquireMP(32, 0);		//make sure we actually have the MP to cast spells
+			else low_mp_handler();
 		}
 		if(canUse(sk)) return;	//we can kill them with a spell
 	}
@@ -920,6 +924,11 @@ boolean auto_pre_adventure()
 	borisTrusty();
 
 	acquireMP(32, 0);
+	
+	if(my_maxmp() < 32)
+	{
+		low_mp_handler();
+	}
 
 	if(in_hardcore() && (my_class() == $class[Sauceror]) && (my_mp() < 32))
 	{
@@ -959,6 +968,15 @@ boolean auto_pre_adventure()
 
 	print_footer();
 	return true;
+}
+
+//At low max MP, important to keep MP near max, since every saucestorm (etc.) counts
+void low_mp_handler()
+{
+	auto_log_debug("Low max MP detected.", "red");
+	int MIN_USEFUL_MP = 6; //Saucestorm
+	int TARGET_MP = my_maxmp() - (my_maxmp() % MIN_USEFUL_MP);
+	acquireMP(TARGET_MP, 0);
 }
 
 void main()

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -1,6 +1,14 @@
 import<autoscend.ash>
 
-void low_mp_handler(); //Calculates MP to acquire at low max mp levels
+//Calculates MP to acquire at low max mp levels
+//At low max MP, important to keep MP near max, since every saucestorm (etc.) counts
+void low_mp_handler()
+{
+	auto_log_debug("Low max MP detected.", "red");
+	int MIN_USEFUL_MP = 6; //Saucestorm
+	int TARGET_MP = my_maxmp() - (my_maxmp() % MIN_USEFUL_MP);
+	acquireMP(TARGET_MP, 0);
+}
 
 void print_footer()
 {
@@ -968,15 +976,6 @@ boolean auto_pre_adventure()
 
 	print_footer();
 	return true;
-}
-
-//At low max MP, important to keep MP near max, since every saucestorm (etc.) counts
-void low_mp_handler()
-{
-	auto_log_debug("Low max MP detected.", "red");
-	int MIN_USEFUL_MP = 6; //Saucestorm
-	int TARGET_MP = my_maxmp() - (my_maxmp() % MIN_USEFUL_MP);
-	acquireMP(TARGET_MP, 0);
 }
 
 void main()


### PR DESCRIPTION
# Description

Adds new function, low_mp_handler, that calculates and acquires target MP numbers when the max is below 32.

This function includes readable and configurable properties, MIN_USEFUL_MP and TARGET_MP. These properties are currently designed to ensure we can cast the maximum number of Saucestorms in each fight.

Adds low_mp_handler to both the main logic and the 'Can we kill ghosts?' logic.

Updates the 'Can we kill ghosts?' logic to unreservedly use our meat when restoring MP for ghost killing, matching other recent changes.

Partially addresses https://github.com/loathers/autoscend/issues/743 - just needs a <6 MP case, possibly aborting.

## How Has This Been Tested?
Tested on a non-shiny hardcore run to ensure performing as expected. MP targets accurately selected and adjusted as max MP grows. Tested for several days on other accounts with varying levels of max MP to ensure autoscend still performing normally.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
