### PR TITLE
unbind vampieroghi at hidden apartment building

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -217,6 +217,13 @@ boolean auto_pre_adventure()
 		uneffect($effect[Scarysauce]);
 		if(!uneffect($effect[Scariersauce])) abort("Could not uneffect [Scariersauce]");
 	}
+	
+	if(my_class() == $class[Pastamancer] && my_thrall() == $thrall[Vampieroghi] && place == $location[The Hidden Apartment Building]
+		&& auto_have_skill($skill[Dismiss Pasta Thrall]))
+	{
+		// vampieroghi can dispell the shaman curse, preventing us from making quest progress
+		use_skill($skill[Dismiss Pasta Thrall]);
+	}
 
 	if(place == $location[The Smut Orc Logging Camp])
 	{


### PR DESCRIPTION
# Description

Dismissing vampieroghi thrall when going to hidden apartment building. We never bind the vamp thrall, but it is possible to manually do it and we should handle that.

Issue reported in discord

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
