### PR TITLE
Don't backup away from a free fight at end of day

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -210,6 +210,7 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	}
 
 	monster backedUpMonster = get_property("lastCopyableMonster").to_monster();
+	// reserve last adv for end of day free fights
 	boolean reserveAdvsForFreeFights = my_adventures() < 2 && !isFreeMonster(backedUpMonster);
 	if(auto_backupTarget() && enemy != backedUpMonster && canUse($skill[Back-Up to your Last Enemy])
 		&& !reserveAdvsForFreeFights)

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -209,10 +209,13 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		}
 	}
 
-	if(auto_backupTarget() && enemy != get_property("lastCopyableMonster").to_monster() && canUse($skill[Back-Up to your Last Enemy]))
+	monster backedUpMonster = get_property("lastCopyableMonster").to_monster();
+	boolean reserveAdvsForFreeFights = my_adventures() < 2 && !isFreeMonster(backedUpMonster);
+	if(auto_backupTarget() && enemy != backedUpMonster && canUse($skill[Back-Up to your Last Enemy])
+		&& !reserveAdvsForFreeFights)
 	{
 		handleTracker(enemy, $skill[Back-Up to your Last Enemy], "auto_replaces");
-		handleTracker(get_property("lastCopyableMonster").to_monster(), $skill[Back-Up to your Last Enemy], "auto_copies");
+		handleTracker(backedUpMonster, $skill[Back-Up to your Last Enemy], "auto_copies");
 		return useSkill($skill[Back-Up to your Last Enemy]);	
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -222,8 +222,8 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	}
 
 	monster backedUpMonster = get_property("lastCopyableMonster").to_monster();
-	// reserve last adv for end of day free fights
-	boolean reserveAdvsForFreeFights = my_adventures() < 2 && !isFreeMonster(backedUpMonster);
+	// reserve last 2 advs for end of day free fights
+	boolean reserveAdvsForFreeFights = my_adventures() < 3 && !isFreeMonster(backedUpMonster);
 	if(auto_backupTarget() && enemy != backedUpMonster && canUse($skill[Back-Up to your Last Enemy])
 		&& !reserveAdvsForFreeFights)
 	{


### PR DESCRIPTION
# Description

Reported in discord. User in HC Oxycore. Was backing up NSA into end of day free fights. Got to critically low turns (<2) while doing end of day free fights and aborted. Doesn't expect adv's to be used while free fighting. 

This should fix backing up from a free to a not free fight when low on advs.

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
