### PR TITLE
copy small task order to default

### DIFF
--- a/BUILD/task_order/A Shrunken Adventurer am I.dat
+++ b/BUILD/task_order/A Shrunken Adventurer am I.dat
@@ -16,11 +16,11 @@ L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
 L11_shenStartQuest
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.
 LX_goingUnderground
-# Forcing Non-combats to progress quests.
 # Burn Breathitin charges
-auto_useBreathitinCharges
+LX_useBreathitinCharges
 # Guild access.
 LX_guildUnlock
 #	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.

--- a/BUILD/task_order/Avatar of Jarlsberg.dat
+++ b/BUILD/task_order/Avatar of Jarlsberg.dat
@@ -52,5 +52,6 @@ L5_slayTheGoblinKing
 L4_batCave
 L3_tavern
 setSoftblockDelay	allowSoftblockDelay
+setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 L13_towerAscent
 LX_attemptPowerLevel

--- a/BUILD/task_order/Legacy of Loathing.dat
+++ b/BUILD/task_order/Legacy of Loathing.dat
@@ -89,6 +89,7 @@ L12_finalizeWar
 L12_clearBattlefield
 LX_koeInvaderHandler
 setSoftblockDelay	allowSoftblockDelay
+setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 L12_lastDitchFlyer
 LX_bugbearInvasionFinale
 L13_towerNSContests

--- a/BUILD/task_order/Quantum Terrarium.dat
+++ b/BUILD/task_order/Quantum Terrarium.dat
@@ -56,5 +56,6 @@ L5_slayTheGoblinKing
 L4_batCave
 L3_tavern
 setSoftblockDelay	allowSoftblockDelay
+setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 L13_towerAscent
 LX_attemptPowerLevel

--- a/BUILD/task_order/Zombie Slayer.dat
+++ b/BUILD/task_order/Zombie Slayer.dat
@@ -52,5 +52,6 @@ L5_slayTheGoblinKing
 L4_batCave
 L3_tavern
 setSoftblockDelay	allowSoftblockDelay
+setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 L13_towerAscent
 LX_attemptPowerLevel

--- a/BUILD/task_order/default.dat
+++ b/BUILD/task_order/default.dat
@@ -11,82 +11,82 @@ L5_findKnob
 L12_sonofaPrefix
 LX_burnDelay
 LX_summonMonster
-LM_edTheUndying
-LX_bugbearInvasion
-LX_lowkeySummer
-resolveSixthDMT
+# make sure we don't waste turns of Ultrahydrated doing something else.
 L11_aridDesert	L11_hasUltrahydrated
-L12_flyerFinish
-L12_getOutfit
-L12_startWar
-LX_loggingHatchet
+# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+L11_shenStartQuest
+# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+finishBuildingSmutOrcBridge
+# Underground Adventuring for CMC/Breathitin.
+LX_goingUnderground
+# Burn Breathitin charges
+LX_useBreathitinCharges
+# Guild access.
 LX_guildUnlock
-LX_bitchinMeatcar	LX_bitchinMeatcar_condition
+#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
 LX_unlockDesert
-handleRainDoh
-LX_spookyravenManorFirstFloor
-L6_friarsGetParts	LX_steelOrgan_condition_slow
-LX_steelOrgan	LX_steelOrgan_condition_slow
-L4_batCave
-L2_mosquito
-LX_unlockHiddenTemple
-L6_dakotaFanning
 LX_lockPicking
 LX_fatLootToken
-L5_slayTheGoblinKing
-LX_islandAccess
-L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
-LX_spookyravenManorSecondFloor
-L3_tavern
-L6_friarsGetParts
-LX_steelOrgan	in_hardcore
-L7_crypt
-fancyOilPainting
-L8_trapperQuest
+#	Get the Steel Organ if the user wants it (needs L6 quest complete)
 LX_steelOrgan
-L10_plantThatBean
-L12_preOutfit
-L10_airship
-L10_basement
-L10_ground
+# open up delay zones.
+LX_spookyravenManorFirstFloor
+# open up zones where we want to force non-combats.
+# Open up underground zones so they are available for Breathitin.
+L5_getEncryptionKey
+L5_findKnob
+#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
+L12_islandWar
+# Start the macguffin quest
 L11_blackMarket
 L11_forgedDocuments
 L11_mcmuffinDiary
-L10_topFloor
-L10_holeInTheSkyUnlock
+L11_getBeehive
+# open the hidden city up (delay zones)
+L2_mosquito
+LX_unlockHiddenTemple
+L6_dakotaFanning
+L11_unlockHiddenCity
+# Murder pygmies for the ancient amulet.
+L11_hiddenCityZones
+L11_hiddenCity
+# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+LX_spookyravenManorSecondFloor
+L11_mauriceSpookyraven
+# Lay the smack down on those Jerk Copperhead twins
+L11_talismanOfNam
+# Open up the top of the beanstalk.
+L10_plantThatBean
+# Clean up the plains
+L10_rainOnThePlains
+# Get Black Angus his pizza
 L9_chasmBuild
 L9_highLandlord
-L12_flyerBackup
-Lsc_flyerSeals
-L11_mauriceSpookyraven
-L11_unlockHiddenCity
-L11_hiddenCityZones
-LX_ornateDowsingRod
-L11_aridDesert
-L11_hiddenCity
-L11_talismanOfNam
+#  Kill Groar because *we* are the monsters.
+L8_trapperQuest
+# Kill the undead? Is this an oxymoron?
+L7_crypt
+# Cleanse the taint.
+L6_friarsGetParts
+# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
 L11_palindome
+L11_aridDesert
 L11_unlockPyramid
 L11_unlockEd
 L11_defeatEd
-L12_gremlins
-L12_sonofaFinish
-L12_sonofaBeach
-L12_filthworms
-L12_orchardFinalize
-L12_themtharHills
-L12_farm
-L11_getBeehive
-L12_finalizeWar
-L12_clearBattlefield
-LX_koeInvaderHandler
+#	Finish off the Goblin King.
+L5_slayTheGoblinKing
+# Show the Boss bat who's boss.
+L4_batCave
+# Fix that dripping tap.
+L3_tavern
+# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
+L2_mosquito
+# release the softblock on delay burning
 setSoftblockDelay	allowSoftblockDelay
-L12_lastDitchFlyer
-LX_bugbearInvasionFinale
-L13_towerNSContests
-L13_towerNSHedge
-L13_sorceressDoor
-L13_towerNSTower
-L13_towerNSNagamar
-L13_towerNSFinal
+# release the softblock on Underground Adventures
+setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
+L13_towerAscent
+# if all else fails, powerlevel like there's no tomorrow.
 LX_attemptPowerLevel

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -22,80 +22,80 @@ A Shrunken Adventurer am I	13	L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
 A Shrunken Adventurer am I	14	L11_shenStartQuest
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+A Shrunken Adventurer am I	15	finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.
-A Shrunken Adventurer am I	15	LX_goingUnderground
-# Forcing Non-combats to progress quests.
+A Shrunken Adventurer am I	16	LX_goingUnderground
 # Burn Breathitin charges
-A Shrunken Adventurer am I	16	auto_useBreathitinCharges
+A Shrunken Adventurer am I	17	LX_useBreathitinCharges
 # Guild access.
-A Shrunken Adventurer am I	17	LX_guildUnlock
+A Shrunken Adventurer am I	18	LX_guildUnlock
 #	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
-A Shrunken Adventurer am I	18	LX_unlockDesert
-A Shrunken Adventurer am I	19	LX_lockPicking
-A Shrunken Adventurer am I	20	LX_fatLootToken
+A Shrunken Adventurer am I	19	LX_unlockDesert
+A Shrunken Adventurer am I	20	LX_lockPicking
+A Shrunken Adventurer am I	21	LX_fatLootToken
 #	Get the Steel Organ if the user wants it (needs L6 quest complete)
-A Shrunken Adventurer am I	21	LX_steelOrgan
+A Shrunken Adventurer am I	22	LX_steelOrgan
 # open up delay zones.
-A Shrunken Adventurer am I	22	LX_spookyravenManorFirstFloor
+A Shrunken Adventurer am I	23	LX_spookyravenManorFirstFloor
 # open up zones where we want to force non-combats.
 # Open up underground zones so they are available for Breathitin.
-A Shrunken Adventurer am I	23	L5_getEncryptionKey
-A Shrunken Adventurer am I	24	L5_findKnob
+A Shrunken Adventurer am I	24	L5_getEncryptionKey
+A Shrunken Adventurer am I	25	L5_findKnob
 #	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-A Shrunken Adventurer am I	25	L12_islandWar
+A Shrunken Adventurer am I	26	L12_islandWar
 # Start the macguffin quest
-A Shrunken Adventurer am I	26	L11_blackMarket
-A Shrunken Adventurer am I	27	L11_forgedDocuments
-A Shrunken Adventurer am I	28	L11_mcmuffinDiary
-A Shrunken Adventurer am I	29	L11_getBeehive
+A Shrunken Adventurer am I	27	L11_blackMarket
+A Shrunken Adventurer am I	28	L11_forgedDocuments
+A Shrunken Adventurer am I	29	L11_mcmuffinDiary
+A Shrunken Adventurer am I	30	L11_getBeehive
 # open the hidden city up (delay zones)
-A Shrunken Adventurer am I	30	L2_mosquito
-A Shrunken Adventurer am I	31	LX_unlockHiddenTemple
-A Shrunken Adventurer am I	32	L6_dakotaFanning
-A Shrunken Adventurer am I	33	L11_unlockHiddenCity
+A Shrunken Adventurer am I	31	L2_mosquito
+A Shrunken Adventurer am I	32	LX_unlockHiddenTemple
+A Shrunken Adventurer am I	33	L6_dakotaFanning
+A Shrunken Adventurer am I	34	L11_unlockHiddenCity
 # Murder pygmies for the ancient amulet.
-A Shrunken Adventurer am I	34	L11_hiddenCityZones
-A Shrunken Adventurer am I	35	L11_hiddenCity
+A Shrunken Adventurer am I	35	L11_hiddenCityZones
+A Shrunken Adventurer am I	36	L11_hiddenCity
 # Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-A Shrunken Adventurer am I	36	LX_spookyravenManorSecondFloor
-A Shrunken Adventurer am I	37	L11_mauriceSpookyraven
+A Shrunken Adventurer am I	37	LX_spookyravenManorSecondFloor
+A Shrunken Adventurer am I	38	L11_mauriceSpookyraven
 # Lay the smack down on those Jerk Copperhead twins
-A Shrunken Adventurer am I	38	L11_talismanOfNam
+A Shrunken Adventurer am I	39	L11_talismanOfNam
 # Open up the top of the beanstalk.
-A Shrunken Adventurer am I	39	L10_plantThatBean
+A Shrunken Adventurer am I	40	L10_plantThatBean
 # Clean up the plains
-A Shrunken Adventurer am I	40	L10_rainOnThePlains
+A Shrunken Adventurer am I	41	L10_rainOnThePlains
 # Get Black Angus his pizza
-A Shrunken Adventurer am I	41	L9_chasmBuild
-A Shrunken Adventurer am I	42	L9_highLandlord
+A Shrunken Adventurer am I	42	L9_chasmBuild
+A Shrunken Adventurer am I	43	L9_highLandlord
 #  Kill Groar because *we* are the monsters.
-A Shrunken Adventurer am I	43	L8_trapperQuest
+A Shrunken Adventurer am I	44	L8_trapperQuest
 # Kill the undead? Is this an oxymoron?
-A Shrunken Adventurer am I	44	L7_crypt
+A Shrunken Adventurer am I	45	L7_crypt
 # Cleanse the taint.
-A Shrunken Adventurer am I	45	L6_friarsGetParts
+A Shrunken Adventurer am I	46	L6_friarsGetParts
 # Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-A Shrunken Adventurer am I	46	L11_palindome
-A Shrunken Adventurer am I	47	L11_aridDesert
-A Shrunken Adventurer am I	48	L11_unlockPyramid
-A Shrunken Adventurer am I	49	L11_unlockEd
-A Shrunken Adventurer am I	50	L11_defeatEd
+A Shrunken Adventurer am I	47	L11_palindome
+A Shrunken Adventurer am I	48	L11_aridDesert
+A Shrunken Adventurer am I	49	L11_unlockPyramid
+A Shrunken Adventurer am I	50	L11_unlockEd
+A Shrunken Adventurer am I	51	L11_defeatEd
 #	Finish off the Goblin King.
-A Shrunken Adventurer am I	51	L5_slayTheGoblinKing
+A Shrunken Adventurer am I	52	L5_slayTheGoblinKing
 # Show the Boss bat who's boss.
-A Shrunken Adventurer am I	52	L4_batCave
+A Shrunken Adventurer am I	53	L4_batCave
 # Fix that dripping tap.
-A Shrunken Adventurer am I	53	L3_tavern
+A Shrunken Adventurer am I	54	L3_tavern
 # Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-A Shrunken Adventurer am I	54	L2_mosquito
+A Shrunken Adventurer am I	55	L2_mosquito
 # release the softblock on delay burning
-A Shrunken Adventurer am I	55	setSoftblockDelay	allowSoftblockDelay
+A Shrunken Adventurer am I	56	setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
-A Shrunken Adventurer am I	56	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+A Shrunken Adventurer am I	57	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-A Shrunken Adventurer am I	57	L13_towerAscent
+A Shrunken Adventurer am I	58	L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.
-A Shrunken Adventurer am I	58	LX_attemptPowerLevel
+A Shrunken Adventurer am I	59	LX_attemptPowerLevel
 
 Avatar of Jarlsberg	0	LM_jarlsberg
 Avatar of Jarlsberg	1	LX_freeCombatsTask
@@ -151,8 +151,9 @@ Avatar of Jarlsberg	50	L5_slayTheGoblinKing
 Avatar of Jarlsberg	51	L4_batCave
 Avatar of Jarlsberg	52	L3_tavern
 Avatar of Jarlsberg	53	setSoftblockDelay	allowSoftblockDelay
-Avatar of Jarlsberg	54	L13_towerAscent
-Avatar of Jarlsberg	55	LX_attemptPowerLevel
+Avatar of Jarlsberg	54	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+Avatar of Jarlsberg	55	L13_towerAscent
+Avatar of Jarlsberg	56	LX_attemptPowerLevel
 
 Legacy of Loathing	0	LX_freeCombatsTask
 Legacy of Loathing	1	woods_questStart
@@ -245,15 +246,16 @@ Legacy of Loathing	79	L12_finalizeWar
 Legacy of Loathing	80	L12_clearBattlefield
 Legacy of Loathing	81	LX_koeInvaderHandler
 Legacy of Loathing	82	setSoftblockDelay	allowSoftblockDelay
-Legacy of Loathing	83	L12_lastDitchFlyer
-Legacy of Loathing	84	LX_bugbearInvasionFinale
-Legacy of Loathing	85	L13_towerNSContests
-Legacy of Loathing	86	L13_towerNSHedge
-Legacy of Loathing	87	L13_sorceressDoor
-Legacy of Loathing	88	L13_towerNSTower
-Legacy of Loathing	89	L13_towerNSNagamar
-Legacy of Loathing	90	L13_towerNSFinal
-Legacy of Loathing	91	LX_attemptPowerLevel
+Legacy of Loathing	83	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+Legacy of Loathing	84	L12_lastDitchFlyer
+Legacy of Loathing	85	LX_bugbearInvasionFinale
+Legacy of Loathing	86	L13_towerNSContests
+Legacy of Loathing	87	L13_towerNSHedge
+Legacy of Loathing	88	L13_sorceressDoor
+Legacy of Loathing	89	L13_towerNSTower
+Legacy of Loathing	90	L13_towerNSNagamar
+Legacy of Loathing	91	L13_towerNSFinal
+Legacy of Loathing	92	LX_attemptPowerLevel
 
 Quantum Terrarium	0	LX_freeCombatsTask
 Quantum Terrarium	1	woods_questStart
@@ -313,8 +315,9 @@ Quantum Terrarium	54	L5_slayTheGoblinKing
 Quantum Terrarium	55	L4_batCave
 Quantum Terrarium	56	L3_tavern
 Quantum Terrarium	57	setSoftblockDelay	allowSoftblockDelay
-Quantum Terrarium	58	L13_towerAscent
-Quantum Terrarium	59	LX_attemptPowerLevel
+Quantum Terrarium	58	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+Quantum Terrarium	59	L13_towerAscent
+Quantum Terrarium	60	LX_attemptPowerLevel
 
 Zombie Slayer	0	LM_zombieSlayer
 Zombie Slayer	1	woods_questStart
@@ -370,8 +373,9 @@ Zombie Slayer	50	L5_slayTheGoblinKing
 Zombie Slayer	51	L4_batCave
 Zombie Slayer	52	L3_tavern
 Zombie Slayer	53	setSoftblockDelay	allowSoftblockDelay
-Zombie Slayer	54	L13_towerAscent
-Zombie Slayer	55	LX_attemptPowerLevel
+Zombie Slayer	54	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+Zombie Slayer	55	L13_towerAscent
+Zombie Slayer	56	LX_attemptPowerLevel
 
 default	0	LX_freeCombatsTask
 default	1	woods_questStart
@@ -386,83 +390,83 @@ default	9	L5_findKnob
 default	10	L12_sonofaPrefix
 default	11	LX_burnDelay
 default	12	LX_summonMonster
-default	13	LM_edTheUndying
-default	14	LX_bugbearInvasion
-default	15	LX_lowkeySummer
-default	16	resolveSixthDMT
-default	17	L11_aridDesert	L11_hasUltrahydrated
-default	18	L12_flyerFinish
-default	19	L12_getOutfit
-default	20	L12_startWar
-default	21	LX_loggingHatchet
-default	22	LX_guildUnlock
-default	23	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
-default	24	LX_unlockDesert
-default	25	handleRainDoh
-default	26	LX_spookyravenManorFirstFloor
-default	27	L6_friarsGetParts	LX_steelOrgan_condition_slow
-default	28	LX_steelOrgan	LX_steelOrgan_condition_slow
-default	29	L4_batCave
-default	30	L2_mosquito
-default	31	LX_unlockHiddenTemple
-default	32	L6_dakotaFanning
-default	33	LX_lockPicking
-default	34	LX_fatLootToken
-default	35	L5_slayTheGoblinKing
-default	36	LX_islandAccess
-default	37	L6_friarsGetParts	L6_friarsGetParts_condition_hardcore
-default	38	LX_spookyravenManorSecondFloor
-default	39	L3_tavern
-default	40	L6_friarsGetParts
-default	41	LX_steelOrgan	in_hardcore
-default	42	L7_crypt
-default	43	fancyOilPainting
+# make sure we don't waste turns of Ultrahydrated doing something else.
+default	13	L11_aridDesert	L11_hasUltrahydrated
+# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+default	14	L11_shenStartQuest
+# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+default	15	finishBuildingSmutOrcBridge
+# Underground Adventuring for CMC/Breathitin.
+default	16	LX_goingUnderground
+# Burn Breathitin charges
+default	17	LX_useBreathitinCharges
+# Guild access.
+default	18	LX_guildUnlock
+#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
+default	19	LX_unlockDesert
+default	20	LX_lockPicking
+default	21	LX_fatLootToken
+#	Get the Steel Organ if the user wants it (needs L6 quest complete)
+default	22	LX_steelOrgan
+# open up delay zones.
+default	23	LX_spookyravenManorFirstFloor
+# open up zones where we want to force non-combats.
+# Open up underground zones so they are available for Breathitin.
+default	24	L5_getEncryptionKey
+default	25	L5_findKnob
+#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
+default	26	L12_islandWar
+# Start the macguffin quest
+default	27	L11_blackMarket
+default	28	L11_forgedDocuments
+default	29	L11_mcmuffinDiary
+default	30	L11_getBeehive
+# open the hidden city up (delay zones)
+default	31	L2_mosquito
+default	32	LX_unlockHiddenTemple
+default	33	L6_dakotaFanning
+default	34	L11_unlockHiddenCity
+# Murder pygmies for the ancient amulet.
+default	35	L11_hiddenCityZones
+default	36	L11_hiddenCity
+# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+default	37	LX_spookyravenManorSecondFloor
+default	38	L11_mauriceSpookyraven
+# Lay the smack down on those Jerk Copperhead twins
+default	39	L11_talismanOfNam
+# Open up the top of the beanstalk.
+default	40	L10_plantThatBean
+# Clean up the plains
+default	41	L10_rainOnThePlains
+# Get Black Angus his pizza
+default	42	L9_chasmBuild
+default	43	L9_highLandlord
+#  Kill Groar because *we* are the monsters.
 default	44	L8_trapperQuest
-default	45	LX_steelOrgan
-default	46	L10_plantThatBean
-default	47	L12_preOutfit
-default	48	L10_airship
-default	49	L10_basement
-default	50	L10_ground
-default	51	L11_blackMarket
-default	52	L11_forgedDocuments
-default	53	L11_mcmuffinDiary
-default	54	L10_topFloor
-default	55	L10_holeInTheSkyUnlock
-default	56	L9_chasmBuild
-default	57	L9_highLandlord
-default	58	L12_flyerBackup
-default	59	Lsc_flyerSeals
-default	60	L11_mauriceSpookyraven
-default	61	L11_unlockHiddenCity
-default	62	L11_hiddenCityZones
-default	63	LX_ornateDowsingRod
-default	64	L11_aridDesert
-default	65	L11_hiddenCity
-default	66	L11_talismanOfNam
-default	67	L11_palindome
-default	68	L11_unlockPyramid
-default	69	L11_unlockEd
-default	70	L11_defeatEd
-default	71	L12_gremlins
-default	72	L12_sonofaFinish
-default	73	L12_sonofaBeach
-default	74	L12_filthworms
-default	75	L12_orchardFinalize
-default	76	L12_themtharHills
-default	77	L12_farm
-default	78	L11_getBeehive
-default	79	L12_finalizeWar
-default	80	L12_clearBattlefield
-default	81	LX_koeInvaderHandler
-default	82	setSoftblockDelay	allowSoftblockDelay
-default	83	L12_lastDitchFlyer
-default	84	LX_bugbearInvasionFinale
-default	85	L13_towerNSContests
-default	86	L13_towerNSHedge
-default	87	L13_sorceressDoor
-default	88	L13_towerNSTower
-default	89	L13_towerNSNagamar
-default	90	L13_towerNSFinal
-default	91	LX_attemptPowerLevel
+# Kill the undead? Is this an oxymoron?
+default	45	L7_crypt
+# Cleanse the taint.
+default	46	L6_friarsGetParts
+# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
+default	47	L11_palindome
+default	48	L11_aridDesert
+default	49	L11_unlockPyramid
+default	50	L11_unlockEd
+default	51	L11_defeatEd
+#	Finish off the Goblin King.
+default	52	L5_slayTheGoblinKing
+# Show the Boss bat who's boss.
+default	53	L4_batCave
+# Fix that dripping tap.
+default	54	L3_tavern
+# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
+default	55	L2_mosquito
+# release the softblock on delay burning
+default	56	setSoftblockDelay	allowSoftblockDelay
+# release the softblock on Underground Adventures
+default	57	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
+default	58	L13_towerAscent
+# if all else fails, powerlevel like there's no tomorrow.
+default	59	LX_attemptPowerLevel
 

--- a/RELEASE/scripts/autoscend/auto_routing.ash
+++ b/RELEASE/scripts/autoscend/auto_routing.ash
@@ -224,7 +224,7 @@ boolean auto_reserveOutdoorAdventures()
 	return false;
 }
 
-boolean auto_useBreathitinCharges()
+boolean LX_useBreathitinCharges()
 {
 	if (get_property("breathitinCharges").to_int() > 0)
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1572,7 +1572,7 @@ boolean LX_goingUnderground();
 boolean allowSoftblockOutdoorAdvs();
 boolean setSoftblockOutdoorAdvs();
 boolean auto_reserveOutdoorAdventures();
-boolean auto_useBreathitinCharges();
+boolean LX_useBreathitinCharges();
 
 ########################################################################################################
 //Defined in autoscend/auto_settings.ash


### PR DESCRIPTION
# Description

Reported in Discord. Some people are being blocked with just the Pyramid to finish as I didn't add the softblock handling for underground adventures to the other task orders files. I was already working on this which fixes the issue.

## How Has This Been Tested?

validates. I'll jump into Normal Standard just to double check it all works fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
