### PR TITLE
KOE and auto_choice_adv Cleanup

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -414,7 +414,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(6); // skip
 			break;
 		case 888: // Take a Look, it's in a Book! (Rise) (The Haunted Library)
-			run_choice(4); // skip
+			run_choice(5); // skip
 			break;
 		case 889: // Take a Look, it's in a Book! (Fall) (The Haunted Library)
 			if(item_amount($item[dictionary]) == 0 && get_property("auto_getDictionary").to_boolean())
@@ -624,18 +624,18 @@ boolean auto_run_choice(int choice, string page)
 		case 1436: // Billiards Room Options (Cartography)
 			cartographyChoiceHandler(choice);
 			break;
-		case 1467:
-		case 1468:
-		case 1469:
-		case 1470:
-		case 1471:
-		case 1472:
-		case 1473:
-		case 1474:
-		case 1475:
+		case 1467: // Poetic Justice (Cleaver)
+		case 1468: // Aunts not Ants (Cleaver)
+		case 1469: // Beware of Aligator (Cleaver)
+		case 1470: // Teacher's Pet (Cleaver)
+		case 1471: // Lost and Found (Cleaver)
+		case 1472: // Summer Days (Cleaver)
+		case 1473: // Bath Time (Cleaver)
+		case 1474: // Delicious Sprouts (Cleaver)
+		case 1475: // Hypnotic Master (Cleaver)
 			juneCleaverChoiceHandler(choice);
 			break;
-		case 1491:  //Strange Stalagmite(s) (Strange stalagmite from Rock Garden)
+		case 1491: // Strange Stalagmite(s) (Rock Garden)
 			if(my_primestat() == $stat[Muscle])
 			{
 				run_choice(1); // muscle stats
@@ -649,23 +649,21 @@ boolean auto_run_choice(int choice, string page)
 				run_choice(3); // moxie stats
 			}
 			break;
-		case 1494:
+		case 1494: // Examine S.I.T. Course Certificate (S.I.T Course)
 			if(my_level() < 8)
 			{
-				run_choice(3); //Cryptobotanist (S.I.T. Course)
+				run_choice(3); // Cryptobotanist (S.I.T. Course)
 			}
 			else
 			{
-				run_choice(2); //Insectologist (S.I.T. Course)
+				run_choice(2); // Insectologist (S.I.T. Course)
 			}
 			break;
 		case 1497: // Calling Rufus
-			// get artifact quest
-			run_choice(2);
+			run_choice(2); // get artifact quest
 			break;
 		case 1500: // Like a Loded Stone
-			// Only come here to get shadow waters buff
-			run_choice(2);
+			run_choice(2); // only come here to get shadow waters buff
 			break;
 		default:
 			break;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2442,10 +2442,14 @@ boolean have_skills(boolean[skill] array)
 //From Bale\'s woods.ash relay script.
 boolean woods_questStart()
 {
-	if (internalQuestStatus("questL02Larva") < 0 && internalQuestStatus("questG02Whitecastle") < 0)
+	if(internalQuestStatus("questL02Larva") < 0 && internalQuestStatus("questG02Whitecastle") < 0)
 	{
 		// distant woods access is gated behind level 2 quest & whitey's grove quest.
 		// for some reason mafia doesn't track this any other way
+		return false;
+	}
+	if(in_koe()) // no access to woods or forest village in KoE
+	{
 		return false;
 	}
 	if(available_amount($item[Continuum Transfunctioner]) > 0)

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -263,7 +263,7 @@ boolean auto_juneCleaverAdventure()
 		{
 			cleaverLoc = $location[Cobb's Knob Treasury]); // arbitrarily picked always accessible location
 		}
-		autoAdv(cleaverLoc);
+		return autoAdv(cleaverLoc);
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -251,7 +251,7 @@ boolean auto_canUseJuneCleaver() {
 
 boolean auto_juneCleaverAdventure()
 {
-	if (!auto_canUseJuneCleaver() || get_property("_juneCleaverFightsLeft").to_int() > 0)
+	if (!auto_canUseJuneCleaver() || get_property("_juneCleaverFightsLeft").to_int() > 0 || !zone_isAvailable($location[The Dire Warren]))
 	{
 		return false;
 	}
@@ -672,7 +672,8 @@ boolean auto_autumnatonQuest()
 	if(auto_autumnatonCheckForUpgrade("leftarm1") &&
 	 auto_autumnatonCheckForUpgrade("rightarm1") &&
 	 item_amount($item[barrel of gunpowder]) < 5 && 
-	 get_property("sidequestLighthouseCompleted") == "none")
+	 get_property("sidequestLighthouseCompleted") == "none" &&
+	 !in_koe())
 	{
 		location targetLocation = $location[Sonofa Beach];
 		if(!auto_autumnatonCanAdv(targetLocation) && zone_available(targetLocation))

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -261,7 +261,7 @@ boolean auto_juneCleaverAdventure()
 		location cleaverLoc = $location[The Dire Warren];
 		if (in_koe())
 		{
-			cleaverLoc = $location[Cobb's Knob Treasury]); // arbitrarily picked always accessible location
+			cleaverLoc = $location[Cobb's Knob Treasury]; // arbitrarily picked always accessible location
 		}
 		return autoAdv(cleaverLoc);
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -258,14 +258,12 @@ boolean auto_juneCleaverAdventure()
 
 	if (autoEquip($slot[weapon], $item[June cleaver]))
 	{
+		location cleaverLoc = $location[The Dire Warren];
 		if (in_koe())
 		{
-			autoAdv($location[Cobb's Knob Treasury]); // arbitrarily picked always accessible location
+			cleaverLoc = $location[Cobb's Knob Treasury]); // arbitrarily picked always accessible location
 		}
-		else
-		{
-			autoAdv($location[The Dire Warren]);
-		}
+		autoAdv(cleaverLoc);
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -251,14 +251,21 @@ boolean auto_canUseJuneCleaver() {
 
 boolean auto_juneCleaverAdventure()
 {
-	if (!auto_canUseJuneCleaver() || get_property("_juneCleaverFightsLeft").to_int() > 0 || !zone_isAvailable($location[The Dire Warren]))
+	if (!auto_canUseJuneCleaver() || get_property("_juneCleaverFightsLeft").to_int() > 0)
 	{
 		return false;
 	}
 
 	if (autoEquip($slot[weapon], $item[June cleaver]))
 	{
-		return autoAdv($location[The Dire Warren]);
+		if (in_koe())
+		{
+			autoAdv($location[Cobb's Knob Treasury]); // arbitrarily picked always accessible location
+		}
+		else
+		{
+			autoAdv($location[The Dire Warren]);
+		}
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -341,7 +341,7 @@ boolean LX_islandAccess()
 
 boolean startHippyBoatmanSubQuest()
 {
-	if(my_basestat(my_primestat()) >= 25 && get_property("questM19Hippy") == "unstarted")
+	if(my_basestat(my_primestat()) >= 25 && get_property("questM19Hippy") == "unstarted" && !in_koe())
 	{
 		string temp = visit_url("place.php?whichplace=woods&action=woods_smokesignals");
 		temp = visit_url("choice.php?pwd=&whichchoice=798&option=1");


### PR DESCRIPTION
Make KoE Great Again

# Description

Recent IOTM and 8-Bit Realm changes were preventing autoscend from doing anything in KoE path.  This cleans those up (and now lets it run!), fixes a NC choice in Haunted Library, and adds some descriptors in auto_choice_adv for ease of review.

## How Has This Been Tested?

Two KoE runs, one softcore and one hardcore

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
