### PR TITLE
re-add Ed, bugbear & LKS functions to default task order

### DIFF
--- a/BUILD/task_order/default.dat
+++ b/BUILD/task_order/default.dat
@@ -11,6 +11,10 @@ L5_findKnob
 L12_sonofaPrefix
 LX_burnDelay
 LX_summonMonster
+# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
+LM_edTheUndying
+LX_bugbearInvasion
+LX_lowkeySummer
 # make sure we don't waste turns of Ultrahydrated doing something else.
 L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -390,83 +390,87 @@ default	9	L5_findKnob
 default	10	L12_sonofaPrefix
 default	11	LX_burnDelay
 default	12	LX_summonMonster
+# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
+default	13	LM_edTheUndying
+default	14	LX_bugbearInvasion
+default	15	LX_lowkeySummer
 # make sure we don't waste turns of Ultrahydrated doing something else.
-default	13	L11_aridDesert	L11_hasUltrahydrated
+default	16	L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-default	14	L11_shenStartQuest
+default	17	L11_shenStartQuest
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
-default	15	finishBuildingSmutOrcBridge
+default	18	finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.
-default	16	LX_goingUnderground
+default	19	LX_goingUnderground
 # Burn Breathitin charges
-default	17	LX_useBreathitinCharges
+default	20	LX_useBreathitinCharges
 # Guild access.
-default	18	LX_guildUnlock
+default	21	LX_guildUnlock
 #	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
-default	19	LX_unlockDesert
-default	20	LX_lockPicking
-default	21	LX_fatLootToken
+default	22	LX_unlockDesert
+default	23	LX_lockPicking
+default	24	LX_fatLootToken
 #	Get the Steel Organ if the user wants it (needs L6 quest complete)
-default	22	LX_steelOrgan
+default	25	LX_steelOrgan
 # open up delay zones.
-default	23	LX_spookyravenManorFirstFloor
+default	26	LX_spookyravenManorFirstFloor
 # open up zones where we want to force non-combats.
 # Open up underground zones so they are available for Breathitin.
-default	24	L5_getEncryptionKey
-default	25	L5_findKnob
+default	27	L5_getEncryptionKey
+default	28	L5_findKnob
 #	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-default	26	L12_islandWar
+default	29	L12_islandWar
 # Start the macguffin quest
-default	27	L11_blackMarket
-default	28	L11_forgedDocuments
-default	29	L11_mcmuffinDiary
-default	30	L11_getBeehive
+default	30	L11_blackMarket
+default	31	L11_forgedDocuments
+default	32	L11_mcmuffinDiary
+default	33	L11_getBeehive
 # open the hidden city up (delay zones)
-default	31	L2_mosquito
-default	32	LX_unlockHiddenTemple
-default	33	L6_dakotaFanning
-default	34	L11_unlockHiddenCity
+default	34	L2_mosquito
+default	35	LX_unlockHiddenTemple
+default	36	L6_dakotaFanning
+default	37	L11_unlockHiddenCity
 # Murder pygmies for the ancient amulet.
-default	35	L11_hiddenCityZones
-default	36	L11_hiddenCity
+default	38	L11_hiddenCityZones
+default	39	L11_hiddenCity
 # Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-default	37	LX_spookyravenManorSecondFloor
-default	38	L11_mauriceSpookyraven
+default	40	LX_spookyravenManorSecondFloor
+default	41	L11_mauriceSpookyraven
 # Lay the smack down on those Jerk Copperhead twins
-default	39	L11_talismanOfNam
+default	42	L11_talismanOfNam
 # Open up the top of the beanstalk.
-default	40	L10_plantThatBean
+default	43	L10_plantThatBean
 # Clean up the plains
-default	41	L10_rainOnThePlains
+default	44	L10_rainOnThePlains
 # Get Black Angus his pizza
-default	42	L9_chasmBuild
-default	43	L9_highLandlord
+default	45	L9_chasmBuild
+default	46	L9_highLandlord
 #  Kill Groar because *we* are the monsters.
-default	44	L8_trapperQuest
+default	47	L8_trapperQuest
 # Kill the undead? Is this an oxymoron?
-default	45	L7_crypt
+default	48	L7_crypt
 # Cleanse the taint.
-default	46	L6_friarsGetParts
+default	49	L6_friarsGetParts
 # Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-default	47	L11_palindome
-default	48	L11_aridDesert
-default	49	L11_unlockPyramid
-default	50	L11_unlockEd
-default	51	L11_defeatEd
+default	50	L11_palindome
+default	51	L11_aridDesert
+default	52	L11_unlockPyramid
+default	53	L11_unlockEd
+default	54	L11_defeatEd
 #	Finish off the Goblin King.
-default	52	L5_slayTheGoblinKing
+default	55	L5_slayTheGoblinKing
 # Show the Boss bat who's boss.
-default	53	L4_batCave
+default	56	L4_batCave
 # Fix that dripping tap.
-default	54	L3_tavern
+default	57	L3_tavern
 # Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-default	55	L2_mosquito
+default	58	L2_mosquito
 # release the softblock on delay burning
-default	56	setSoftblockDelay	allowSoftblockDelay
+default	59	setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
-default	57	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+default	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-default	58	L13_towerAscent
+default	61	L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.
-default	59	LX_attemptPowerLevel
+default	62	LX_attemptPowerLevel
 


### PR DESCRIPTION
# Description

When I updated the default task order in #1390 I "accidentally" removed LM_edTheUndying, LX_bugbearInvasion and LX_lowkeySummer from it. This restores them.

These should go in their own task order files since at least 2 of the 3 I wrote as custom routing for those paths before the task order functionality was created by Rinn but that's tech debt for a future contributor I guess.

## How Has This Been Tested?

validates. I'm not running all 3 of those paths to check it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
