### PR TITLE
Create sim function

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -26,6 +26,7 @@ import <autoscend/auto_providers.ash>
 import <autoscend/auto_restore.ash>
 import <autoscend/auto_routing.ash>
 import <autoscend/auto_settings.ash>
+import <autoscend/auto_sim.ash>
 import <autoscend/auto_util.ash>
 import <autoscend/auto_zlib.ash>
 import <autoscend/auto_zone.ash>
@@ -2046,9 +2047,18 @@ void safe_preference_reset_wrapper(int level)
 	}
 }
 
-void main()
+void main(string... input)
 {
 	backupSetting("printStackOnAbort", true);
+
+	// parse input
+    if(count(input) > 0 && input[0] == "sim")
+    {
+        // display useful items/skills/perms/etc and if the user has them
+        printSim();
+		return;
+    }
+
 	print_help_text();
 	sad_times();
 	if(!autoscend_migrate() && !user_confirm("autoscend might not have upgraded from a previous version correctly, do you want to continue? Will default to true in 10 seconds.", 10000, true)){

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2052,12 +2052,12 @@ void main(string... input)
 	backupSetting("printStackOnAbort", true);
 
 	// parse input
-    if(count(input) > 0 && input[0] == "sim")
-    {
-        // display useful items/skills/perms/etc and if the user has them
-        printSim();
+	if(count(input) > 0 && input[0] == "sim")
+	{
+		// display useful items/skills/perms/etc and if the user has them
+		printSim();
 		return;
-    }
+	}
 
 	print_help_text();
 	sad_times();

--- a/RELEASE/scripts/autoscend/auto_sim.ash
+++ b/RELEASE/scripts/autoscend/auto_sim.ash
@@ -1,0 +1,116 @@
+
+void printSim()
+{
+	printSimRequired();
+	printSimSuggested();
+	printSimMarginal();
+	print();
+	print("Note: Recommended to run in aftercore to properly detetct everything");
+}
+
+void PrintSimRequired()
+{
+	print("Required Things:");
+	skill sk = $skill[Saucestorm];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "Critical for autoscend combat");
+	sk = $skill[Itchy Curse Finger];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "Critical for autoscend combat");
+	sk = $skill[Curse of Weaksauce];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "Critical for autoscend combat");
+	sk = $skill[Tongue of the Walrus];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "Healing skill which cures beaten up");
+	sk = $skill[Cannelloni Cocoon];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "Heals up to 1000 HP for 20 MP. Very cost effective");
+}
+
+void printSimSuggested()
+{
+	print();
+	print("Suggested Things:");
+
+	skill sk = $skill[Transcendent Olfaction];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "Significantly increases chance of encountering a monster");
+	sk = $skill[Stuffed Mortar Shell];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "MP efficient and high damage");
+	sk = $skill[Saucegeyser];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "High damage spell. Helpful for bosses");
+	sk = $skill[Lock Picking];
+	formattedSimPrint(have_skill(sk), sk.to_string(), "Out of standard easy key source");
+
+	familiar fam = $familiar[Nosy Nose];
+	formattedSimPrint(have_familiar(fam), fam.to_string(), "Familiar with olfaction-lite ability");
+	fam = $familiar[Gelatinous Cubeling];
+	formattedSimPrint(have_familiar(fam), fam.to_string(), "Familiar which speeds up the daily dungeon");
+
+	boolean maxedPoolSkill = get_property("poolSharkCount").to_int() >= 25;
+	formattedSimPrint(maxedPoolSkill, "Pool Shark", "Lucky! adv which permanently increases your pool skill. It is possible for Mafia to not realize you have maxed this. If you are confident you have, enter the following in the CLI: `set poolSharkCount=25`");
+
+	// if we have combat locket, check if we have used monsters in there
+	if(auto_haveCombatLoversLocket())
+	{
+		monster mon = $monster[Fantasy Bandit];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Fighting 5x in a day will get you a fat loot token");
+		mon = $monster[screambat];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Lets you break a wall in the Bat Hole");
+		mon = $monster[ninja snowman assassin];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Fighting 3x is optimal for L8 quest");
+		mon = $monster[lobsterfrogman];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Need 5x for war sidequest");
+		mon = $monster[Astronomer];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Helpful for star key");
+		mon = $monster[War Frat Mobile Grill Unit];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Frat warrior war start outfit");
+		mon = $monster[War Hippy Airborne Commander];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "War hippy war start outfit");
+		mon = $monster[Baa\'baa\'bu\'ran];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "3x Stone Wool for L12 quest");
+	}
+
+	// if we have cookbookbat, make sure we have all its recipes
+	if(have_familiar($familiar[Cookbookbat]))
+	{
+		boolean[string] recipes = $strings[Boris's beer, honey bun of Boris, ratatouille de Jarlsberg, Jarlsberg's vegetable soup, Pete's wiley whey bar,
+				St. Pete's sneaky smoothie, Boris's bread, roasted vegetable of Jarlsberg, Pete's rich ricotta, roasted vegetable focaccia, 
+				plain calzone, baked veggie ricotta casserole];
+		foreach recipe in recipes
+		{
+			boolean haveRecipe = !get_property(`unknownRecipe${recipe.to_item().to_int()}`).to_boolean();
+			formattedSimPrint(haveRecipe, `Recipe: {recipe}`, "Cookbookbat recipes need to be learned, even if you have the familiar");
+		}
+	}
+
+}
+
+void printSimMarginal()
+{
+	print();
+	print("Marginal Things:");
+
+	familiar fam = $familiar[Oily Woim];
+	formattedSimPrint(have_familiar(fam), fam.to_string(), "Familiar which provides init");
+	fam = $familiar[Exotic Parrot];
+	formattedSimPrint(have_familiar(fam), fam.to_string(), "Familiar which provides elemental resistance");
+	fam = $familiar[Hobo Monkey];
+	formattedSimPrint(have_familiar(fam), fam.to_string(), "Familiar that's a 1.25x leprechaun");
+
+	item it = $item[Etched Hourglass];
+	formattedSimPrint(item_amount(it) > 0, `Potential Pull: {it.to_string()}`, "Extra RO adventures");
+	it = $item[Potato Alarm Clock];
+	formattedSimPrint(item_amount(it) > 0, `Potential Pull: {it.to_string()}`, "Extra RO adventures");
+	it = $item[Mafia Thumb Ring];
+	formattedSimPrint(possessEquipment(it), `Potential Pull: {it.to_string()}`, "Accessory which generates an adv 4% of combats");
+	it = $item[Numberwang];
+	formattedSimPrint(possessEquipment(it), `Potential Pull: {it.to_string()}`, "Good all around accessory");
+	it = $item[Deck of Lewd Playing Cards];
+	formattedSimPrint(possessEquipment(it), `Potential Pull: {it.to_string()}`, "Sleaze dmg helps Belch House, Zeppelin Mob, and sometimes tower test");
+	it = $item[Infinite BACON Machine];
+	formattedSimPrint(item_amount(it) > 0, `Potential Pull: {it.to_string()}`, "Might make milk for big stats. Poor, for modern standards, yellow ray source");
+	it = $item[Mime Army Shotglass];
+	formattedSimPrint(item_amount(it) > 0, `Potential Pull: {it.to_string()}`, "Only pulled for Dark Gyffte as every organ space is really good");
+}
+
+void formattedSimPrint(boolean have, string name, string description)
+{
+	string symbol = have ? "✓" : "X";
+	print(`{symbol} {name} - {description}`, have ? "blue" : "red");
+}

--- a/RELEASE/scripts/autoscend/auto_sim.ash
+++ b/RELEASE/scripts/autoscend/auto_sim.ash
@@ -11,6 +11,7 @@ void printSim()
 void PrintSimRequired()
 {
 	print("Required Things:");
+	
 	skill sk = $skill[Saucestorm];
 	formattedSimPrint(have_skill(sk), sk.to_string(), "Critical for autoscend combat");
 	sk = $skill[Itchy Curse Finger];

--- a/RELEASE/scripts/autoscend/auto_sim.ash
+++ b/RELEASE/scripts/autoscend/auto_sim.ash
@@ -5,7 +5,7 @@ void printSim()
 	printSimSuggested();
 	printSimMarginal();
 	print();
-	print("Note: Recommended to run in aftercore to properly detetct everything");
+	print("Note: Recommended to run in aftercore to properly detect everything");
 }
 
 void PrintSimRequired()

--- a/RELEASE/scripts/autoscend/auto_sim.ash
+++ b/RELEASE/scripts/autoscend/auto_sim.ash
@@ -58,12 +58,18 @@ void printSimSuggested()
 		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Need 5x for war sidequest");
 		mon = $monster[Astronomer];
 		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Helpful for star key");
+		mon = $monster[Skinflute];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Helpful for star key");
+		mon = $monster[Camel\'s Toe];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Helpful for star key");
 		mon = $monster[War Frat Mobile Grill Unit];
 		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Frat warrior war start outfit");
 		mon = $monster[War Hippy Airborne Commander];
 		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "War hippy war start outfit");
 		mon = $monster[Baa\'baa\'bu\'ran];
 		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "3x Stone Wool for L12 quest");
+		mon = $monster[Green Ops Soldier];
+		formattedSimPrint(auto_monsterInLocket(mon), `Locket Monster: {mon.to_string()}`, "Get war progress even when copied into other zones, plus smoke bombs");
 	}
 
 	// if we have cookbookbat, make sure we have all its recipes

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1588,6 +1588,14 @@ void auto_settingsDefaults();
 void auto_settings();
 
 ########################################################################################################
+//Defined in autoscend/auto_sim.ash
+void printSim();
+void PrintSimRequired();
+void printSimSuggested();
+void printSimMarginal();
+void formattedSimPrint(boolean have, string name, string description);
+
+########################################################################################################
 //Defined in autoscend/auto_zlib.ash
 void auto_process_kmail(string functionname);
 


### PR DESCRIPTION
# Description

Let autoscend accept an optional `sim` parameter to print if you have required, suggested, and marginal things

Things and descriptions taken from prior similar effort, which was a separate script. This PR incorporates it as part of autoscend.
https://github.com/JamesDowney/kol-json-suggestions

Formatting of display generally taken from Kas's scripts

Bat recipes and combat locket monsters are only shown if you own the respective iotm

## How Has This Been Tested?

Tested on my main which has everyone. And on my testing alt which doesn't have much

Main:
![image](https://github.com/loathers/autoscend/assets/4781473/60003159-eb6a-4cfd-aed4-2285b599fd93)

Alt:
![image](https://github.com/loathers/autoscend/assets/4781473/e936e72e-f846-4614-8279-179b08441de0)


## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
