### PR TITLE
Blacklist Oliver's Place from Back-ups

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -325,6 +325,12 @@ boolean auto_backupTarget()
 		return false;
 	}
 
+	// don't backup into oliver's (it won't be free and will waste a free fight and currently also mess up tracking)
+	if (get_property("nextAdventure").to_location() == $location[An Unusually Quiet Barroom Brawl])
+	{
+		return false;
+	}
+
 	// determine if we want to backup
 	boolean wantBackupLFM = item_amount($item[barrel of gunpowder]) < 5 && get_property("sidequestLighthouseCompleted") == "none" && internalQuestStatus("questL12War") == 1 && !auto_hasAutumnaton() && !in_koe();
 	boolean wantBackupNSA = (item_amount($item[ninja rope]) < 1 || item_amount($item[ninja carabiner]) < 1 || item_amount($item[ninja crampons]) < 1) && internalQuestStatus("questL08Trapper") < 3 && !get_property("auto_L8_extremeInstead").to_boolean();


### PR DESCRIPTION
# Description

When an enemy is encountered at Oliver's, they are given a flag at the start of combat that makes them free. Backing Up (or other switchmonster effects) over them causes the flag to be destroyed and makes the combat no longer free (effectively wasting a free fight) and additionally currently causes mafia to mistakenly not track the fight as a speakeasy free fight (maybe it would if the backed up monster was inherently free but there's no reason to back up such a monster into Oliver's to begin with). This causes further issues since the _speakeasyFreeFights counter will never reach 3 and Oliver's will always look like it has free fights available when they've become turntaking fights instead.

## How Has This Been Tested?

It hasn't! I've only encountered this issue once (prompting the PR) in the  so it isn't a frequent issue. Since the issue is so rare I'm not sure if there's an easy way to go about testing it. 

It's possible I don't understand the backup logic or the combat logic or how nextAdventure actually works but it seems to me like this should stop autoscend from backing up into Oliver's fights.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
