### PR TITLE
Vampyres can't eat guilty sprouts

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -333,7 +333,8 @@ void juneCleaverChoiceHandler(int choice)
 			break;			
 		case 1474: // Delicious Sprouts
 			if (can_eat() && my_level() < 13 && 
-			have_fireworks_shop() && auto_is_valid($item[red rocket]) && !in_darkGyffe() &&
+			have_fireworks_shop() && auto_is_valid($item[red rocket]) && 
+			!in_darkGyffe() && !is_jarlsberg() &&
 			auto_is_valid($item[guilty sprout]) && item_amount($item[guilty sprout]) == 0)
 				run_choice(2); // guilty sprout is level 8+ good size 1 food but it gives big stats, would want to use a red rocket
 			if (my_primestat() == $stat[mysticality] && (my_level() < 13 || disregardInstantKarma())) {

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -334,7 +334,7 @@ void juneCleaverChoiceHandler(int choice)
 		case 1474: // Delicious Sprouts
 			if (can_eat() && my_level() < 13 && 
 			have_fireworks_shop() && auto_is_valid($item[red rocket]) && 
-			!in_darkGyffe() && !is_jarlsberg() &&
+			!in_darkGyffte() && !is_jarlsberg() &&
 			auto_is_valid($item[guilty sprout]) && item_amount($item[guilty sprout]) == 0)
 				run_choice(2); // guilty sprout is level 8+ good size 1 food but it gives big stats, would want to use a red rocket
 			if (my_primestat() == $stat[mysticality] && (my_level() < 13 || disregardInstantKarma())) {

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -334,7 +334,7 @@ void juneCleaverChoiceHandler(int choice)
 		case 1474: // Delicious Sprouts
 			if (can_eat() && my_level() < 13 && 
 			have_fireworks_shop() && auto_is_valid($item[red rocket]) && 
-			!in_darkGyffte() && !is_jarlsberg() &&
+			!in_darkGyffte() && !is_jarlsberg() && !in_tcrs() //paths that can eat but can't eat guilty sprouts/won't get the stats from it anyway
 			auto_is_valid($item[guilty sprout]) && item_amount($item[guilty sprout]) == 0)
 				run_choice(2); // guilty sprout is level 8+ good size 1 food but it gives big stats, would want to use a red rocket
 			if (my_primestat() == $stat[mysticality] && (my_level() < 13 || disregardInstantKarma())) {

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -333,7 +333,7 @@ void juneCleaverChoiceHandler(int choice)
 			break;			
 		case 1474: // Delicious Sprouts
 			if (can_eat() && my_level() < 13 && 
-			have_fireworks_shop() && auto_is_valid($item[red rocket]) &&
+			have_fireworks_shop() && auto_is_valid($item[red rocket]) && !in_darkGyffe() &&
 			auto_is_valid($item[guilty sprout]) && item_amount($item[guilty sprout]) == 0)
 				run_choice(2); // guilty sprout is level 8+ good size 1 food but it gives big stats, would want to use a red rocket
 			if (my_primestat() == $stat[mysticality] && (my_level() < 13 || disregardInstantKarma())) {

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -334,7 +334,7 @@ void juneCleaverChoiceHandler(int choice)
 		case 1474: // Delicious Sprouts
 			if (can_eat() && my_level() < 13 && 
 			have_fireworks_shop() && auto_is_valid($item[red rocket]) && 
-			!in_darkGyffte() && !is_jarlsberg() && !in_tcrs() //paths that can eat but can't eat guilty sprouts/won't get the stats from it anyway
+			!in_darkGyffte() && !is_jarlsberg() && !in_tcrs() && //paths that can eat but can't eat guilty sprouts/won't get the stats from it anyway
 			auto_is_valid($item[guilty sprout]) && item_amount($item[guilty sprout]) == 0)
 				run_choice(2); // guilty sprout is level 8+ good size 1 food but it gives big stats, would want to use a red rocket
 			if (my_primestat() == $stat[mysticality] && (my_level() < 13 || disregardInstantKarma())) {


### PR DESCRIPTION
You can't eat guilty sprouts in Dark Gyffe or Avatar of Jarlsberg, so autoscend should avoid getting them in those paths.

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
