### PR TITLE
ELG added for standard free runs

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27722;	// feat: preferences candy cane options  
+since r27772;	// feat: everything looks green color + noremove 
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -876,7 +876,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	}
 
 	//Standard free-runs
-	if (!inAftercore() && have_effect($effect[Everything Looks Green]) = 0)
+	if (!inAftercore() && have_effect($effect[Everything Looks Green]) == 0)
 	{
 		foreach it in $items[green smoke bomb, tattered scrap of paper, GOTO]
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -882,7 +882,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{
-				return useItems(it);
+				return useItem(it);
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -765,13 +765,13 @@ string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inComba
 		// todo: other ghosts
 		if(isGhost(enemy) && canUse($item[T.U.R.D.S. Key]) && item_amount($item[T.U.R.D.S. Key]) > 0)
 		{
-			return useItem($item[T.U.R.D.S. Key]);
+			return useItems($item[T.U.R.D.S. Key], $item[none]);
 		}
 		//free runaway against pygmies. accelerates hidden city quest
 		if(canUse($item[short writ of habeas corpus]) && item_amount($item[short writ of habeas corpus]) > 0
 			&& $monsters[Pygmy Orderlies, Pygmy Witch Lawyer, Pygmy Witch Nurse] contains enemy)
 		{
-			return useItem($item[Short Writ Of Habeas Corpus]);
+			return useItems($item[Short Writ Of Habeas Corpus], $item[none]);
 		}
 	}
 
@@ -870,7 +870,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{
-				return useItem(it);
+				return useItems(it, $item[none]);
 			}
 		}
 	}
@@ -882,7 +882,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{
-				return useItem(it);
+				return useItems(it, $item[none]);
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -760,12 +760,12 @@ string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inComba
 	if (isFreeMonster(enemy, loc)) return "";
 
 	// Prefer some specalized free run items before other sources
-	if (!inAftercore())
+	if (!inAftercore() && !(have_effect($effect[Everything Looks Green]) > 0))
 	{
 		// todo: other ghosts
 		if(isGhost(enemy) && canUse($item[T.U.R.D.S. Key]) && item_amount($item[T.U.R.D.S. Key]) > 0)
 		{
-			return "item " + $item[T.U.R.D.S. Key];
+			return "item " + $item[	.R.D.S. Key];
 		}
 		//free runaway against pygmies. accelerates hidden city quest
 		if(canUse($item[short writ of habeas corpus]) && item_amount($item[short writ of habeas corpus]) > 0
@@ -863,9 +863,22 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Peel Out];
 	}
 
-	if (!inAftercore())
+	//Non-standard free-runs
+	if(!inAftercore())
 	{
-		foreach it in $items[giant eraser, green smoke bomb, tattered scrap of paper, GOTO]
+		foreach it in $items[giant eraser] //assuming additional ones will be added, eventually
+		{
+			if (canUse(it) && item_amount(it) > 0)
+			{
+				return "item " + it;
+			}
+		}
+	}
+
+	//Standard free-runs
+	if (!inAftercore() && !(have_effect($effect[Everything Looks Green]) > 0))
+	{
+		foreach it in $items[green smoke bomb, tattered scrap of paper, GOTO]
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -765,7 +765,7 @@ string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inComba
 		// todo: other ghosts
 		if(isGhost(enemy) && canUse($item[T.U.R.D.S. Key]) && item_amount($item[T.U.R.D.S. Key]) > 0)
 		{
-			return "item " + $item[	.R.D.S. Key];
+			return "item " + $item[T.U.R.D.S. Key];
 		}
 		//free runaway against pygmies. accelerates hidden city quest
 		if(canUse($item[short writ of habeas corpus]) && item_amount($item[short writ of habeas corpus]) > 0

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -760,7 +760,7 @@ string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inComba
 	if (isFreeMonster(enemy, loc)) return "";
 
 	// Prefer some specalized free run items before other sources
-	if (!inAftercore() && !(have_effect($effect[Everything Looks Green]) > 0))
+	if (!inAftercore() && have_effect($effect[Everything Looks Green]) == 0)
 	{
 		// todo: other ghosts
 		if(isGhost(enemy) && canUse($item[T.U.R.D.S. Key]) && item_amount($item[T.U.R.D.S. Key]) > 0)
@@ -876,7 +876,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	}
 
 	//Standard free-runs
-	if (!inAftercore() && !(have_effect($effect[Everything Looks Green]) > 0))
+	if (!inAftercore() && have_effect($effect[Everything Looks Green]) = 0)
 	{
 		foreach it in $items[green smoke bomb, tattered scrap of paper, GOTO]
 		{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -765,13 +765,13 @@ string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inComba
 		// todo: other ghosts
 		if(isGhost(enemy) && canUse($item[T.U.R.D.S. Key]) && item_amount($item[T.U.R.D.S. Key]) > 0)
 		{
-			return "item " + $item[T.U.R.D.S. Key];
+			return useItem($item[T.U.R.D.S. Key]);
 		}
 		//free runaway against pygmies. accelerates hidden city quest
 		if(canUse($item[short writ of habeas corpus]) && item_amount($item[short writ of habeas corpus]) > 0
 			&& $monsters[Pygmy Orderlies, Pygmy Witch Lawyer, Pygmy Witch Nurse] contains enemy)
 		{
-			return "item " + $item[Short Writ Of Habeas Corpus];
+			return useItem($item[Short Writ Of Habeas Corpus]);
 		}
 	}
 
@@ -870,7 +870,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{
-				return "item " + it;
+				return useItem(it);
 			}
 		}
 	}
@@ -882,7 +882,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{
-				return "item " + it;
+				return useItem(it);
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -765,13 +765,13 @@ string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inComba
 		// todo: other ghosts
 		if(isGhost(enemy) && canUse($item[T.U.R.D.S. Key]) && item_amount($item[T.U.R.D.S. Key]) > 0)
 		{
-			return useItems($item[T.U.R.D.S. Key], $item[none]);
+			return useItem($item[T.U.R.D.S. Key]);
 		}
 		//free runaway against pygmies. accelerates hidden city quest
 		if(canUse($item[short writ of habeas corpus]) && item_amount($item[short writ of habeas corpus]) > 0
 			&& $monsters[Pygmy Orderlies, Pygmy Witch Lawyer, Pygmy Witch Nurse] contains enemy)
 		{
-			return useItems($item[Short Writ Of Habeas Corpus], $item[none]);
+			return useItem($item[Short Writ Of Habeas Corpus]);
 		}
 	}
 
@@ -870,7 +870,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{
-				return useItems(it, $item[none]);
+				return useItem(it);
 			}
 		}
 	}
@@ -882,7 +882,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{
-				return useItems(it, $item[none]);
+				return useItems(it);
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -185,7 +185,8 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(freeRunAction, "item") == 0)
 			{
-				handleTracker(enemy, to_item(substring(freeRunAction, 5)), "auto_freeruns");
+				int commapos = index_of(combatAction, ", none");
+				handleTracker(enemy, to_item(substring(freeRunAction, 5, commapos)), "auto_freeruns");
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -185,7 +185,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(freeRunAction, "item") == 0)
 			{
-				int commapos = index_of(combatAction, ", none");
+				int commapos = index_of(freeRunAction, ", none");
 				handleTracker(enemy, to_item(substring(freeRunAction, 5, commapos)), "auto_freeruns");
 			}
 			else

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -584,7 +584,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if (canUse($item[Tattered Scrap of Paper], false) && have_effect($effect[Everything Looks Green]) > 0)
+	if (canUse($item[Tattered Scrap of Paper], false) && have_effect($effect[Everything Looks Green]) == 0)
 	{
 		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
 		{
@@ -678,7 +678,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		// insta-kills protestors and removes an additional 5-7 (optimal!)
 	}
 
-	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus], false) && have_effect($effect[Everything Looks Green]) > 0)
+	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus], false) && have_effect($effect[Everything Looks Green]) == 0)
 	{
 		return useItem($item[Short Writ of Habeas Corpus]);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -584,7 +584,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if (canUse($item[Tattered Scrap of Paper], false))
+	if (canUse($item[Tattered Scrap of Paper], false) && !(have_effect($effect[Everything Looks Green]) > 0))
 	{
 		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
 		{
@@ -678,7 +678,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		// insta-kills protestors and removes an additional 5-7 (optimal!)
 	}
 
-	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus], false))
+	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus], false) && !(have_effect($effect[Everything Looks Green]) > 0))
 	{
 		return useItem($item[Short Writ of Habeas Corpus]);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -584,7 +584,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if (canUse($item[Tattered Scrap of Paper], false) && !(have_effect($effect[Everything Looks Green]) > 0))
+	if (canUse($item[Tattered Scrap of Paper], false) && have_effect($effect[Everything Looks Green]) > 0)
 	{
 		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
 		{
@@ -678,7 +678,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		// insta-kills protestors and removes an additional 5-7 (optimal!)
 	}
 
-	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus], false) && !(have_effect($effect[Everything Looks Green]) > 0))
+	if(enemy == $monster[Pygmy Orderlies] && canUse($item[Short Writ of Habeas Corpus], false) && have_effect($effect[Everything Looks Green]) > 0)
 	{
 		return useItem($item[Short Writ of Habeas Corpus]);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -588,7 +588,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 	{
 		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
 		{
-			return useItem($item[Tattered Scrap Of Paper], false);
+			return useItem($item[Tattered Scrap Of Paper]);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -267,7 +267,7 @@ skill getSniffer(monster enemy, boolean inCombat)
 	{
 		return $skill[Perceive Soul];
 	}
-	if(canUse($skill[Motif], true , inCombat) && !isSniffed(enemy, $skill[Motif]) && !(have_effect($effect[Everything Looks Blue]) > 0))
+	if(canUse($skill[Motif], true , inCombat) && !isSniffed(enemy, $skill[Motif]) && (have_effect($effect[Everything Looks Blue]) == 0))
 	{
 		return $skill[Motif];
 	}


### PR DESCRIPTION
# Description

Quick fix adding Everything Looks Green to any instance of standard free runs

## How Has This Been Tested?

Running it on D2 and D1 of standard HC runs. Only had one instance of ELG over both of those so will force it to have it on a normal run, but there's no real reason why it shouldn't work fine.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
