### PR TITLE
Abort earlier if run in Community Service

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1670,11 +1670,6 @@ boolean doTasks()
 {
 	//this is the main loop for autoscend. returning true will restart from the begining. returning false will quit the loop and go on to do bedtime
 
-	if(in_community())
-	{
-		abort("Community Service is no longer supported.");
-	}
-
 	auto_settingsFix();		//check and correct invalid configuration inputs made by users
 	if(!auto_unreservedAdvRemaining())
 	{
@@ -1907,6 +1902,11 @@ void auto_begin()
 		{
 			auto_log_warning("Okay, but the warranty is off.", "red");
 		}
+	}
+
+	if(in_community())
+	{
+		abort("Community Service is no longer supported.");
 	}
 
 	LX_handleIntroAdventures(); // handle early non-combats in challenge paths.


### PR DESCRIPTION
# Description

Autoscend doesn't support Community Service, but the check for whether a player is in a Community Service run happens a lot later than desirable if you happen to be tired and ascend into the wrong path or run the wrong ascension script without realizing until it's too late to reverse the damage.

## How Has This Been Tested?

I ran autoscend in CS and it aborted before doing things it probably shouldn't do if it is just about to abort.

It's the same exact check as before, just moved closer to startup so that if someone runs autoscend in CS they don't get clubbed for it.

## Checklist:

- [x ] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
