### PR TITLE
feat: replace CheeseFax with OnlyFax for Zatara consults

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1719,7 +1719,7 @@ boolean auto_deleteMail(kmailObject msg)
 			return true;
 		}
 	}
-	if((msg.fromid == 3038166) && (contains_text(msg.message, "completed your relationship fortune test")) && get_property("auto_hideAdultery").to_boolean())
+	if((msg.fromid == 3690803) && (contains_text(msg.message, "completed your relationship fortune test")) && get_property("auto_hideAdultery").to_boolean())
 	{
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -428,7 +428,7 @@ boolean zataraClanmate()
 #	set_property("_clanFortuneConsultUses", get_property("_clanFortuneConsultUses").to_int() + 1);
 
 	int attempts = 0;
-	int player = 3038166;
+	int player = 3690803;
 	string consultOverrideName = get_property("auto_consultChoice");
 	string name = get_player_name(player);
 	if (consultOverrideName != "")


### PR DESCRIPTION
# Description

A follow-up to #1380. Use OnlyFax instead of CheeseFax. The cycle continues!

## How Has This Been Tested?

I haven't, but the numbers look right.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
