### PR TITLE
fix: Asdon Martin keyfob name change

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2210,7 +2210,7 @@ boolean uneffect(effect toRemove)
 	{
 		return true;
 	}
-	if(($effects[Driving Intimidatingly, Driving Obnoxiously, Driving Observantly, Driving Quickly, Driving Recklessly, Driving Safely, Driving Stealthily, Driving Wastefully, Driving Waterproofly] contains toRemove) && (auto_get_campground() contains $item[Asdon Martin Keyfob]))
+	if(($effects[Driving Intimidatingly, Driving Obnoxiously, Driving Observantly, Driving Quickly, Driving Recklessly, Driving Safely, Driving Stealthily, Driving Wastefully, Driving Waterproofly] contains toRemove) && (auto_get_campground() contains $item[Asdon Martin keyfob (on ring)]))
 	{
 		visit_url("campground.php?pwd=&preaction=undrive");
 		return true;

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -1230,11 +1230,11 @@ boolean asdonBuff(string goal)
 
 boolean canAsdonBuff(effect goal)
 {
-	if(!(auto_get_campground() contains $item[Asdon Martin Keyfob]))
+	if(!(auto_get_campground() contains $item[Asdon Martin keyfob (on ring)]))
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Asdon Martin Keyfob]))
+	if(!is_unrestricted($item[Asdon Martin keyfob (on ring)]))
 	{
 		return false;
 	}
@@ -1307,11 +1307,11 @@ boolean asdonAutoFeed(int goal)
 	{
 		return false;
 	}
-	if(!(auto_get_campground() contains $item[Asdon Martin Keyfob]))
+	if(!(auto_get_campground() contains $item[Asdon Martin keyfob (on ring)]))
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Asdon Martin Keyfob]))
+	if(!is_unrestricted($item[Asdon Martin keyfob (on ring)]))
 	{
 		return false;
 	}
@@ -1450,11 +1450,11 @@ boolean asdonAutoFeed(int goal)
 
 boolean asdonFeed(item it, int qty)
 {
-	if(!(auto_get_campground() contains $item[Asdon Martin Keyfob]))
+	if(!(auto_get_campground() contains $item[Asdon Martin keyfob (on ring)]))
 	{
 		return false;
 	}
-	if(!is_unrestricted($item[Asdon Martin Keyfob]))
+	if(!is_unrestricted($item[Asdon Martin keyfob (on ring)]))
 	{
 		return false;
 	}
@@ -1478,7 +1478,7 @@ boolean asdonFeed(item it)
 
 boolean asdonCanMissile()
 {
-	return (auto_get_campground() contains $item[Asdon Martin Keyfob]) && (get_fuel() >= fuel_cost($skill[Asdon Martin: Missile Launcher])) && !get_property("_missileLauncherUsed").to_boolean();
+	return (auto_get_campground() contains $item[Asdon Martin keyfob (on ring)]) && (get_fuel() >= fuel_cost($skill[Asdon Martin: Missile Launcher])) && !get_property("_missileLauncherUsed").to_boolean();
 }
 
 boolean isHorseryAvailable() {

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -605,7 +605,7 @@ boolean auto_spoonReadyToTuneMoon()
 			// we want to get the meatcar via the knoll store
 			return false;
 		}
-		if((auto_get_campground() contains $item[Asdon Martin Keyfob]) && is_unrestricted($item[Asdon Martin Keyfob]) ||
+		if((auto_get_campground() contains $item[Asdon Martin keyfob (on ring)]) && is_unrestricted($item[Asdon Martin keyfob (on ring)]) ||
 		   (auto_is_valid($familiar[cookbookbat]) && have_familiar($familiar[cookbookbat])))
 		{
 			// we want to get the bugbear outfit before switching away for easy bread access

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -814,7 +814,7 @@ item LX_getDesiredWorkshed(){
 			return $item[cold medicine cabinet];
 		case "asdon martin keyfob":
 		case "asdon":
-			return $item[Asdon Martin keyfob];
+			return $item[Asdon Martin keyfob (on ring)];
 		case "diabolic pizza cube":
 		case "pizza":
 			return $item[diabolic pizza cube]; //unless support is added, don't want to use this
@@ -879,9 +879,9 @@ boolean LX_setWorkshed(){
 				auto_log_info("Installed your model train set");
 				return true;
 			}
-			if ((auto_is_valid($item[Asdon Martin keyfob])) && (item_amount($item[Asdon Martin keyfob]) > 0))
+			if ((auto_is_valid($item[Asdon Martin keyfob (on ring)])) && (item_amount($item[Asdon Martin keyfob (on ring)]) > 0))
 			{
-				use(1, $item[Asdon Martin keyfob]);
+				use(1, $item[Asdon Martin keyfob (on ring)]);
 				auto_log_info("Installed your Asdon Martin keyfob");
 				return true;
 			}
@@ -909,9 +909,9 @@ boolean LX_setWorkshed(){
 		//once we have enough fasteners and only if we are currently using the model train set
 		if((fastenerCount() >= 30 && lumberCount() >= 30) && existingShed == $item[model train set])
 		{
-			if ((auto_is_valid($item[Asdon Martin keyfob])) && (item_amount($item[Asdon Martin keyfob]) > 0))
+			if ((auto_is_valid($item[Asdon Martin keyfob (on ring)])) && (item_amount($item[Asdon Martin keyfob (on ring)]) > 0))
 			{
-				use(1, $item[Asdon Martin keyfob]);
+				use(1, $item[Asdon Martin keyfob (on ring)]);
 				auto_log_info("Changed your workshed to Asdon Martin keyfob");
 				return true;
 			}


### PR DESCRIPTION
# Description

Avoid a warning due to the mismatched name after the change. Requires at least r27735 but the script already requires r27772.

## How Has This Been Tested?

Did a run (in Standard, but Mafia parsed the items okay).

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
