### PR TITLE
fix: can only Monkey Slap if no wishes have been used

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -185,8 +185,15 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(freeRunAction, "item") == 0)
 			{
-				int commapos = index_of(freeRunAction, ", none");
-				handleTracker(enemy, to_item(substring(freeRunAction, 5, commapos)), "auto_freeruns");
+				if(contains_text(freeRunAction, ", none"))
+				{
+					int commapos = index_of(freeRunAction, ", none");
+					handleTracker(enemy, to_item(substring(freeRunAction, 5, commapos)), "auto_freeruns");
+				}
+				else
+				{
+					handleTracker(enemy, to_item(substring(freeRunAction, 5)), "auto_freeruns");
+				}
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -151,7 +151,15 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			}
 			else if(index_of(banishAction, "item") == 0)
 			{
-				handleTracker(enemy, to_item(substring(banishAction, 5)), "auto_banishes");
+				if(contains_text(banishAction, ", none"))
+				{
+					int commapos = index_of(banishAction, ", none");
+					handleTracker(enemy, to_item(substring(banishAction, 5, commapos)), "auto_banishes");
+				}
+				else
+				{
+					handleTracker(enemy, to_item(substring(banishAction, 5)), "auto_banishes");
+				}
 			}
 			else
 			{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -173,7 +173,7 @@ string useItem(item it, boolean mark)
 	if(mark)
 		markAsUsed(it);
 	if(auto_have_skill($skill[Ambidextrous Funkslinging]))
-		return "item " + it + ", nothing";	//don't double use
+		return "item " + it + ", none";	//don't double use
 	return "item " + it;
 }
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -665,7 +665,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Snokebomb];
 	}
 
-	if((inCombat ? auto_have_skill($skill[Monkey Slap]) : possessEquipment($item[cursed monkey\'s paw])) && auto_is_valid($skill[Monkey Slap]) && !(used contains "Monkey Slap"))
+	if((inCombat ? auto_have_skill($skill[Monkey Slap]) : possessEquipment($item[cursed monkey\'s paw])) && auto_is_valid($skill[Monkey Slap]) && get_property("_monkeyPawWishesUsed").to_int() == 0 && !(used contains "Monkey Slap"))
 	{
 		return "skill " + $skill[Monkey Slap];
 	}


### PR DESCRIPTION
# Description
Only try to Monkey Slap if no wishes have been used today.

Also contains a couple of other fixes around banishes / runaways:
* `auto_combat_util.ash` was slinging GSBs with `, nothing` but `auto_combat_default_stage2.ash` was matching on `, none`
* The latter file was also always matching on `, none`, but the player might not have Ambidextrous Funkslinging.

## How Has This Been Tested?
Did a run, all went smoothly.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
