### PR TITLE
feat: get Peppermint Rush from Lyle before init tests

### DIFF
--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -530,6 +530,15 @@ float provideInitiative(int amt, location loc, boolean doEquips, boolean specula
 			return result();
 	}
 
+	if(doEquips && auto_haveCCSC() && have_effect($effect[Peppermint Rush]) == 0 && !get_property("_candyCaneSwordLyle").to_boolean()) {
+		if (!speculative) {
+			string temp = visit_url("place.php?whichplace=monorail&action=monorail_lyle");
+		}
+		handleEffect($effect[Peppermint Rush]);
+		if(pass())
+			return result();
+	}
+
 	if(doEquips && amt >= 400)
 	{
 		if(!get_property("_bowleggedSwaggerUsed").to_boolean() && buffMaintain($effect[Bow-Legged Swagger], 0, 1, 1, speculative))

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -532,6 +532,7 @@ float provideInitiative(int amt, location loc, boolean doEquips, boolean specula
 
 	if(doEquips && auto_haveCCSC() && have_effect($effect[Peppermint Rush]) == 0 && !get_property("_candyCaneSwordLyle").to_boolean()) {
 		if (!speculative) {
+			equip($item[candy cane sword cane]);
 			string temp = visit_url("place.php?whichplace=monorail&action=monorail_lyle");
 		}
 		handleEffect($effect[Peppermint Rush]);


### PR DESCRIPTION
# Description

Lyle can give Peppermint Rush, which might be useful for the modern zombies / 8-bit if we happen to not have enough turns from previous Surprisingly Sweet Slashes.

## How Has This Been Tested?

Did a run; it was used in Vanya's Castle.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
