### PR TITLE
fix: don't go to Twin Peak with drones if enough trimmers

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -1010,7 +1010,7 @@ boolean LX_dronesOut()
 		}
 		return autoAdv($location[The Middle Chamber]); //Tomb ratchets
 	}
-	if((internalQuestStatus("questL09Topping") >= 2 && internalQuestStatus("questL09Topping") <= 3) && get_property("twinPeakProgress").to_int() < 15 && zone_isAvailable($location[Twin Peak]))
+	if((internalQuestStatus("questL09Topping") >= 2 && internalQuestStatus("questL09Topping") <= 3) && hedgeTrimmersNeeded() > 0 && zone_isAvailable($location[Twin Peak]))
 	{
 		auto_log_info("Going to Twin Peak");
 		if(get_property("auto_priorLocation").to_location() != $location[Twin Peak])


### PR DESCRIPTION
# Description
When deciding where to go with drones out, don't go to Twin Peak if we already have enough hedge trimmers (e.g. if autumnaton was sent out and returned).

## How Has This Been Tested?
Hasn't yet. Hit the bug last run, will see if I hit it again.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
