### PR TITLE
fix: don't fail to cast dirge at NS tower

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2722,6 +2722,8 @@ boolean[effect] ATSongList()
 		Inigo\'s Incantation of Inspiration,
 		The Ballad of Richie Thingfinder,
 		Chorale of Companionship,
+		// under normal circumstances we should never get this, but if we do we want to keep it
+		Dirge of Dreadfulness (Remastered),
 		Ode to Booze,
 		Ur-Kel\'s Aria of Annoyance,
 		Carlweather\'s Cantata of Confrontation,
@@ -2735,7 +2737,6 @@ boolean[effect] ATSongList()
 		Prelude of Precision,
 		Elron\'s Explosive Etude,
 		Benetton\'s Medley of Diversity,
-		Dirge of Dreadfulness (Remastered),
 		Dirge of Dreadfulness,
 		Stevedave\'s Shanty of Superiority,
 		Brawnee\'s Anthem of Absorption,

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -585,7 +585,12 @@ boolean L13_towerNSContests()
 				if(crowd3Insufficient()) auto_beachCombHead("spooky");
 				if(crowd3Insufficient()) buffMaintain($effect[Spooky Hands]);
 				if(crowd3Insufficient()) buffMaintain($effect[Spooky Weapon]);
-				if(crowd3Insufficient()) buffMaintain($effect[Dirge of Dreadfulness (Remastered)]);
+				// at this point, an example list of songs is phat loot / polka / celerity / madrigal
+				if(crowd3Insufficient()) {
+					shrugAT($effect[Dirge of Dreadfulness (Remastered)]);
+					buffMaintain($effect[Dirge of Dreadfulness (Remastered)]);
+				}
+				// if we were to shrugAT here with only three songs, we could get rid of the remastered dirge
 				if(crowd3Insufficient()) buffMaintain($effect[Dirge of Dreadfulness], 10, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Intimidating Mien], 15, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Snarl of Three Timberwolves]);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -587,11 +587,14 @@ boolean L13_towerNSContests()
 				if(crowd3Insufficient()) buffMaintain($effect[Spooky Weapon]);
 				// at this point, an example list of songs is phat loot / polka / celerity / madrigal
 				if(crowd3Insufficient()) {
-					shrugAT($effect[Dirge of Dreadfulness (Remastered)]);
+					// specify normal effect to avoid failing the skill check
+					shrugAT($effect[Dirge of Dreadfulness]);
 					buffMaintain($effect[Dirge of Dreadfulness (Remastered)]);
 				}
-				// if we were to shrugAT here with only three songs, we could get rid of the remastered dirge
-				if(crowd3Insufficient()) buffMaintain($effect[Dirge of Dreadfulness], 10, 1, 1);
+				if(crowd3Insufficient()) {
+					shrugAT($effect[Dirge of Dreadfulness]);
+					buffMaintain($effect[Dirge of Dreadfulness], 10, 1, 1);
+				}
 				if(crowd3Insufficient()) buffMaintain($effect[Intimidating Mien], 15, 1, 1);
 				if(crowd3Insufficient()) buffMaintain($effect[Snarl of Three Timberwolves]);
 				if(crowd3Insufficient()) buffMaintain($effect[Snarl of the Timberwolf], 10, 1, 1);


### PR DESCRIPTION
# Description

If we have a spooky test at the NS tower, we may fail to cast dirge due to already having max songs (from the init / stat tests).

Shrug once before remastered dirge / dirge to avoid this. 

## How Has This Been Tested?

If I hit spooky at the tower I'll see if it fixes the problem. Might take a while ;)

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
