### PR TITLE
add debugging & workaround for maximizer empty hands issue

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -897,14 +897,14 @@ void equipMaximizedGear()
 			}
 		}
 		if (equippableWeapon != $item[none]) {
-			auto_log_error("NO WEAPON EQUIPPED. REPORT THIS IN DISCORD AND INCLUDE YOUR SESSION LOG!");
+			auto_log_error("It looks like the maximizer didn't equip any weapons for you. Lets dump some debugging info to help the KolMafia devs look into this.");
 			addToMaximize("2 dump"); // maximizer will dump a bunch of stuff to the session log with this
 			maximize(get_property("auto_maximize_current"), 2500, 0, false);
 			removeFromMaximize("2 dump");
 			if (equipped_item($slot[weapon]) == $item[none]) {
 				// workaround. equip a weapon & re-running maximizer appears to fix the issue.
 				equip(equippableWeapon);
-				maximize(get_property("auto_maximize_current"), 2500, 0, false);
+				abort("NO WEAPON WAS EQUIPPED BY THE MAXIMIZER. REPORT THIS IN DISCORD AND INCLUDE YOUR SESSION LOG! YOU CAN RE-RUN AUTOSCEND AND IT SHOULD RUN OK (possibly).");
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -884,6 +884,24 @@ void equipMaximizedGear()
 {
 	finalizeMaximize();
 	maximize(get_property("auto_maximize_current"), 2500, 0, false);
+	// below code is to help diagnose, debug and workaround the intermittent issue where the maximizer fails to equip anything in hand slots
+	// if this is confirmed as fixed by mafia devs, remove the below code.
+	if (equipped_item($slot[weapon]) == $item[none] && my_path() != $path[Way of the Surprising Fist]) {
+		auto_log_error("NO WEAPON EQUIPPED. REPORT THIS IN DISCORD AND INCLUDE YOUR SESSION LOG!");
+		addToMaximize("2 dump"); // maximizer will dump a bunch of stuff to the session log with this
+		maximize(get_property("auto_maximize_current"), 2500, 0, false);
+		if (equipped_item($slot[weapon]) == $item[none]) {
+			foreach it in get_inventory() {
+				if (it.to_slot() == $slot[weapon]) {
+					if (equip(it)) {
+						break;
+					}
+				}
+			}
+			removeFromMaximize("2 dump");
+			maximize(get_property("auto_maximize_current"), 2500, 0, false);
+		}
+	}
 }
 
 void equipOverrides()

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -887,19 +887,25 @@ void equipMaximizedGear()
 	// below code is to help diagnose, debug and workaround the intermittent issue where the maximizer fails to equip anything in hand slots
 	// if this is confirmed as fixed by mafia devs, remove the below code.
 	if (equipped_item($slot[weapon]) == $item[none] && my_path() != $path[Way of the Surprising Fist]) {
-		auto_log_error("NO WEAPON EQUIPPED. REPORT THIS IN DISCORD AND INCLUDE YOUR SESSION LOG!");
-		addToMaximize("2 dump"); // maximizer will dump a bunch of stuff to the session log with this
-		maximize(get_property("auto_maximize_current"), 2500, 0, false);
-		if (equipped_item($slot[weapon]) == $item[none]) {
-			foreach it in get_inventory() {
-				if (it.to_slot() == $slot[weapon]) {
-					if (equip(it)) {
-						break;
-					}
-				}
+		// do we actually have a weapon we can equip?
+		item equippableWeapon = $item[none];
+		foreach it in get_inventory() {
+			if (it.to_slot() == $slot[weapon] && can_equip(it)) {
+				// found a weapon and we should be able to equip it.
+				equippableWeapon = it;
+				break;
 			}
-			removeFromMaximize("2 dump");
+		}
+		if (equippableWeapon != $item[none]) {
+			auto_log_error("NO WEAPON EQUIPPED. REPORT THIS IN DISCORD AND INCLUDE YOUR SESSION LOG!");
+			addToMaximize("2 dump"); // maximizer will dump a bunch of stuff to the session log with this
 			maximize(get_property("auto_maximize_current"), 2500, 0, false);
+			removeFromMaximize("2 dump");
+			if (equipped_item($slot[weapon]) == $item[none]) {
+				// workaround. equip a weapon & re-running maximizer appears to fix the issue.
+				equip(equippableWeapon);
+				maximize(get_property("auto_maximize_current"), 2500, 0, false);
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Description

As title

## How Has This Been Tested?

Hasn't. I have never encountered this issue myself but hopefully this helps us provide some info to the mafia devs. Validates.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
