### PR TITLE
Put Twin Peak into Choice Handler

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -333,7 +333,7 @@ boolean auto_run_choice(int choice, string page)
 				break;
 			}
 			// do oil jar if we can
-			if(options contains 3 && item_amount($item[oil jar]) > 0)
+			if(options contains 3 && item_amount($item[jar of oil]) > 0)
 			{
 				run_choice(3);
 				break;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -333,7 +333,7 @@ boolean auto_run_choice(int choice, string page)
 				break;
 			}
 			// do oil jar if we can
-			if(options contains 3)
+			if(options contains 3 && item_amount($item[oil jar]) > 0)
 			{
 				run_choice(3);
 				break;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -317,7 +317,37 @@ boolean auto_run_choice(int choice, string page)
 			break;
 		case 604: // Welcome to the Great Overlook Lodge (Twin Peak Part 1)
 		case 605: // Welcome to the Great Overlook Lodge (Twin Peak Part 2)
+			run_choice(1); // always advance to next option via choice 1
+			break;
 		case 606: // Lost in the Great Overlook
+			if(in_bhy())
+			{
+				// we can't make an oil jar to solve the quest, just adventure until the hotel is burned down
+				run_choice(6); // and flee the music NC
+			}
+			// do init if we can
+			if(options contains 4)
+			{
+				run_choice(4);
+			}
+			// do oil jar if we can
+			if(options contains 3)
+			{
+				run_choice(3);
+			}
+			// do pantry search if we can
+			if(options contains 2)
+			{
+				run_choice(2);
+			}
+			// do stench test if we can
+			if(options contains 1)
+			{
+				run_choice(1);
+			}
+			// getting this NC without being able to pick a choice is not ideal
+			auto_log_warning("Got the Twin Peak NC (Lost in the Great Overlook) without able to complete any of the tasks :(");
+			break;
 		case 607: // Room 237 (Lost in the Great Overlook Lodge)
 		case 608: // Go Check It Out! (Lost in the Great Overlook Lodge)
 		case 609: // There's Always Music In the Air (Lost in the Great Overlook Lodge)

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -6,7 +6,7 @@ boolean auto_run_choice(int choice, string page)
 	
 	auto_log_debug("Running auto_choice_adv.ash");
 	string[int] options = available_choice_options();
-	
+
 	switch(choice)
 	{
 		case 15: // Yeti Nother Hippy (The eXtreme Slope)
@@ -324,26 +324,31 @@ boolean auto_run_choice(int choice, string page)
 			{
 				// we can't make an oil jar to solve the quest, just adventure until the hotel is burned down
 				run_choice(6); // and flee the music NC
+				break;
 			}
 			// do init if we can
 			if(options contains 4)
 			{
 				run_choice(4);
+				break;
 			}
 			// do oil jar if we can
 			if(options contains 3)
 			{
 				run_choice(3);
+				break;
 			}
 			// do pantry search if we can
 			if(options contains 2)
 			{
 				run_choice(2);
+				break;
 			}
 			// do stench test if we can
 			if(options contains 1)
 			{
 				run_choice(1);
+				break;
 			}
 			// getting this NC without being able to pick a choice is not ideal
 			auto_log_warning("Got the Twin Peak NC (Lost in the Great Overlook) without able to complete any of the tasks :(");

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -242,6 +242,11 @@ boolean auto_pre_adventure()
 		prepareForSmutOrcs();
 	}
 
+	if(place == $location[Twin Peak])
+	{
+		prepareForTwinPeak(false);
+	}
+
 	if(place == $location[Vanya\'s Castle])
 	{
 		provideInitiative(600, $location[Vanya\'s Castle], true);	

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -1010,7 +1010,7 @@ boolean LX_dronesOut()
 		}
 		return autoAdv($location[The Middle Chamber]); //Tomb ratchets
 	}
-	if((internalQuestStatus("questL09Topping") >= 2 && internalQuestStatus("questL09Topping") <= 3) && hedgeTrimmersNeeded() > 0 && zone_isAvailable($location[Twin Peak]))
+	if((internalQuestStatus("questL09Topping") >= 2 && internalQuestStatus("questL09Topping") <= 3) && hedgeTrimmersNeeded() > 1 && zone_isAvailable($location[Twin Peak]) && prepareForTwinPeak(true))
 	{
 		auto_log_info("Going to Twin Peak");
 		if(get_property("auto_priorLocation").to_location() != $location[Twin Peak])


### PR DESCRIPTION
# Description

Multiple Twin Peak NC issues report in discord. This PR does the following:
1. Flesh out NC 606 in the choice adv script
2. Create function to prepare for Twin Peak NC. Has speculative option
3. Call function to prepare in pre_adv

~~todo: look at goose drones code to make sure it is correct for this update~~ done

## How Has This Been Tested?

No issues with 1 standard run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
