### PR TITLE
Don't delay for batsnake if out of stuff to do

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -195,10 +195,15 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 		else
 		{
 			// if we're already level 11, well either be starting ASAP
-			foreach z, _ in shenSnakeLocations(my_daycount(), 0)
+			foreach z, _ in shenSnakeLocations(1, 0)
 			{
 				zones_to_avoid[z] = true;
 			}
+		}
+		// if ran out of stuff to do and need to get enchanted bean for L10 quest, don't delay for bat snake
+		if(internalQuestStatus("questL10Garbage") == 0 && get_property("auto_delayLastLevel").to_int() == 10 && item_amount($item[enchanted bean]) == 0)
+		{
+			zones_to_avoid[$location[The Batrat and Ratbat Burrow]] = false;
 		}
 		return zones_to_avoid;
 	}
@@ -206,7 +211,7 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 
 boolean shenShouldDelayZone(location loc)
 {
-	return shenZonesToAvoidBecauseMaybeSnake() contains loc;
+	return shenZonesToAvoidBecauseMaybeSnake()[loc];
 }
 
 int[location] getShenZonesTurnsSpent()

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -195,7 +195,7 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 		else
 		{
 			// if we're already level 11, well either be starting ASAP
-			foreach z, _ in shenSnakeLocations(1, 0)
+			foreach z, _ in shenSnakeLocations(my_daycount(), 0)
 			{
 				zones_to_avoid[z] = true;
 			}


### PR DESCRIPTION
# Description

Reported in discord:

> Has this ever happened to you?: You need to grow the beanstalk, but you don't have an enchanted bean, so you try to get one fron the Beanbat Chamber, but the Chamber isn't open, and Autoscend gets stuck instead of trying to open the Chamber?  I've had it a few times lately.  Next time it happens I'll give it a proper investigation

Relevent snippet of log:

> [INFO] Planting enchanted bean to open the beanstalk and start L10 quest.
> [INFO] In the bat hole!
> [INFO] Requested monkey paw wish without paw available, skipping sonar-in-a-biscuit
> [INFO] No enchanted bean. Getting one from The Beanbat Chamber.
> [WARNING] Can't get to The Beanbat Chamber right now.
> [INFO] Planting enchanted bean to open the beanstalk and start L10 quest.
> [INFO] In the bat hole!
> [INFO] Requested monkey paw wish without paw available, skipping sonar-in-a-biscuit
> [INFO] No enchanted bean. Getting one from The Beanbat Chamber.
> [WARNING] Can't get to The Beanbat Chamber right now.
> [INFO] In the bat hole!
> [INFO] Requested monkey paw wish without paw available, skipping sonar-in-a-biscuit
> [WARNING] I was trying to avoid delay zones, but I've run out of stuff to do. Releasing softblock.
Preference auto_delayLastLevel changed from 9 to 10

Repeats

## How Has This Been Tested?

Validates. Asked Aventuristo to try this branch if they would be so kind to confirm it helps

Aventuristo has confirmed this works! Saw in log situation which was previously failing and no longer does

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
