### PR TITLE
Maximizer no weapons bug: remove the abort, add another maximizer call to workaround the bug.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -904,7 +904,8 @@ void equipMaximizedGear()
 			if (equipped_item($slot[weapon]) == $item[none]) {
 				// workaround. equip a weapon & re-running maximizer appears to fix the issue.
 				equip(equippableWeapon);
-				abort("NO WEAPON WAS EQUIPPED BY THE MAXIMIZER. REPORT THIS IN DISCORD AND INCLUDE YOUR SESSION LOG! YOU CAN RE-RUN AUTOSCEND AND IT SHOULD RUN OK (possibly).");
+				maximize(get_property("auto_maximize_current"), 2500, 0, false);
+				auto_log_error("No weapon was equipped by the maximizer. If you want to report this to the mafia devs at kolmafia.us include your session log. We have attempted a work around.");
 			}
 		}
 	}


### PR DESCRIPTION
# Description

Just removing the abort & adding a maximize call to workaround the bug. Kept a warning message so people can search logs if required in future for mafia devs.

## How Has This Been Tested?

Hasn't. Again, I'm unable to reproduce this myself. Validates.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
