### PR TITLE
Check if we actually recovered cinch when doFreeRest() returns false

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2201,7 +2201,7 @@ boolean doFreeRest(){
 		} else if (get_dwelling() == $item[Newbiesport&trade; tent])
 		{
 			mpToBurn = 10 - restorableMp;
-		} else if (get_dwelling() == $item[big rock]) // just the ground
+		} else // assume resting on the ground
 		{
 			mpToBurn = 5 - restorableMp;
 		}

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2188,8 +2188,36 @@ boolean haveAnyIotmAlternativeRestSiteAvailable(){
  */
 boolean doFreeRest(){
 	if(haveFreeRestAvailable()){
+
+		// burn MP if possible prior to resting
+		int restorableMp = my_maxmp() - my_mp();
+		int mpToBurn = 0;
+		if (chateaumantegna_available() || auto_campawayAvailable()) // will restore at least 100 MP
+		{
+			mpToBurn = 100 - restorableMp;
+		} else if (get_dwelling() == $item[Frobozz Real-Estate Company Instant House (TM)])
+		{
+			mpToBurn = 40 - restorableMp;
+		} else if (get_dwelling() == $item[Newbiesport&trade; tent])
+		{
+			mpToBurn = 10 - restorableMp;
+		} else if (get_dwelling() == $item[big rock]) // just the ground
+		{
+			mpToBurn = 5 - restorableMp;
+		}
+
+		if (mpToBurn > 0)
+		{
+			cli_execute("burn " + mpToBurn);
+		}
+
+		// resting and success check
+		int hpMp_before = my_hp() + my_mp();
 		int rest_count = get_property("timesRested").to_int();
-		return doRest() > rest_count;
+		boolean result = doRest() > rest_count;
+		int hpMp_after = my_hp() + my_mp();
+		boolean success = (hpMp_after > hpMp_before) || result;
+		return success;
 	}
 	return false;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -351,9 +351,18 @@ boolean auto_getCinch(int goal)
 			// can't rest if we have full mp and hp
 			return false;
 		}
+		int cinchBeforeRest = auto_currentCinch();
 		if(!doFreeRest())
 		{
-			abort("Failed to rest to charge cincho");
+			int cinchAfterRest = auto_currentCinch();
+			if(cinchAfterRest > cinchBeforeRest)
+			{
+				auto_log_debug("doFreeRest() returns false, but we still recovered cinch", "purple");
+			}
+			else
+			{
+				abort("Failed to rest to charge cincho");
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -317,19 +317,9 @@ boolean auto_nextRestOverCinch()
 
 boolean auto_getCinch(int goal)
 {
-	boolean atMaxMpHp()
-	{
-		return my_mp() == my_maxmp() && my_hp() == my_maxhp();
-	}
-
 	if(auto_currentCinch() >= goal)
 	{
 		return true;
-	}
-	if(atMaxMpHp())
-	{
-		// can't rest if we have full mp and hp
-		return false;
 	}
 	if(!haveFreeRestAvailable())
 	{
@@ -346,23 +336,9 @@ boolean auto_getCinch(int goal)
 	// use free rests until have enough cinch or out of rests
 	while(auto_currentCinch() < goal && haveFreeRestAvailable())
 	{
-		if(atMaxMpHp())
-		{
-			// can't rest if we have full mp and hp
-			return false;
-		}
-		int cinchBeforeRest = auto_currentCinch();
 		if(!doFreeRest())
 		{
-			int cinchAfterRest = auto_currentCinch();
-			if(cinchAfterRest > cinchBeforeRest)
-			{
-				auto_log_debug("doFreeRest() returns false, but we still recovered cinch", "purple");
-			}
-			else
-			{
-				abort("Failed to rest to charge cincho");
-			}
+			abort("Failed to rest to charge cincho");
 		}
 	}
 


### PR DESCRIPTION
# Description

As described in the issue, `timesRested` can be unreliable when checking if resting actually took place.
When `doFreeRest()` returns `false`, we check if cinch has been increased. If yes, resting worked, if no, we really abort.

Fixes #1420

## How Has This Been Tested?

Several smol runs. Works smoothly

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
