### PR TITLE
feat: move Ezan's scripts back to her; relocate to default branch

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -1,6 +1,6 @@
-github Ezandora/Detective-Solver Release
-github Ezandora/Helix-Fossil Release
-github Ezandora/Far-Future Release
+github Ezandora/Detective-Solver
+github Ezandora/Helix-Fossil
+github Ezandora/Far-Future
+github Ezandora/Voting-Booth
 github gausie/excavator
-github midgleyc/Voting-Booth
 github loathers/combo release

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -105,7 +105,7 @@ string auto_combatHandler(int round, monster enemy, string text)
 
 	if(in_pokefam())
 	{
-		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
+		if(git_exists("Ezandora-Helix-Fossil"))
 		{
 		auto_log_info("Combat via Ezandora:", "green");
 		boolean ignore = cli_execute("Pocket Familiars");

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -604,7 +604,7 @@ boolean auto_doPrecinct()
 	{
 		return false;
 	}
-	if(svn_exists("Ezandora-Detective-Solver-branches-Release") || git_exists("Ezandora-Detective-Solver-Release"))
+	if(git_exists("Ezandora-Detective-Solver"))
 	{
 		//Assume if someone has this installed that they want to use it.
 		cli_execute("ash import<Detective Solver.ash> solveAllCases(false);");
@@ -1105,7 +1105,7 @@ boolean timeSpinnerGet(string goal)
 		return false;
 	}
 
-	if(svn_exists("Ezandora-Far-Future-branches-Release") || git_exists("Ezandora-Far-Future-Release"))
+	if(git_exists("Ezandora-Far-Future"))
 	{
 		//Required by dependencies
 		cli_execute("FarFuture " + goal);

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -1180,7 +1180,7 @@ boolean auto_voteSetup(int candidate, int first, int second)
 		return false;
 	}
 
-	if(git_exists("midgleyc-Voting-Booth"))
+	if(git_exists("Ezandora-Voting-Booth"))
 	{
 		cli_execute("VotingBooth.ash");
 		return true;

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -36,7 +36,7 @@ boolean pokefam_makeTeam()
 	if(in_pokefam())
 	{
 		// Choose "strongest 2" in order to allow a middle spot for a pocket familiar to level up and earn pokebucks.
-		if(svn_exists("Ezandora-Helix-Fossil-branches-Release") || git_exists("Ezandora-Helix-Fossil-Release"))
+		if(git_exists("Ezandora-Helix-Fossil"))
 		{
 		auto_log_info("Setting our team via Ezandora:", "green");
 		boolean ignore = cli_execute("PocketFamiliarsAutoSelect Strongest 2;");


### PR DESCRIPTION
# Description

Ezandora's scripts now support git downloads, and have moved from the `Release` branch to the `master` branch.
