### PR TITLE
Disallow using stooper in smol because of organ restrictions

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1225,6 +1225,10 @@ boolean doBedtime()
 
 	boolean canChangeToStooper()
 	{
+		if (in_small()) // In smol, the stooper can be equipped, but does not modify the liver size
+		{
+			return false;
+		}
 		if(have_familiar($familiar[Stooper]) &&	//do not use auto_ that returns false in 100run, which stooper drinking does not interrupt.
 		pathAllowsChangingFamiliar() &&		//some paths forbid familiar or dont allow changing it but mafia still indicates you have the familiar
 		my_familiar() != $familiar[Stooper])


### PR DESCRIPTION
# Description

Return `false` for stooper use in smol to fix bedtime. Stooper is not increasing liver in smol, so it should not be used.

Fixes #1423

## How Has This Been Tested?

I applied the fix and bedtime is working now.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
