### PR TITLE
Spring Shoes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27772;	// feat: everything looks green color + noremove 
+since r27832;	// Spring Kick banish management
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -48,6 +48,7 @@ import <autoscend/iotms/mr2020.ash>
 import <autoscend/iotms/mr2021.ash>
 import <autoscend/iotms/mr2022.ash>
 import <autoscend/iotms/mr2023.ash>
+import <autoscend/iotms/mr2024.ash>
 
 import <autoscend/paths/actually_ed_the_undying.ash>
 import <autoscend/paths/auto_path_util.ash>

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -286,7 +286,8 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		{
 			useSkill = $skill[Curiosity of Br\'er Tarrypin];
 		}																						break;
-	case $effect[Crunching Leaves]:				useItem = $item[Autumn Leaf];					break;	
+	case $effect[Crunching Leaves]:				useItem = $item[Autumn Leaf];					break;
+	case $effect[Crunchy Steps]:				useItem = $item[crunchy brush];					break;
 	case $effect[Dance of the Sugar Fairy]:		useItem = $item[Sugar Fairy];					break;
 	case $effect[Destructive Resolve]:			useItem = $item[Resolution: Be Feistier];		break;
 	case $effect[Dexteri Tea]:					useItem = $item[cuppa Dexteri tea];				break;
@@ -820,6 +821,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		}																						break;
 	case $effect[Twen Tea]:						useItem = $item[cuppa Twen tea];				break;
 	case $effect[Twinkly Weapon]:				useItem = $item[Twinkly Nuggets];				break;
+	case $effect[Ultra-Soft Steps]:				useItem = $item[ultra-soft ferns];				break;
 	case $effect[Unmuffled]:
 		if(get_property("peteMotorbikeMuffler") == "Extra-Loud Muffler")
 		{

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -115,7 +115,8 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 		Celestial Saltiness,
 		Simply Irresistible,
 		Crunching Leaves,
-		Romantically Roused
+		Romantically Roused,
+		Crunchy Steps
 	])) {
 		return result();
 	}
@@ -301,7 +302,8 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 		Inky Camouflage,	
 		Celestial Camouflage,
 		Feeling Lonely,
-		Feeling Sneaky
+		Feeling Sneaky,
+		Ultra-Soft Steps
 	])) {
 		return result();
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -734,6 +734,10 @@ boolean adjustForBanish(string combat_string)
 	{
 		return autoEquip($item[familiar scrapbook]);
 	}
+	if(combat_string == "skill " + $skill[Spring Kick])
+	{
+		return autoEquip($item[spring shoes]);
+	}
 	if(combat_string == ("skill " + $skill[Use the Force]))
 	{
 		return autoEquip($slot[weapon], wrap_item($item[Fourth of May cosplay saber]));
@@ -884,6 +888,12 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	if (canUse($skill[Peel Out]) && pete_peelOutRemaining() > 0)
 	{
 		return "skill " + $skill[Peel Out];
+	}
+
+	if (auto_haveSpringShoes() && have_effect($effect[Everything Looks Green]) == 0)
+	{
+		autoEquip($item[spring shoes]);
+		return "skill" + $skill[Spring Away];
 	}
 
 	//Non-standard free-runs

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -540,6 +540,10 @@ boolean auto_handleCCSC();
 void auto_useWardrobe();
 
 ########################################################################################################
+//Defined in autoscend/iotms/mr2024.ash
+boolean auto_haveSpringShoes();
+
+########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash
 boolean isActuallyEd();
 int ed_spleen_limit();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -620,6 +620,10 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		return "skill " + $skill[Show Your Boring Familiar Pictures];
 	}
+	if((inCombat ? auto_have_skill($skill[Spring Kick]) : possessEquipment($item[spring shoes])) && auto_is_valid($skill[Spring Kick]) && !(used contains "Spring Kick"))
+	{
+		return "skill " + $skill[Spring Kick];
+	}
 
 	// bowling ball is only in inventory if it is available to use in combat. While on cooldown, it is not in inventory
 	if((inCombat ? auto_have_skill($skill[Bowl a Curveball]) : item_amount($item[Cosmic Bowling Ball]) > 0) && auto_is_valid($skill[Bowl a Curveball]) && !(used contains "Bowl a Curveball"))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -539,6 +539,12 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		Breathe Out: per hot jelly usage
 	*/
 
+	//Spring Kick is at the top because it is not turn ending. If a replacer is used the replaced monster can then have unspeakable things done to it (like another banish)
+	if((inCombat ? auto_have_skill($skill[Spring Kick]) : possessEquipment($item[spring shoes])) && auto_is_valid($skill[Spring Kick]) && !(used contains "Spring Kick"))
+	{
+		return "skill " + $skill[Spring Kick];
+	}
+
 	if(auto_have_skill($skill[Peel Out]) && pete_peelOutRemaining() > 0 && get_property("peteMotorbikeMuffler") == "Extra-Smelly Muffler" && !(used contains "Peel Out"))
 	{
 		return "skill " + $skill[Peel Out];
@@ -619,10 +625,6 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	if((inCombat ? auto_have_skill($skill[Show Your Boring Familiar Pictures]) : possessEquipment($item[familiar scrapbook])) && auto_is_valid($skill[Show Your Boring Familiar Pictures]) && (get_property("scrapbookCharges").to_int() >= 200 || (get_property("scrapbookCharges").to_int() >= 100 && my_level() >= 13)) && !(used contains "Show Your Boring Familiar Pictures"))
 	{
 		return "skill " + $skill[Show Your Boring Familiar Pictures];
-	}
-	if((inCombat ? auto_have_skill($skill[Spring Kick]) : possessEquipment($item[spring shoes])) && auto_is_valid($skill[Spring Kick]) && !(used contains "Spring Kick"))
-	{
-		return "skill " + $skill[Spring Kick];
 	}
 
 	// bowling ball is only in inventory if it is available to use in combat. While on cooldown, it is not in inventory

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -1,0 +1,10 @@
+# This is meant for items that have a date of 2024
+
+boolean auto_haveSpringShoes()
+{
+	if(auto_is_valid($item[spring shoes]) && available_amount($item[spring shoes]) > 0 )
+	{
+		return true;
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -15,6 +15,10 @@ boolean L10_plantThatBean()
 	}
 	if(item_amount($item[Enchanted Bean]) > 0)
 	{
+		if(auto_haveSpringShoes())
+		{
+			equip($slot[acc3], $item[spring shoes]); //free stats
+		}
 		visit_url("place.php?whichplace=plains&action=garbage_grounds");
 		return true;
 	}


### PR DESCRIPTION
# Description

Spring Shoe support. Equips Spring Shoes before planting the beanstalk, Spring Kicks and Springs Away as appropriate, added Crunchy Steps and Ultra-Soft Steps to providers

## How Has This Been Tested?

Did D1 of a Normal Standard Sauceror run and all things that I added were performed and worked as expected

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
