### PR TITLE
Spring shoes support

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -48,6 +48,7 @@ import <autoscend/iotms/mr2020.ash>
 import <autoscend/iotms/mr2021.ash>
 import <autoscend/iotms/mr2022.ash>
 import <autoscend/iotms/mr2023.ash>
+import <autoscend/iotms/mr2024.ash>
 
 import <autoscend/paths/actually_ed_the_undying.ash>
 import <autoscend/paths/auto_path_util.ash>

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -287,6 +287,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 			useSkill = $skill[Curiosity of Br\'er Tarrypin];
 		}																						break;
 	case $effect[Crunching Leaves]:				useItem = $item[Autumn Leaf];					break;	
+	case $effect[Crunchy Steps]:				useItem = $item[crunchy brush];					break;	
 	case $effect[Dance of the Sugar Fairy]:		useItem = $item[Sugar Fairy];					break;
 	case $effect[Destructive Resolve]:			useItem = $item[Resolution: Be Feistier];		break;
 	case $effect[Dexteri Tea]:					useItem = $item[cuppa Dexteri tea];				break;
@@ -820,6 +821,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		}																						break;
 	case $effect[Twen Tea]:						useItem = $item[cuppa Twen tea];				break;
 	case $effect[Twinkly Weapon]:				useItem = $item[Twinkly Nuggets];				break;
+	case $effect[Ultra-Soft Steps]:				useItem = $item[ultra-soft ferns];				break;
 	case $effect[Unmuffled]:
 		if(get_property("peteMotorbikeMuffler") == "Extra-Loud Muffler")
 		{

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -115,7 +115,8 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 		Celestial Saltiness,
 		Simply Irresistible,
 		Crunching Leaves,
-		Romantically Roused
+		Romantically Roused,
+		Crunchy Steps
 	])) {
 		return result();
 	}
@@ -301,7 +302,8 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 		Inky Camouflage,	
 		Celestial Camouflage,
 		Feeling Lonely,
-		Feeling Sneaky
+		Feeling Sneaky,
+		Ultra-Soft Steps
 	])) {
 		return result();
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -757,6 +757,10 @@ boolean adjustForBanish(string combat_string)
 	{
 		return autoEquip($item[cursed monkey\'s paw]);
 	}
+	if(combat_string == "skill " + $skill[Spring Kick])
+	{
+		return autoEquip($item[spring shoes]);
+	}
 	return true;
 }
 
@@ -806,6 +810,34 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	if (isFreeMonster(enemy, my_location())) return "";
 	string pre_banish = freeRunCombatStringPreBanish(enemy, loc, inCombat);
 	if (pre_banish != "") return pre_banish;
+
+	//Standard free-runs
+	if (!inAftercore() && have_effect($effect[Everything Looks Green]) == 0)
+	{
+		if(auto_hasSpringShoes())
+		{
+			if(!inCombat)
+			{
+				autoEquip($item[spring shoes]);
+				return "runaway item " + $item[spring shoes];
+			}
+			else
+			{
+				if(have_equipped($item[spring shoes]))
+				{
+					return "skill " + $skill[Spring Away];
+				}
+			}
+		}
+
+		foreach it in $items[green smoke bomb, tattered scrap of paper, GOTO]
+		{
+			if (canUse(it) && item_amount(it) > 0)
+			{
+				return useItem(it);
+			}
+		}
+	}
 
 	if(canChangeToFamiliar($familiar[Frumious Bandersnatch]))
 	{
@@ -890,18 +922,6 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	if(!inAftercore())
 	{
 		foreach it in $items[giant eraser] //assuming additional ones will be added, eventually
-		{
-			if (canUse(it) && item_amount(it) > 0)
-			{
-				return useItem(it);
-			}
-		}
-	}
-
-	//Standard free-runs
-	if (!inAftercore() && have_effect($effect[Everything Looks Green]) == 0)
-	{
-		foreach it in $items[green smoke bomb, tattered scrap of paper, GOTO]
 		{
 			if (canUse(it) && item_amount(it) > 0)
 			{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -540,6 +540,10 @@ boolean auto_handleCCSC();
 void auto_useWardrobe();
 
 ########################################################################################################
+//Defined in autoscend/iotms/mr2024.ash
+boolean auto_hasSpringShoes();
+
+########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash
 boolean isActuallyEd();
 int ed_spleen_limit();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -524,6 +524,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		Asdon Martin: Spring-Loaded Front Bumper: no limit
 		Curse of Vacation: no limit? No turn limit?
 		Walk Away Explosion: no limit, turn limited irrelavant.
+		Spring Kick: no limit, no turn limit
 
 		Howl of the Alpha: no limit, no turn limit, can banish up to 3 monsters simultaneously
 
@@ -668,6 +669,11 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	if((inCombat ? auto_have_skill($skill[Monkey Slap]) : possessEquipment($item[cursed monkey\'s paw])) && auto_is_valid($skill[Monkey Slap]) && get_property("_monkeyPawWishesUsed").to_int() == 0 && !(used contains "Monkey Slap"))
 	{
 		return "skill " + $skill[Monkey Slap];
+	}
+
+	if((inCombat ? auto_have_skill($skill[Spring Kick]) : possessEquipment($item[spring shoes])) && auto_is_valid($skill[Spring Kick]) && have_equipped($item[spring shoes]) && (!(used contains "Spring Kick")))
+	{
+		return "skill " + $skill[Spring Kick];
 	}
 	
 	//[Nanorhino] familiar specific banish. fairly low priority as it consumes 40 to 50 adv worth of a decent buff.

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -1,0 +1,11 @@
+# This is meant for items that have a date of 2024
+
+boolean auto_hasSpringShoes()
+{
+	// check for normal version
+	static item springShoes = $item[spring shoes];
+	if(auto_is_valid(springShoes) && (item_amount(springShoes) > 0 || have_equipped(springShoes)))
+	{
+		return true;
+	}
+}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -15,6 +15,12 @@ boolean L10_plantThatBean()
 	}
 	if(item_amount($item[Enchanted Bean]) > 0)
 	{
+		static item springShoes = $item[spring shoes];
+		if (equipped_amount(springShoes, true) < 0 && item_amount(springShoes) > 0)
+		{
+			equip($item[spring shoes]);
+		}
+
 		visit_url("place.php?whichplace=plains&action=garbage_grounds");
 		return true;
 	}


### PR DESCRIPTION
# Description

Spring shoes support:

- Add it to `mr2024.ash`
- Add `spring away` to runaways
- Add `ultra-soft ferns` and `crunchy bush` to NC frequency modifiers
- Add `spring kick` to banishers
- Make sure `spring shoes` are equipped before planting the `enchanted bean`

## How Has This Been Tested?

Several smol runs so far
No standard or unrestricted yet

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
