### PR TITLE
Buy thrall skills that are used by autoscend

### DIFF
--- a/RELEASE/scripts/autoscend/paths/auto_path_util.ash
+++ b/RELEASE/scripts/autoscend/paths/auto_path_util.ash
@@ -121,6 +121,10 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		{
 			visit_url("guild.php?action=buyskill&skillid=6", true);
 		}
+		if((my_level() >= 5) && (my_meat() >= 4000) && !have_skill($skill[Bind Vermincelli]))
+		{
+			visit_url("guild.php?action=buyskill&skillid=29", true);
+		}
 		if((my_level() >= 9) && (my_meat() >= 12500) && !have_skill($skill[Spirit of Ravioli]))
 		{
 			visit_url("guild.php?action=buyskill&skillid=14", true);
@@ -132,6 +136,10 @@ boolean auto_buySkills()  // This handles skill acquisition for general paths
 		if((my_level() >= 12) && (my_meat() >= 25000) && !have_skill($skill[Cannelloni Cocoon]))
 		{
 			visit_url("guild.php?action=buyskill&skillid=12", true);
+		}
+		if((my_level() >= 15) && (my_meat() >= 32500) && !have_skill($skill[Bind Spice Ghost]))
+		{
+			visit_url("guild.php?action=buyskill&skillid=39", true);
 		}
 		break;
 	case $class[Sauceror]:


### PR DESCRIPTION
# Description

Make autoscend buy `Bind Vermincelli` and `Bind Spice Ghost` because they are also considered as pasta thralls. Especially the vermincelli can be useful for some extra MP gain.

## How Has This Been Tested?

Can not test it, i already own the skills.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
