### PR TITLE
Disambiguate AoSoL's Punt skill

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -638,9 +638,9 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Feel Hatred];
 	}
 	
-	if(auto_have_skill($skill[Punt]) && (my_mp() > mp_cost($skill[Punt])) && !(used contains "Punt"))
+	if(auto_have_skill($skill[[28021]Punt]) && (my_mp() > mp_cost($skill[[28021]Punt])) && !(used contains "Punt"))
 	{
-		return "skill " + $skill[Punt];
+		return "skill " + $skill[[28021]Punt];
 	}
 
 	item saber = wrap_item($item[Fourth of May cosplay saber]);

--- a/RELEASE/scripts/autoscend/paths/avatar_of_shadows_over_loathing.ash
+++ b/RELEASE/scripts/autoscend/paths/avatar_of_shadows_over_loathing.ash
@@ -69,7 +69,7 @@ boolean aosol_buySkills()
 				auto_log_info("Skill points found: " + skillPoints);
 				while(skillPoints > 0)
 				{
-					if(!have_skill($skill[Punt])) //Banish for the day
+					if(!have_skill($skill[[28021]Punt])) //Banish for the day
 					{
 						page = visit_url("choice.php?pwd&option=1&whichchoice=1495&use=points&whichsk=21", true);
 					}
@@ -217,7 +217,7 @@ boolean aosol_buySkills()
 				page = visit_url("choice.php?pwd&whichchoice=1495&option=1&whichsk=11", true);
 				set_property("auto_aosolLastSkill", 10);
 			}
-			if(!have_skill($skill[Punt]) && my_level()>=11 && my_meat()>1100 + meatReserve()) //Banish for the day
+			if(!have_skill($skill[[28021]Punt]) && my_level()>=11 && my_meat()>1100 + meatReserve()) //Banish for the day
 			{
 				page = visit_url("choice.php?pwd&whichchoice=1495&option=1&whichsk=21", true);
 				set_property("auto_aosolLastSkill", 100);


### PR DESCRIPTION
# Description

AoSoL's Punt is 28021, which autoscend supports. WereProfessor added a Punt skill number 7510 (support was added in Mafia r27841), so now mafia throws multiple skill match warnings.

Adding [7510]Punt (duplicating the [28021]Punt use, more or less) to auto_combat_util.ash would make sense if autoscend is expected to eventually handle WereProfessor, but that's more than just a trivial warning-removal fix.

## How Has This Been Tested?

Before patch, importing `autoscend.ash` gives
```
Multiple matches for "Punt"; using "[28021]Punt". (auto_combat_util.ash, line 641, char 28 to char 32) Clarify by using one of:
$skill[[7510]Punt]
$skill[[28021]Punt]
Multiple matches for "Punt"; using "[28021]Punt". (auto_combat_util.ash, line 641, char 64 to char 68) Clarify by using one of:
$skill[[7510]Punt]
$skill[[28021]Punt]
Multiple matches for "Punt"; using "[28021]Punt". (auto_combat_util.ash, line 643, char 28 to char 32) Clarify by using one of:
$skill[[7510]Punt]
$skill[[28021]Punt]
Multiple matches for "Punt"; using "[28021]Punt". (avatar_of_shadows_over_loathing.ash, line 72, char 28 to char 32) Clarify by using one of:
$skill[[7510]Punt]
$skill[[28021]Punt]
Multiple matches for "Punt"; using "[28021]Punt". (avatar_of_shadows_over_loathing.ash, line 220, char 26 to char 30) Clarify by using one of:
$skill[[7510]Punt]
$skill[[28021]Punt]
```

After patch, these warnings are gone.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
