### PR TITLE
Bees Hate You fixes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1670,11 +1670,6 @@ boolean doTasks()
 {
 	//this is the main loop for autoscend. returning true will restart from the begining. returning false will quit the loop and go on to do bedtime
 
-	if(in_community())
-	{
-		abort("Community Service is no longer supported.");
-	}
-
 	auto_settingsFix();		//check and correct invalid configuration inputs made by users
 	if(!auto_unreservedAdvRemaining())
 	{
@@ -1907,6 +1902,11 @@ void auto_begin()
 		{
 			auto_log_warning("Okay, but the warranty is off.", "red");
 		}
+	}
+
+	if(in_community())
+	{
+		abort("Community Service is no longer supported.");
 	}
 
 	LX_handleIntroAdventures(); // handle early non-combats in challenge paths.

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -398,6 +398,11 @@ void equipStatgainIncreasers(boolean[stat] increaseThisStat, boolean alwaysEquip
 			maximizerStatement += "1handed,";		//ignore incompatible weapons
 		}
 	}
+	if(in_bhy())
+	{
+		// can't use garbage tote and wad of used tape gives +MP
+		maximizerStatement += "-equip wad of used tape";
+	}
 	if(!maximize(maximizerStatement,true))
 	{
 		if(!alwaysEquip)

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -223,7 +223,16 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	{
 		auto_log_info("We're gonna slurp up some sausage, let's make sure we have enough max mp", "blue");
 		cli_execute("checkpoint");
-		maximize("mp,-tie", false);
+		if(in_bhy())
+		{
+			// can't use january's garbage tote, but that won't prevent
+			// the maximizer from suggesting we fold a wad of used tape.
+			maximize("mp,-equip wad of used tape,-tie", false);
+		}
+		else
+		{
+			maximize("mp,-tie", false);
+		}
 	}
 	// I could optimize this a little more by eating more sausage at once if you have enough max mp...
 	// but meh.

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3347,7 +3347,17 @@ boolean L11_defeatEd()
 	auto_log_info("Time to waste all of Ed's Ka Coins :(", "blue");
 
 	set_property("auto_nextEncounter","Ed the Undying");
-	autoAdv($location[The Lower Chambers]);
+	if(in_bhy())
+	{
+		maximize("beeosity,-tie", false);
+		set_property("auto_disableAdventureHandling", true);
+		autoAdvBypass("place.php?whichplace=pyramid&action=pyramid_state1a", $location[The Lower Chambers]);
+		set_property("auto_disableAdventureHandling", false);
+	}
+	else
+	{
+		autoAdv($location[The Lower Chambers]);
+	}
 	if(in_pokefam() || in_koe())
 	{
 		cli_execute("refresh inv");

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -468,11 +468,15 @@ boolean L13_towerNSContests()
 			int [stat] statGoal;
 			statGoal[crowd_stat] = 600;
 			provideStats(statGoal, $location[Noob Cave], true);
+			string maximize_string = crowd_stat + ", -equip snow suit";
+			if(in_bhy())
+			{
+				maximize_string += ", -equip wad of used tape";
+			}
+			autoMaximize(maximize_string, 1500, 0, false);
 			switch(crowd_stat)
 			{
 			case $stat[moxie]:
-				autoMaximize("moxie -equip snow suit", 1500, 0, false);
-
 				if(have_effect($effect[Ten out of Ten]) == 0 && auto_is_valid($effect[Ten out of Ten]))
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Ten out of Ten]);
@@ -484,8 +488,6 @@ boolean L13_towerNSContests()
 				}
 				break;
 			case $stat[muscle]:
-				autoMaximize("muscle -equip snow suit", 1500, 0, false);
-
 				if(have_effect($effect[Muddled]) == 0 && auto_is_valid($effect[Muddled]))
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Muddled]);
@@ -497,8 +499,6 @@ boolean L13_towerNSContests()
 				}
 				break;
 			case $stat[mysticality]:
-				autoMaximize("myst -equip snow suit", 1500, 0, false);
-
 				if(have_effect($effect[Uncucumbered]) == 0 && auto_is_valid($effect[Uncucumbered]))
 				{
 					if(crowd2Insufficient()) fightClubSpa($effect[Uncucumbered]);


### PR DESCRIPTION
# Description

This fixes an issue I had in all prior BHY autoscend runs where 50+ turns would get spent losing to Ed. Every time 2 B's we're being worn into the 5 round combat which guaranteed 100% damage by the start of round 5. The other issues were almost all places where the maximizer wanted to fold the January's Garbage Tote. The wad of used tape kept getting chosen by the maximizer for MP and +10% to all stats.

## How Has This Been Tested?

I have done a couple BHY runs in a row and was able to confirm that major issues I had in earlier runs are absent from the most recent ones. In particular the Ed issue and the maximizer crashes appear to be gone.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
