### PR TITLE
fix: excavator is now on a branch

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -2,5 +2,5 @@ github Ezandora/Detective-Solver
 github Ezandora/Helix-Fossil
 github Ezandora/Far-Future
 github Ezandora/Voting-Booth
-github gausie/excavator
+github gausie/excavator release
 github loathers/combo release


### PR DESCRIPTION
Excavator has moved to a release branch; don't try to install the old one.