### PR TITLE
Refactor regex for boombox song count to handle April 1st word salad

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -385,7 +385,12 @@ boolean songboomSetting(int option)
 
 	int boomsLeft = 0;
 	string page = visit_url("inv_use.php?pwd=&which=3&whichitem=9919");
-	matcher boomMatcher = create_matcher("You grab your boombox and select the soundtrack for your life,  which you can do <b>(?:-?)(\\d+)", page);
+
+	// Find the number of songs left by matching the number in the "X more times" sentence. Overly flexible to prevent April Fools word salad breakage.
+	// \\b(\\d+)\\b matches a whole number (\\d+) that's surrounded by word boundaries (\\b), e.g. a space
+	// [^.]* matches any characters except a period (.), any number of times (*), capturing everything up to the end of the sentence
+	// \\. matches the literal ending period to only check the top boombox sentence
+	matcher boomMatcher = create_matcher("\\b(\\d+)\\b[^.]*\\.", page);
 	if(boomMatcher.find())
 	{
 		boomsLeft = to_int(boomMatcher.group(1));


### PR DESCRIPTION
# Description

On April 1st, noncombat text gets randomly garbled with "salad". This results in 
`You grab your boombox and select the soundtrack for your life, which you can do 11 more times today.` turning into variants like `Salad grab your boombox and select the salad for your life, which salad can do 11 salad times today.`

autoscend can't determine song count which isn't very problematic since it selects a song anyway, but this error
```
> [WARNING] Could not find how many songs we have left...
```
could be avoided by making the matcher more flexible.

## How Has This Been Tested?

Before:
```
use 1 SongBoom&trade; BoomBox
Preference lastEncounter changed from Enter the Boxing Daycare to Choose a Soundtrack
Encounter: Choose a Soundtrack
Preference boomBoxSong changed from Total Eclipse of Your Meat to 
Preference boomBoxSong changed from  to Total Eclipse of Your Meat
> [WARNING] Could not find how many songs we have left...
Took choice 1312/6: Silence
choice.php?whichchoice=1312&option=6
Preference boomBoxSong changed from Total Eclipse of Your Meat to 
Switching soundtrack off
```

After:
```
use 1 SongBoom&trade; BoomBox
Preference lastEncounter changed from demonic icebox to Choose a Soundtrack
Encounter: Choose a Soundtrack
Preference boomBoxSong changed from Eye of the Giger to 
Preference boomBoxSong changed from  to Eye of the Giger
Took choice 1312/2: &quot;Food Vibrations&quot;
choice.php?whichchoice=1312&option=2
Preference boomBoxSong changed from Eye of the Giger to Food Vibrations
Preference _boomBoxSongsLeft changed from 7 to 6
Setting soundtrack to Food Vibrations
```

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
