### PR TITLE
Everfull Darts Holster

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -211,6 +211,8 @@ void initializeSettings() {
 	set_property("auto_ignoreCombat", "");
 	set_property("auto_ignoreFlyer", false);
 	set_property("auto_instakill", "");
+	set_property("auto_instakillSource", "");
+	set_property("auto_instakillSuccess", false);
 	set_property("auto_modernzmobiecount", "");
 	set_property("auto_powerfulglove", "");
 	set_property("auto_otherstuff", "");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27858;	// Parse dart skill -> target
+since r27883	;	// Everything looks red disables darts: bullseye
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27854;	// feat: store everfull dart perks
+since r27858;	// Parse dart skill -> target
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27832;	// Spring Kick banish management
+since r27854;	// feat: store everfull dart perks
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27883	;	// Everything looks red disables darts: bullseye
+since r27883;	// Everything looks red disables darts: bullseye
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -721,6 +721,9 @@ boolean auto_run_choice(int choice, string page)
 		case 1500: // Like a Loded Stone
 			run_choice(2); // only come here to get shadow waters buff
 			break;
+		case 1525:
+			dartChoiceHandler(choice, options);
+			break;
 		default:
 			break;
 	}

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -83,6 +83,14 @@ boolean auto_post_adventure()
 		set_property("auto_parkaSpikesDeployed", false);
 	}
 
+	if(get_property("auto_instakillSource") != "" && get_property("auto_instakillSuccess").to_boolean())
+	{
+		auto_log_info("Successful instakill with: " + get_property("auto_instakillSource"), "blue");
+		handleTracker(get_property("lastEncounter"), get_property("auto_instakillSource"), "auto_instakill");
+		set_property("auto_instakillSource", "");
+		set_property("auto_instakillSuccess", false);
+	}
+
 	if(have_effect($effect[Eldritch Attunement]) > 0)
 	{
 		if(last_monster() != $monster[Eldritch Tentacle])

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -559,6 +559,14 @@ boolean auto_pre_adventure()
 		autoEquip($slot[acc3], DOCTOR_BAG);
 	}
 
+	item dartHolster = $item[Everful Dart Holster];
+	if(auto_haveDarts() && have_effect($effect[Everything Looks Red]) == 0)
+	{
+		auto_log_info("We don't have ELR so let's hit a bullseye");
+		autoEquip($slot[acc3], dartHolster);
+	}
+
+
 	equipOverrides();
 	kolhs_preadv(place);
 

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -213,6 +213,8 @@ boolean auto_pre_adventure()
 		item_amount($item[red rocket]) == 0 &&			// Don't buy if we already have one
 		auto_is_valid($item[red rocket]) &&				// or if it's not valid
 		can_eat() &&									// be in a path that can eat
+		my_class() != $class[Pig Skinner] &&			// don't want to use a red rocket in Pig Skinner
+		!auto_haveDarts() &&							// don't want to use a red rocket if we have darts
 		my_meat() > npc_price($item[red rocket]) + meatReserve())
 	{
 		retrieve_item(1, $item[red rocket]);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -559,7 +559,7 @@ boolean auto_pre_adventure()
 		autoEquip($slot[acc3], DOCTOR_BAG);
 	}
 
-	item dartHolster = $item[Everful Dart Holster];
+	item dartHolster = $item[Everfull Dart Holster];
 	if(auto_haveDarts() && have_effect($effect[Everything Looks Red]) == 0)
 	{
 		auto_log_info("We don't have ELR so let's hit a bullseye");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2961,7 +2961,7 @@ boolean auto_is_valid(item it)
 	{
 		return bhy_is_item_valid(it);
 	}
-	if(my_class() == $class[Pig Skinner]) //want to ignore Red Rocket in PS because Free-For-All is more important
+	if(my_class() == $class[Pig Skinner] || auto_haveDarts()) //want to ignore Red Rocket in PS because Free-For-All is more important. Darts bullseyes are also important
 	{
 		if(it == $item[Red Rocket]) return false;
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2961,10 +2961,6 @@ boolean auto_is_valid(item it)
 	{
 		return bhy_is_item_valid(it);
 	}
-	if(my_class() == $class[Pig Skinner] || auto_haveDarts()) //want to ignore Red Rocket in PS because Free-For-All is more important. Darts bullseyes are also important
-	{
-		if(it == $item[Red Rocket]) return false;
-	}
 	
 	return is_unrestricted(it);
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -545,6 +545,7 @@ boolean auto_haveSpringShoes();
 boolean auto_haveDarts();
 void dartChoiceHandler(int choice, string[int] options);
 int dartBullseyeChance();
+int dartELRcd();
 skill dartSkill();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -542,6 +542,9 @@ void auto_useWardrobe();
 ########################################################################################################
 //Defined in autoscend/iotms/mr2024.ash
 boolean auto_haveSpringShoes();
+boolean auto_haveDarts();
+void dartChoiceHandler(int choice, string[int] options);
+skill dartSkill();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -544,6 +544,7 @@ void auto_useWardrobe();
 boolean auto_haveSpringShoes();
 boolean auto_haveDarts();
 void dartChoiceHandler(int choice, string[int] options);
+int dartBullseyeChance();
 skill dartSkill();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -364,7 +364,8 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 
 		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills) && dartBullseyeChance() >= 50)
 		{
-			handleTracker(enemy, $skill[Darts: Aim for the Bullseye], "auto_instakill");
+			set_property("auto_instakillSource", "darts bullseye");
+			set_property("auto_instakillSuccess", true);
 			loopHandlerDelayAll();
 			return useSkill($skill[Darts: Aim for the Bullseye]);
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -362,7 +362,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			return useSkill($skill[lightning strike]);
 		}
 
-		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills) && dartBullseyeChance() == 100)
+		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills) && dartBullseyeChance() >= 50)
 		{
 			handleTracker(enemy, $skill[Darts: Aim for the Bullseye], "auto_instakill");
 			loopHandlerDelayAll();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -362,7 +362,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			return useSkill($skill[lightning strike]);
 		}
 
-		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills) && dartBullseyeChance() >= 50)
+		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills))
 		{
 			set_property("auto_instakillSource", "darts bullseye");
 			set_property("auto_instakillSuccess", true);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -362,7 +362,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			return useSkill($skill[lightning strike]);
 		}
 
-		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills))
+		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills) && dartBullseyeChance() == 100)
 		{
 			handleTracker(enemy, $skill[Darts: Aim for the Bullseye], "auto_instakill");
 			loopHandlerDelayAll();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -362,7 +362,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			return useSkill($skill[lightning strike]);
 		}
 
-		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills))
+		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && dartELRcd() <= 40)
 		{
 			set_property("auto_instakillSource", "darts bullseye");
 			set_property("auto_instakillSuccess", true);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -362,6 +362,12 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			return useSkill($skill[lightning strike]);
 		}
 
+		if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && (wantFreeKillNowEspecially || !reserveFreekills))
+		{
+			handleTracker(enemy, $skill[Darts: Aim for the Bullseye], "auto_instakill");
+			loopHandlerDelayAll();
+			return useSkill($skill[Darts: Aim for the Bullseye]);
+		}
 		if(canUse($skill[Chest X-Ray]) && equipped_amount($item[Lil\' Doctor&trade; bag]) > 0 && (get_property("_chestXRayUsed").to_int() < 3))
 		{
 			if((wantFreeKillNowEspecially || my_adventures() < 20) || inAftercore() || (my_daycount() >= 3))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -3,6 +3,9 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 	// stage 3 = debuff: delevel, stun, curse, damage over time
 	string retval;
 
+	// Set to false because instakills are in stage 2 and if we get here, it was not successful
+	set_property("auto_instakillSuccess", false);
+
 	//Unskip stage 2
 	if(get_property("auto_skipStage2").to_boolean()) set_property("auto_skipStage2", false);
 	

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -157,7 +157,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	}
 
 	//Everfull Dart Holder
-	if(get_property("dartsThrown").to_int() < 2 && have_equipped($item[Everfull Dart Holster]))
+	if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0)
 	{
 		return useSkill(dartSkill());
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -155,6 +155,12 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	{
 		return useSkill($skill[Surprisingly Sweet Stab]);
 	}
+
+	//Everfull Dart Holder
+	if(get_property("dartsThrown") < 2)
+	{
+		return useSkill(dartSkill());
+	}
     
 	//mortar shell is amazing. it really should not be limited to sauceror only.
 	if(canUse($skill[Stuffed Mortar Shell]) && (my_class() == $class[Sauceror]) && canSurvive(2.0) && (currentFlavour() != monster_element(enemy) || currentFlavour() == $element[none]))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -157,7 +157,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	}
 
 	//Everfull Dart Holder
-	if(get_property("dartsThrown") < 2)
+	if(get_property("dartsThrown").to_int() < 2 && have_equipped($item[Everfull Dart Holster]))
 	{
 		return useSkill(dartSkill());
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -58,6 +58,21 @@ int dartBullseyeChance()
 	return chance;
 }
 
+int dartELRcd()
+{
+	string[int] perks;
+	int cd = 50; // base cd is 50 turns
+	perks = split_string(get_property("everfullDartPerks").to_string().to_lower_case(), ",");
+	foreach perk in perks
+	{
+		if (contains_text(perks[perk], "impress"))
+		{
+			cd -= 10;
+		}	
+	}
+	return cd;
+}
+
 skill dartSkill()
 {
 	string[int] curDartboard;

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -52,10 +52,10 @@ int dartBullseyeChance()
 	perks = split_string(get_property("everfullDartPerks").to_string(), ",");
 	foreach perk in perks
 	{
-		if (contains_text(perk, "25%"))
+		if (contains_text(perks[perk], "25%"))
 		{
 			chance += 25;
-		}
+		}	
 	}
 	return chance;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -31,7 +31,7 @@ void dartChoiceHandler(int choice, string[int] options)
 	{
 		foreach idx, str in options
 		{
-			if(contains_text(str,perk))
+			if(contains_text(str.to_lower_case(),perk))
 			{
 				dcchoice = idx;
 				break;
@@ -47,10 +47,10 @@ int dartBullseyeChance()
 {
 	string[int] perks;
 	int chance = 25; // base bullseye chance is 25%
-	perks = split_string(get_property("everfullDartPerks").to_string(), ",");
+	perks = split_string(get_property("everfullDartPerks").to_string().to_lower_case(), ",");
 	foreach perk in perks
 	{
-		if (contains_text(perks[perk], "25%"))
+		if (contains_text(perks[perk], "better") || contains_text(perks[perk], "targeting"))
 		{
 			chance += 25;
 		}	
@@ -61,7 +61,7 @@ int dartBullseyeChance()
 skill dartSkill()
 {
 	string[int] curDartboard;
-	curDartboard = split_string(get_property("_currentDartboard").to_string(), ",");
+	curDartboard = split_string(get_property("_currentDartboard").to_string().to_lower_case(), ",");
 	foreach sk in curDartboard
 	{
 		if(contains_text(curDartboard[sk], "butt")) // get more items

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -61,21 +61,21 @@ skill dartSkill()
 	while (m.find())
 		out[m.group(2)] = m.group(1).to_skill();
 
-	foreach sk in out
+	foreach skst, sk in out
 	{
-		if(contains_text(sk, "Bullseye")) //Free-kill that wasn't taken care of in stage2
+		if(contains_text(skst, "Bullseye")) //Free-kill that wasn't taken care of in stage2
 		{
 			return sk;
 		}
-		else if(contains_text(sk, "butt")) //More items
+		else if(contains_text(skst, "butt")) //More items
 		{
 			return sk;
 		}
-		else if(contains_text(sk, "torso")) //More meat
+		else if(contains_text(skst, "torso") || contains_text(skst, "pseudopod")) //More meat
 		{
 			return sk;
 		}
 		else return to_skill(7513); // Darts: throw at %part1;
 	}
-	return to_skill(7513); // Darts: throw at %part1;
+	return $skill[none]; // If there aren't any darts available return the none skill
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -48,7 +48,7 @@ void dartChoiceHandler(int choice, string[int] options)
 int dartBullseyeChance()
 {
 	string[int] perks;
-	int chance = 25;
+	int chance = 25; // base bullseye chance is 25%
 	perks = split_string(get_property("everfullDartPerks").to_string(), ",");
 	foreach perk in perks
 	{
@@ -62,52 +62,17 @@ int dartBullseyeChance()
 
 skill dartSkill()
 {
-	//from c2t
-	/*skill[string] c2t_parts(string page) {
-		skill[string] out;
-		matcher m = create_matcher('<option\\s+value="(\\d+)"\\s+picurl="nicedart"\\s*>Darts:\\s+Throw\\s+at\\s+([^\\(]+)\\s+\\(',page);
-		while (m.find())
-			out[m.group(2)] = m.group(1).to_skill();
-		return out;
-	}*/
-	/*skill[string] out;
-	string page = visit_url('fight.php');
-	matcher m = create_matcher('<option\\s+value="(\\d+)"\\s+picurl="nicedart"\\s*>Darts:\\s+Throw\\s+at\\s+([^\\(]+)\\s+\\(',page);
-	while (m.find())
-		out[m.group(2)] = m.group(1).to_skill();
-
-	foreach skst, sk in out
-	{
-		if(contains_text(skst, "Bullseye")) //Free-kill that wasn't taken care of in stage2
-		{
-			return sk;
-		}
-		else if(contains_text(skst, "butt")) //More items
-		{
-			return sk;
-		}
-		else if(contains_text(skst, "torso") || contains_text(skst, "pseudopod")) //More meat
-		{
-			return sk;
-		}
-		else return to_skill(7513); // Darts: throw at %part1;
-	}
-	return $skill[none]; // If there aren't any darts available return the none skill*/
 	string[int] curDartboard;
 	curDartboard = split_string(get_property("_currentDartboard").to_string(), ",");
 	foreach sk in curDartboard
 	{
-		//auto_log_info("Searching for parts in " + curDartboard[sk], "blue");
-		//set_property("auto_interrupt", true);
-		if(contains_text(curDartboard[sk], "butt"))
+		if(contains_text(curDartboard[sk], "butt")) // get more items
 		{
-			//set_property("auto_interrupt", true);
 			auto_log_info("Going for the butt", "blue");
 			return to_skill(substring(curDartboard[sk],0,4).to_int());
 		}
-		else if(contains_text(curDartboard[sk], "torso") || contains_text(sk, "pseudopod"))
+		else if(contains_text(curDartboard[sk], "torso") || contains_text(sk, "pseudopod")) //get more meat
 		{
-			//set_property("auto_interrupt", true);
 			auto_log_info("Going for the chest", "blue");
 			return to_skill(substring(curDartboard[sk],0,4).to_int());
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -25,27 +25,21 @@ void dartChoiceHandler(int choice, string[int] options)
 	int dcchoice = 0;
 	foreach idx, str in options
 	{
-		if(contains_text(str,"25%") && dcchoice == 0) //Higher chance of getting a Bullseye
-		{
-			dcchoice = idx;
-			break;
-		}
-		else if(contains_text(str,"impress") && dcchoice == 0) //Shorter CD on ELR after Bullseye
-		{
-			dcchoice = idx;
-			break;
-		}
-		else if(contains_text(str,"Butt") && dcchoice == 0) //Get all that junk in the trunk (butt)
-		{
-			dcchoice = idx;
-			break;
-		}
-		else
-		{
-			dcchoice = 1;
-			break;
-		}
+		auto_log_info("choice " + idx + " is " + str, "blue");
 	}
+	foreach perk in $strings[better,targeting,bullseye,butt] //Ranked as 1. bullseye chance, 2. Shorter ELR CD, 3. Butt Awareness, 4. Everything else
+	{
+		foreach idx, str in options
+		{
+			if(contains_text(str,perk))
+			{
+				dcchoice = idx;
+				break;
+			}
+		}
+		if(dcchoice != 0) break;
+	}
+	if(dcchoice == 0) dcchoice = 1; //if choice is not set, just choose the 1st option
 	run_choice(dcchoice);
 }
 

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -52,7 +52,7 @@ int dartBullseyeChance()
 	perks = split_string(get_property("everfullDartPerks").to_string(), ",");
 	foreach perk in perks
 	{
-		if (contains_text("25%"))
+		if (contains_text(perk, "25%"))
 		{
 			chance += 25;
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -27,7 +27,7 @@ void dartChoiceHandler(int choice, string[int] options)
 	{
 		auto_log_info("choice " + idx + " is " + str, "blue");
 	}
-	foreach perk in $strings[better,targeting,bullseye,butt] //Ranked as 1. bullseye chance, 2. Shorter ELR CD, 3. Butt Awareness, 4. Everything else
+	foreach perk in $strings[impress,better,targeting,butt] //Ranked as 1. Shorter ELR CD, 2. bullseye chance, 3. Butt Awareness, 4. Everything else
 	{
 		foreach idx, str in options
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -8,3 +8,74 @@ boolean auto_haveSpringShoes()
 	}
 	return false;
 }
+
+boolean auto_haveDarts()
+{
+	if(auto_is_valid($item[Everfull Dart Holster]) && possessEquipment($item[Everfull Dart Holster]))
+	{
+		return true;
+	}
+	return false;
+}
+
+void dartChoiceHandler(int choice, string[int] options)
+{
+	auto_log_info("dartChoiceHandler Running choice " + choice, "blue");
+	
+	int dcchoice = 0;
+	foreach idx, str in options
+	{
+		if(contains_text(str,"impress") && dcchoice == 0) //Shorter CD on ELR after Bullseye
+		{
+			dcchoice = idx;
+		}
+		else if(contains_text(str,"25%") && dcchoice == 0) //Higher chance of getting a Bullseye
+		{
+			dcchoice = idx;
+		}
+		else if(contains_text(str,"Butt") && dcchoice == 0) //Get all that junk in the trunk (butt)
+		{
+			dcchoice = idx;
+		}
+		else
+		{
+			dcchoice = 1;
+		}
+	}
+	run_choice(dcchoice);
+}
+
+skill dartSkill()
+{
+	//from c2t
+	/*skill[string] c2t_parts(string page) {
+		skill[string] out;
+		matcher m = create_matcher('<option\\s+value="(\\d+)"\\s+picurl="nicedart"\\s*>Darts:\\s+Throw\\s+at\\s+([^\\(]+)\\s+\\(',page);
+		while (m.find())
+			out[m.group(2)] = m.group(1).to_skill();
+		return out;
+	}*/
+	skill[string] out;
+	string page = visit_url('fight.php');
+	matcher m = create_matcher('<option\\s+value="(\\d+)"\\s+picurl="nicedart"\\s*>Darts:\\s+Throw\\s+at\\s+([^\\(]+)\\s+\\(',page);
+	while (m.find())
+		out[m.group(2)] = m.group(1).to_skill();
+
+	foreach sk in out
+	{
+		if(contains_text(sk, "Bullseye")) //Free-kill that wasn't taken care of in stage2
+		{
+			return sk;
+		}
+		else if(contains_text(sk, "butt")) //More items
+		{
+			return sk;
+		}
+		else if(contains_text(sk, "torso")) //More meat
+		{
+			return sk;
+		}
+		else return to_skill(7513); // Darts: throw at %part1;
+	}
+	return to_skill(7513); // Darts: throw at %part1;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -25,11 +25,11 @@ void dartChoiceHandler(int choice, string[int] options)
 	int dcchoice = 0;
 	foreach idx, str in options
 	{
-		if(contains_text(str,"impress") && dcchoice == 0) //Shorter CD on ELR after Bullseye
+		if(contains_text(str,"25%") && dcchoice == 0) //Higher chance of getting a Bullseye
 		{
 			dcchoice = idx;
 		}
-		else if(contains_text(str,"25%") && dcchoice == 0) //Higher chance of getting a Bullseye
+		else if(contains_text(str,"impress") && dcchoice == 0) //Shorter CD on ELR after Bullseye
 		{
 			dcchoice = idx;
 		}
@@ -45,6 +45,21 @@ void dartChoiceHandler(int choice, string[int] options)
 	run_choice(dcchoice);
 }
 
+int dartBullseyeChance()
+{
+	string[int] perks;
+	int chance = 25;
+	perks = split_string(get_property("everfullDartPerks").to_string(), ",");
+	foreach perk in perks
+	{
+		if (contains_text("25%"))
+		{
+			chance += 25;
+		}
+	}
+	return chance;
+}
+
 skill dartSkill()
 {
 	//from c2t
@@ -55,7 +70,7 @@ skill dartSkill()
 			out[m.group(2)] = m.group(1).to_skill();
 		return out;
 	}*/
-	skill[string] out;
+	/*skill[string] out;
 	string page = visit_url('fight.php');
 	matcher m = create_matcher('<option\\s+value="(\\d+)"\\s+picurl="nicedart"\\s*>Darts:\\s+Throw\\s+at\\s+([^\\(]+)\\s+\\(',page);
 	while (m.find())
@@ -77,5 +92,25 @@ skill dartSkill()
 		}
 		else return to_skill(7513); // Darts: throw at %part1;
 	}
-	return $skill[none]; // If there aren't any darts available return the none skill
+	return $skill[none]; // If there aren't any darts available return the none skill*/
+	string[int] curDartboard;
+	curDartboard = split_string(get_property("_currentDartboard").to_string(), ",");
+	foreach sk in curDartboard
+	{
+		//auto_log_info("Searching for parts in " + curDartboard[sk], "blue");
+		//set_property("auto_interrupt", true);
+		if(contains_text(curDartboard[sk], "butt"))
+		{
+			//set_property("auto_interrupt", true);
+			auto_log_info("Going for the butt", "blue");
+			return to_skill(substring(curDartboard[sk],0,4).to_int());
+		}
+		else if(contains_text(curDartboard[sk], "torso") || contains_text(sk, "pseudopod"))
+		{
+			//set_property("auto_interrupt", true);
+			auto_log_info("Going for the chest", "blue");
+			return to_skill(substring(curDartboard[sk],0,4).to_int());
+		}
+	}
+	return to_skill(7513); // If there aren't any darts available return the Darts: Throw at %PART1
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -28,18 +28,22 @@ void dartChoiceHandler(int choice, string[int] options)
 		if(contains_text(str,"25%") && dcchoice == 0) //Higher chance of getting a Bullseye
 		{
 			dcchoice = idx;
+			break;
 		}
 		else if(contains_text(str,"impress") && dcchoice == 0) //Shorter CD on ELR after Bullseye
 		{
 			dcchoice = idx;
+			break;
 		}
 		else if(contains_text(str,"Butt") && dcchoice == 0) //Get all that junk in the trunk (butt)
 		{
 			dcchoice = idx;
+			break;
 		}
 		else
 		{
 			dcchoice = 1;
+			break;
 		}
 	}
 	run_choice(dcchoice);


### PR DESCRIPTION
# Description

Implements Everfull Dart Holster. This force equips the Holster if Everything Looks Red is not active to ensure we can Bullseye when it is ready. It will only try to Bullseye if the % chance is >= 50%. Will auto-upgrade perks as the choice adventure comes up at the end of combat. In stage 5 of combat we will use as many darts as possible to increase perks faster

## How Has This Been Tested?

Many, many Standard Normal runs across all classes

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
