### PR TITLE
update excavator to loathers

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -2,5 +2,5 @@ github Ezandora/Detective-Solver
 github Ezandora/Helix-Fossil
 github Ezandora/Far-Future
 github Ezandora/Voting-Booth
-github gausie/excavator release
+github loathers/excavator release
 github loathers/combo release


### PR DESCRIPTION
# Description

Excavator is on loathers now, use that path instead of the git url redirect

## How Has This Been Tested?

n/a

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
