### PR TITLE
Change Bonerdagon evilness check to 999

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -333,7 +333,7 @@ boolean L7_crypt()
 		return autoAdv($location[The Defiled Cranny]);
 	}
 
-	if(get_property("cyrptTotalEvilness").to_int() <= 0)
+	if(get_property("cyrptTotalEvilness").to_int() == 999)
 	{
 		if(my_class() == $class[seal clubber] && auto_have_skill($skill[Iron Palm Technique]) && (have_effect($effect[Iron Palms]) == 0))
 		{


### PR DESCRIPTION
Checking for 999 evilness instead of <= 0 to determine if Bonerdagon is ready to be fought

# Description

Currently autoscend doesn't kill the Bonerdagon.
It checks totalEvilness to be less than or equal to 0 before trying to adventure in the Haert of the Cyrpt.

This changes the evilness check to be 999 - which should only be reached if all 4 sub-zones are cleared and the Haert is open.

## How Has This Been Tested?

Fairly minimal testing.

Before change:
```
[DEBUG] Attempting to execute task 48 L7_crypt
Using 1 Evilometer...
Finished using 1 Evilometer.
Updating inventory...
Preference _concoctionDatabaseRefreshes changed from 430 to 431
[DEBUG] Attempting to execute task 49 L6_friarsGetParts
```
Added some debug statements to check, and its getting to the end of `L7_crypt` function, and returning false.
Current prefs:
```
questL07Cyrptic - started
cyrptAlcoveEvilness - 0
cyrptCrannyEvilness - 0
cyrptNicheEvilness  - 0
cyrptNookEvilness  - 0
cyrptTotalEvilness - 999
```

After change:
```
[DEBUG] Attempting to execute task 48 L7_crypt
Using 1 Evilometer...
Finished using 1 Evilometer.
Updating inventory...
Preference _concoctionDatabaseRefreshes changed from 434 to 435
--> [INFO] Target hp => 901 - Considering restore options at 784/901 HP with 1560/1680 MP
--> [INFO] Active Negative Effects => []
--> [DEBUG] Calculating restore objective values.
--> [INFO] Loading restoration data.
--> [INFO] Using skill cannelloni cocoon as restore.
--> Casting Cannelloni Cocoon 1 times...
--> You gain 117 hit points
--> Cannelloni Cocoon was successfully cast.
--> Preference auto_mcd_target changed from 0 to 10
--> Preference auto_nextEncounter changed from to Bonerdagon
// These last 3 lines were a custom check I'd placed initially, which wasn't being reached. Its now being reached. I added a wait so I could cancel the script for testing without it progressing
--> Testing to see if we even get here...
--> Countdown: 15 seconds...
--> KoLmafia declares world peace.
```

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
