### PR TITLE
Apriling band implementation, and smoe updates to Kingdom of Exploathing.

### DIFF
--- a/BUILD/task_order/default.dat
+++ b/BUILD/task_order/default.dat
@@ -90,6 +90,8 @@ L2_mosquito
 setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
 setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# There's an extra task in KoE
+LX_koeInvaderHandler
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
 L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -155,6 +155,105 @@ Avatar of Jarlsberg	54	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 Avatar of Jarlsberg	55	L13_towerAscent
 Avatar of Jarlsberg	56	LX_attemptPowerLevel
 
+default	0	LX_freeCombatsTask
+default	1	woods_questStart
+default	2	LX_unlockPirateRealm
+default	3	catBurglarHeist
+default	4	auto_breakfastCounterVisit
+default	5	chateauPainting
+default	6	LX_setWorkshed
+default	7	LX_galaktikSubQuest
+default	8	L9_leafletQuest
+default	9	L5_findKnob
+default	10	L12_sonofaPrefix
+default	11	LX_burnDelay
+default	12	LX_summonMonster
+# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
+default	13	LM_edTheUndying
+default	14	LX_bugbearInvasion
+default	15	LX_lowkeySummer
+# make sure we don't waste turns of Ultrahydrated doing something else.
+default	16	L11_aridDesert	L11_hasUltrahydrated
+# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+default	17	L11_shenStartQuest
+# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+default	18	finishBuildingSmutOrcBridge
+# Underground Adventuring for CMC/Breathitin.
+default	19	LX_goingUnderground
+# Burn Breathitin charges
+default	20	LX_useBreathitinCharges
+# Guild access.
+default	21	LX_guildUnlock
+#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
+default	22	LX_unlockDesert
+default	23	LX_lockPicking
+default	24	LX_fatLootToken
+#	Get the Steel Organ if the user wants it (needs L6 quest complete)
+default	25	LX_steelOrgan
+# open up delay zones.
+default	26	LX_spookyravenManorFirstFloor
+# open up zones where we want to force non-combats.
+# Open up underground zones so they are available for Breathitin.
+default	27	L5_getEncryptionKey
+default	28	L5_findKnob
+#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
+default	29	L12_islandWar
+# Start the macguffin quest
+default	30	L11_blackMarket
+default	31	L11_forgedDocuments
+default	32	L11_mcmuffinDiary
+default	33	L11_getBeehive
+# open the hidden city up (delay zones)
+default	34	L2_mosquito
+default	35	LX_unlockHiddenTemple
+default	36	L6_dakotaFanning
+default	37	L11_unlockHiddenCity
+# Murder pygmies for the ancient amulet.
+default	38	L11_hiddenCityZones
+default	39	L11_hiddenCity
+# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+default	40	LX_spookyravenManorSecondFloor
+default	41	L11_mauriceSpookyraven
+# Lay the smack down on those Jerk Copperhead twins
+default	42	L11_talismanOfNam
+# Open up the top of the beanstalk.
+default	43	L10_plantThatBean
+# Clean up the plains
+default	44	L10_rainOnThePlains
+# Get Black Angus his pizza
+default	45	L9_chasmBuild
+default	46	L9_highLandlord
+#  Kill Groar because *we* are the monsters.
+default	47	L8_trapperQuest
+# Kill the undead? Is this an oxymoron?
+default	48	L7_crypt
+# Cleanse the taint.
+default	49	L6_friarsGetParts
+# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
+default	50	L11_palindome
+default	51	L11_aridDesert
+default	52	L11_unlockPyramid
+default	53	L11_unlockEd
+default	54	L11_defeatEd
+#	Finish off the Goblin King.
+default	55	L5_slayTheGoblinKing
+# Show the Boss bat who's boss.
+default	56	L4_batCave
+# Fix that dripping tap.
+default	57	L3_tavern
+# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
+default	58	L2_mosquito
+# release the softblock on delay burning
+default	59	setSoftblockDelay	allowSoftblockDelay
+# release the softblock on Underground Adventures
+default	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# There's an extra task in KoE
+default	61	LX_koeInvaderHandler()
+# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
+default	62	L13_towerAscent
+# if all else fails, powerlevel like there's no tomorrow.
+default	63	LX_attemptPowerLevel
+
 Legacy of Loathing	0	LX_freeCombatsTask
 Legacy of Loathing	1	woods_questStart
 Legacy of Loathing	2	LX_unlockPirateRealm
@@ -376,101 +475,4 @@ Zombie Slayer	53	setSoftblockDelay	allowSoftblockDelay
 Zombie Slayer	54	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 Zombie Slayer	55	L13_towerAscent
 Zombie Slayer	56	LX_attemptPowerLevel
-
-default	0	LX_freeCombatsTask
-default	1	woods_questStart
-default	2	LX_unlockPirateRealm
-default	3	catBurglarHeist
-default	4	auto_breakfastCounterVisit
-default	5	chateauPainting
-default	6	LX_setWorkshed
-default	7	LX_galaktikSubQuest
-default	8	L9_leafletQuest
-default	9	L5_findKnob
-default	10	L12_sonofaPrefix
-default	11	LX_burnDelay
-default	12	LX_summonMonster
-# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
-default	13	LM_edTheUndying
-default	14	LX_bugbearInvasion
-default	15	LX_lowkeySummer
-# make sure we don't waste turns of Ultrahydrated doing something else.
-default	16	L11_aridDesert	L11_hasUltrahydrated
-# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-default	17	L11_shenStartQuest
-# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
-default	18	finishBuildingSmutOrcBridge
-# Underground Adventuring for CMC/Breathitin.
-default	19	LX_goingUnderground
-# Burn Breathitin charges
-default	20	LX_useBreathitinCharges
-# Guild access.
-default	21	LX_guildUnlock
-#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
-default	22	LX_unlockDesert
-default	23	LX_lockPicking
-default	24	LX_fatLootToken
-#	Get the Steel Organ if the user wants it (needs L6 quest complete)
-default	25	LX_steelOrgan
-# open up delay zones.
-default	26	LX_spookyravenManorFirstFloor
-# open up zones where we want to force non-combats.
-# Open up underground zones so they are available for Breathitin.
-default	27	L5_getEncryptionKey
-default	28	L5_findKnob
-#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-default	29	L12_islandWar
-# Start the macguffin quest
-default	30	L11_blackMarket
-default	31	L11_forgedDocuments
-default	32	L11_mcmuffinDiary
-default	33	L11_getBeehive
-# open the hidden city up (delay zones)
-default	34	L2_mosquito
-default	35	LX_unlockHiddenTemple
-default	36	L6_dakotaFanning
-default	37	L11_unlockHiddenCity
-# Murder pygmies for the ancient amulet.
-default	38	L11_hiddenCityZones
-default	39	L11_hiddenCity
-# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-default	40	LX_spookyravenManorSecondFloor
-default	41	L11_mauriceSpookyraven
-# Lay the smack down on those Jerk Copperhead twins
-default	42	L11_talismanOfNam
-# Open up the top of the beanstalk.
-default	43	L10_plantThatBean
-# Clean up the plains
-default	44	L10_rainOnThePlains
-# Get Black Angus his pizza
-default	45	L9_chasmBuild
-default	46	L9_highLandlord
-#  Kill Groar because *we* are the monsters.
-default	47	L8_trapperQuest
-# Kill the undead? Is this an oxymoron?
-default	48	L7_crypt
-# Cleanse the taint.
-default	49	L6_friarsGetParts
-# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-default	50	L11_palindome
-default	51	L11_aridDesert
-default	52	L11_unlockPyramid
-default	53	L11_unlockEd
-default	54	L11_defeatEd
-#	Finish off the Goblin King.
-default	55	L5_slayTheGoblinKing
-# Show the Boss bat who's boss.
-default	56	L4_batCave
-# Fix that dripping tap.
-default	57	L3_tavern
-# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-default	58	L2_mosquito
-# release the softblock on delay burning
-default	59	setSoftblockDelay	allowSoftblockDelay
-# release the softblock on Underground Adventures
-default	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
-# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-default	61	L13_towerAscent
-# if all else fails, powerlevel like there's no tomorrow.
-default	62	LX_attemptPowerLevel
 

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -248,7 +248,7 @@ default	59	setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
 default	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 # There's an extra task in KoE
-default	61	LX_koeInvaderHandler()
+default	61	LX_koeInvaderHandler
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
 default	62	L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1137,6 +1137,7 @@ boolean dailyEvents()
 	auto_buyFrom2002MrStore();
 	auto_useBlackMonolith();
 	auto_scepterSkills();
+	auto_getAprilingBandItems();
 	
 	return true;
 }

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27832;	// Spring Kick banish management
+since r27891;	// April band CLI command
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -1137,6 +1137,7 @@ boolean dailyEvents()
 	auto_buyFrom2002MrStore();
 	auto_useBlackMonolith();
 	auto_scepterSkills();
+	auto_getAprilingBandItems();
 	
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -728,6 +728,14 @@ void finalizeMaximize(boolean speculative)
 			addBonusToMaximize($item[spring shoes], 50);
 		}
 	}
+	// We still need pixels in KoE, badly.
+	if(in_koe() && auto_hasPowerfulGlove())
+	{
+		if(koe_NeedWhitePixels())
+		{
+			addBonusToMaximize($item[powerful glove], 250);
+		}
+	}
 	if(pathHasFamiliar())
 	{
 		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -717,6 +717,17 @@ void finalizeMaximize(boolean speculative)
 		}
 	}
 	
+	if(auto_haveSpringShoes())
+	{
+		if(item_amount($item[ultra-soft ferns])<4 || item_amount($item[crunchy brush])<4) // collect the spring shoes potions
+		{
+			addBonusToMaximize($item[spring shoes], 200);
+		}
+		else // just add a little bonus for the MP generation
+		{
+			addBonusToMaximize($item[spring shoes], 50);
+		}
+	}
 	if(pathHasFamiliar())
 	{
 		addBonusToMaximize($item[familiar scrapbook], 200); // scrap generation for banish/exp

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -87,6 +87,9 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 		}
 		return false;
 	}
+	
+	// Do the April band
+	auto_setAprilBandCombat();
 
 	// Now handle buffs that cost MP, items or other resources
 
@@ -256,6 +259,9 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 		}
 		return false;
 	}
+	
+	// Do the April band
+	auto_setAprilBandNonCombat();
 
 	// Now handle buffs that cost MP, items or other resources
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2195,6 +2195,10 @@ boolean evokeEldritchHorror()
 
 boolean fightScienceTentacle()
 {
+	if(in_koe())
+	{
+		return false;
+	}
 	if(get_property("_eldritchTentacleFought").to_boolean())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1236,6 +1236,8 @@ int cloversAvailable(boolean override)
 		{
 			numClovers += 1;
 		}
+		//Get from April band
+		numClovers += auto_AprilSaxLuckyLeft();
 	}
 
 	//count Astral Energy Drinks which we have room to chew. Must specify ID since there are now 2 items with this name
@@ -1269,6 +1271,18 @@ boolean cloverUsageInit(boolean override)
 	if (have_effect($effect[Lucky!]) > 0)
 	{
 		return true;
+	}
+	
+	if (auto_AprilSaxLuckyLeft() > 0)
+	{
+		if (auto_playAprilSax()) {
+			auto_log_info("Clover usage initialized, using Apriling sax.");
+			return true;
+		}
+		else
+		{
+			auto_log_warning("Did not acquire Lucky! after playing the Apriling sax.");
+		}
 	}
 
 	//Use August Scepter skill if we can
@@ -4038,6 +4052,17 @@ boolean _auto_forceNextNoncombat(location loc, boolean speculative)
 			abort("Attempted to force a noncombat with [Cincho] but was unable to.");
 		}
 		set_property("auto_forceNonCombatSource", "cincho");
+		return true;
+	}
+	else if(auto_AprilTubaForcesLeft()>0)
+	{
+		if(speculative) return true;
+		auto_playAprilTuba();
+		if(!auto_haveQueuedForcedNonCombat())
+		{
+			abort("Attempted to force a noncombat with [Apriling tuba] but was unable to.");
+		}
+		set_property("auto_forceNonCombatSource", "Apriling tuba");
 		return true;
 	}
 	else if(auto_hasParka() && get_property("_spikolodonSpikeUses") < 5 && hasTorso())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1490,6 +1490,10 @@ boolean isUnclePAvailable()
 	{
 		return false;
 	}
+	if(in_koe())
+	{
+		return false;
+	}
 	string page_text = visit_url("place.php?whichplace=desertbeach");
 	return !page_text.contains_text("You don't know where a desert beach is");
 }

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -750,6 +750,7 @@ boolean in_koe();
 boolean koe_initializeSettings();
 int koe_rmi_count();
 boolean koe_acquire_rmi();
+boolean koe_NeedWhitePixels();
 boolean LX_koeInvaderHandler();
 item koe_L12FoodSelect();
 void koe_RationingOutDestruction();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -542,6 +542,15 @@ void auto_useWardrobe();
 ########################################################################################################
 //Defined in autoscend/iotms/mr2024.ash
 boolean auto_haveSpringShoes();
+boolean auto_haveAprilingBandHelmet();
+boolean auto_getAprilingBandItems();
+boolean auto_playAprilSax();
+boolean auto_playAprilTuba();
+boolean auto_setAprilBandNonCombat();
+boolean auto_setAprilBandCombat();
+boolean auto_setAprilBandDrops();
+int auto_AprilSaxLuckyLeft();
+int auto_AprilTubaForcesLeft();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -90,7 +90,12 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		{
 			return "item " +hand_1;
 		}
-		abort("Uh oh, I ran out of healing items to use against your shadow");
+		if (item_amount($item[scented massage oil])==0) {
+			abort("Uh oh, I ran out of healing items to use against your shadow");
+		}
+		else {
+		  abort("Uh oh, I ran out of simple healing items to use against your shadow. You could win manually with Scented Massage oil though.");
+		}
 	}
 
 	if(enemy == $monster[Wall Of Meat])

--- a/RELEASE/scripts/autoscend/combat/auto_combat_kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_kingdom_of_exploathing.ash
@@ -4,6 +4,11 @@ string auto_combatExploathingStage1(int round, monster enemy, string text)
 {
 	##stage1 = 1st round actions: puzzle boss, banish, escape, pickpocket, etc. things that need to be done before debuff
 	
+	if (enemy == $monster[The Invader] && canUse($skill[Lunging Thrust-Smack], false) && have_equipped($item[June Cleaver]))
+	{
+		return useSkill($skill[Lunging Thrust-Smack], false);
+	}
+	
 	if (enemy == $monster[The Invader] && canUse($skill[Weapon of the Pastalord], false))
 	{
 		return useSkill($skill[Weapon of the Pastalord], false);

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -7,4 +7,76 @@ boolean auto_haveSpringShoes()
 		return true;
 	}
 	return false;
+	
+}
+
+boolean auto_haveAprilingBandHelmet()
+{
+	if(auto_is_valid($item[Apriling band helmet]) && available_amount($item[Apriling band helmet]) > 0 )
+	{
+		return true;
+	}
+	return false;
+}
+
+boolean auto_getAprilingBandItems()
+{
+	if(!auto_haveAprilingBandHelmet()) {return false;}
+	boolean have_sax  = available_amount($item[Apriling band saxophone]) > 0;
+	boolean have_tuba = available_amount($item[Apriling band tuba]     ) > 0;
+	if (!have_tuba) { cli_execute("aprilband item tuba"); }
+	if (!have_sax ) { cli_execute("aprilband item saxophone"); }
+	
+	have_sax  = available_amount($item[Apriling band saxophone]) > 0;
+	have_tuba = available_amount($item[Apriling band tuba]     ) > 0;
+	
+	return have_sax && have_tuba;
+}
+
+boolean auto_playAprilSax()
+{
+	cli_execute("aprilband play saxophone");
+	return have_effect($effect[Lucky!]).to_boolean();
+}
+
+boolean auto_playAprilTuba()
+{
+	cli_execute("aprilband play tuba");
+	return get_property("noncombatForcerActive").to_boolean();
+}
+
+boolean auto_setAprilBandNonCombat()
+{
+	if(have_effect($effect[Apriling Band Patrol Beat]).to_boolean()) {return true;}
+	if(!auto_haveAprilingBandHelmet()) {return false;}
+	cli_execute("aprilband effect nc");
+	return have_effect($effect[Apriling Band Patrol Beat]).to_boolean();
+}
+
+boolean auto_setAprilBandCombat()
+{
+	if(have_effect($effect[Apriling Band Battle Cadence]).to_boolean()) {return true;}
+	if(!auto_haveAprilingBandHelmet()) {return false;}
+	cli_execute("aprilband effect c");
+	return have_effect($effect[Apriling Band Battle Cadence]).to_boolean();
+}
+
+boolean auto_setAprilBandDrops()
+{
+	if(have_effect($effect[Apriling Band Celebration Bop]).to_boolean()) {return true;}
+	if(!auto_haveAprilingBandHelmet()) {return false;}
+	cli_execute("aprilband effect drop");
+	return have_effect($effect[Apriling Band Celebration Bop]).to_boolean();
+}
+
+int auto_AprilSaxLuckyLeft()
+{
+	if(!auto_haveAprilingBandHelmet()) return 0;
+	return 3-get_property("_aprilBandSaxophoneUses").to_int();
+}
+
+int auto_AprilTubaForcesLeft()
+{
+	if(!auto_haveAprilingBandHelmet()) return 0;
+	return 3-get_property("_aprilBandTubaUses").to_int();
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -24,8 +24,10 @@ boolean auto_getAprilingBandItems()
 	if(!auto_haveAprilingBandHelmet()) {return false;}
 	boolean have_sax  = available_amount($item[Apriling band saxophone]) > 0;
 	boolean have_tuba = available_amount($item[Apriling band tuba]     ) > 0;
-	if (!have_tuba) { cli_execute("aprilband item tuba"); }
-	if (!have_sax ) { cli_execute("aprilband item saxophone"); }
+	int instruments_so_far = get_property("_aprilBandInstruments").to_int();
+	if (!have_tuba && instruments_so_far < 2) { cli_execute("aprilband item tuba"); }
+	instruments_so_far = get_property("_aprilBandInstruments").to_int();
+	if (!have_sax && instruments_so_far < 2) { cli_execute("aprilband item saxophone"); }
 	
 	have_sax  = available_amount($item[Apriling band saxophone]) > 0;
 	have_tuba = available_amount($item[Apriling band tuba]     ) > 0;

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -12,6 +12,10 @@ boolean auto_haveSpringShoes()
 boolean auto_haveAprilingBandHelmet()
 {
 	if(auto_is_valid($item[Apriling band helmet]) && available_amount($item[Apriling band helmet]) > 0 )
+	{
+		return true;
+	}
+	return false;
 }
 
 boolean auto_getAprilingBandItems()

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -71,12 +71,14 @@ boolean auto_setAprilBandDrops()
 
 int auto_AprilSaxLuckyLeft()
 {
-	if(!auto_haveAprilingBandHelmet()) return 0;
+	if(!auto_haveAprilingBandHelmet()) {return 0;}
+	if(available_amount($item[Apriling band saxophone]) == 0) {return 0;}
 	return 3-get_property("_aprilBandSaxophoneUses").to_int();
 }
 
 int auto_AprilTubaForcesLeft()
 {
-	if(!auto_haveAprilingBandHelmet()) return 0;
+	if(!auto_haveAprilingBandHelmet()) {return 0;}
+	if(available_amount($item[Apriling band tuba]) == 0) {return 0;}
 	return 3-get_property("_aprilBandTubaUses").to_int();
 }

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -49,7 +49,7 @@ boolean LX_koeInvaderHandler()
 	{
 		return false;
 	}
-	if (internalQuestStatus("questL13Final") < 3 || get_property("spaceInvaderDefeated").to_boolean())
+	if (get_property("spaceInvaderDefeated").to_boolean())
 	{
 		// invader drops 10 white pixels so fight it before we do the hedge maze
 		// as we need elemental resists for both and we may be able to get enough

--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -70,6 +70,11 @@ boolean LX_koeInvaderHandler()
 	buffMaintain($effect[Elemental Saucesphere], 10, 1, 1);
 	buffMaintain($effect[Scariersauce], 10, 1, 1);
 	buffMaintain($effect[Scarysauce], 10, 1, 1);
+	buffMaintain($effect[Oiled-Up]);
+	
+	buffMaintain($effect[Minor Invulnerability]);
+	buffMaintain($effect[Feeling Peaceful]);
+	buffMaintain($effect[Covered in the Rainbow]);
 
 	resetMaximize();
 
@@ -91,27 +96,86 @@ boolean LX_koeInvaderHandler()
 	int turns = ceil(0.95 / damagePerRound);
 
 	int damageCap = 100 * my_daycount();
-
+	
+	// It's easiest to kill the invader in two hits with the June cleaver and Lunging Thrust Smack
+	if(have_skill($skill[Lunging Thrust-Smack]) && auto_is_valid($skill[Lunging Thrust-Smack]) &&
+	   auto_canUseJuneCleaver())
+	{
+		// To kill in 3 rounds, need 19 of each element, or 10 plus bend hell. Check we have it.
+		boolean have_19_each = true;
+		boolean have_10_each = true;
+		foreach el in "Cold;Hot;Sleaze;Spooky;Stench".split_string(";")
+		{
+			int damage_bonus = to_int(get_property("_juneCleaver"+el));
+			if (damage_bonus < 19) { have_19_each = false; }
+			if (damage_bonus < 10) { have_10_each = false; }
+		}
+		// Cast bend hell if needed
+		if (have_10_each)
+		{
+			if (have_skill($skill[Bend Hell]) && auto_is_valid($skill[Bend Hell]) &&
+			   !have_19_each)
+			{
+				buffMaintain($effect[Bendin\' Hell]);
+			}
+			if (have_effect($effect[Bendin\' Hell])>0)
+			{
+				have_19_each = true;
+			}
+		}
+		
+		// Actually go in for the kill
+		if (have_19_each)
+		{
+			acquireMP(24, 0);
+			auto_log_info("Attacking the Invader, using June Cleaver and LTS.", "blue");
+			addToMaximize("200 all res, +equip june cleaver");
+			boolean ret = autoAdv(1, $location[The Invader]);
+			if(have_effect($effect[Beaten Up]) > 0)
+			{
+				abort("We died to the invader. Do it manually please?");
+			}
+			return ret;
+	  }
+	}
+	// End of the June cleaver logic. Try a spell instead?
+	
 	// How many damage sources do we need?
 	if(have_skill($skill[Weapon of the Pastalord]) && auto_is_valid($skill[Weapon of the Pastalord]))
 	{
 		int sources = 2;
-		if(acquireOrPull($item[meteorb])) sources++;
+		item hot_source = $item[none];
+		if(item_amount($item[Big hot pepper]) > 0 && auto_is_valid($item[Big hot pepper]))
+		{
+			hot_source = $item[Big hot pepper];
+			sources++;
+		}
+		else if(acquireOrPull($item[meteorb]))
+		{
+			hot_source = $item[meteorb];
+			sources++;
+		}
+		
 		if(sources * turns * damageCap >= 1000)
 		{
 			foreach el in $elements[cold, hot, sleaze, spooky, stench]
 			{
 				auto_beachCombHead(el);
 			}
-			// Meteorb is going to add +hot, so remove that
+			// Meteorb/pepper is going to add +hot, so remove that
 			setFlavour($element[cold]);
 			buffMaintain($effect[Carol of the Hells], 50, 1, 1);
 			buffMaintain($effect[Song of Sauce], 150, 1, 1);
 			buffMaintain($effect[Glittering Eyelashes]);
 			acquireMP(100, 0);
-
+			
+			auto_log_info("Attacking the Invader, using Weapon of the Pastalord.", "blue");
 			// Use maximizer now that we are for sure fighting the Invader
 			addToMaximize("200 all res");
+			if (hot_source != $item[none])
+			{
+				addToMaximize("+equip "+to_string(hot_source));
+			}
 
 			boolean ret = autoAdv(1, $location[The Invader]);
 			if(have_effect($effect[Beaten Up]) > 0)
@@ -169,7 +233,7 @@ boolean L12_koe_clearBattlefield()
 	{
 		return false;
 	}
-	if(!haveWarOutfit())
+	if(!haveWarOutfit(true))
 	{
 		return false;
 	}
@@ -306,4 +370,11 @@ boolean L13_koe_towerNSNagamar()
 	}
 	abort("I failed to acquire [Wand of Nagamar]");
 	return false;	//must have return value even after an abort
+}
+
+boolean koe_NeedWhitePixels()
+{
+	if(!needDigitalKey()) { return false; }
+	int pixels_needed = to_boolean(get_property("spaceInvaderDefeated")) ? 30 : 20;
+	return item_amount($item[white pixel])<pixels_needed;
 }

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1192,6 +1192,10 @@ boolean L11_aridDesert()
 		if((item_amount($item[Worm-Riding Hooks]) > 0) && ((get_property("gnasirProgress").to_int() & 16) != 16))
 		{
 			pullXWhenHaveY($item[Drum Machine], 1, 0);
+			if(item_amount($item[Drum Machine]) == 0)
+			{
+				auto_makeMonkeyPawWish($item[Drum Machine]));
+			}
 			if(item_amount($item[Drum Machine]) > 0)
 			{
 				auto_log_info("Drum machine desert time!", "blue");

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1194,7 +1194,7 @@ boolean L11_aridDesert()
 			pullXWhenHaveY($item[Drum Machine], 1, 0);
 			if(item_amount($item[Drum Machine]) == 0)
 			{
-				auto_makeMonkeyPawWish($item[Drum Machine]));
+				auto_makeMonkeyPawWish($item[Drum Machine]);
 			}
 			if(item_amount($item[Drum Machine]) > 0)
 			{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1620,7 +1620,7 @@ boolean L13_towerNSTower()
 		cli_execute("scripts/autoscend/auto_post_adv.ash");
 		acquireHP();
 
-		int n_healing_items = item_amount($item[gauze garter]) + item_amount($item[filthy poultice]) + item_amount($item[red pixel potion]);
+		int n_healing_items = item_amount($item[gauze garter]) + item_amount($item[filthy poultice]) + item_amount($item[red pixel potion]) + item_amount($item[scented massage oil]);
 		if(in_plumber())
 		{
 			n_healing_items = item_amount($item[super deluxe mushroom]);
@@ -1638,17 +1638,27 @@ boolean L13_towerNSTower()
 			{
 				pullXWhenHaveY(it,1,item_amount(it));
 			}
-
-			int create_target = min(creatable_amount($item[red pixel potion]), pull_target - pulled_items);
-			if(create_target > 0)
+			
+			// If we're in Kingdom of Exploathing, there's no realm . Let's try clovering for massage oil instead
+			if (in_koe())
 			{
-				if(create(create_target, $item[red pixel potion]))
-				{
-					return true;
-				}
-				abort("I tried to create [red pixel potions] for the shadow and mysteriously failed");
+				cloverUsageInit();
+				autoAdv($location[Cobb\'s Knob Harem]);
+				if(cloverUsageRestart()) autoAdv($location[Cobb\'s Knob Harem]);
+				cloverUsageFinish();
 			}
-			return autoAdv($location[8-bit Realm]);
+			else {
+				int create_target = min(creatable_amount($item[red pixel potion]), pull_target - pulled_items);
+				if(create_target > 0)
+				{
+					if(create(create_target, $item[red pixel potion]))
+					{
+						return true;
+					}
+					abort("I tried to create [red pixel potions] for the shadow and mysteriously failed");
+				}
+				return autoAdv($location[8-bit Realm]);
+			}
 		}
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_09_monster5", $location[Noob Cave]);
 		return true;


### PR DESCRIPTION
# Description

This includes April's IOTM, the Apriling Band. It does four things with it.

- Summons the April Tuba and April Sax
- Generates lucky adventures using the April sax.
- Forces noncombats using the April Tuba.
- Uses the +combat and -combat intrinsic functions.

Additionally, this PR adds a priority to using the Spring Shoes, because they generate + and - combat potions, and also MP.

It adds a monkey paw wish usage to grab the Drum Machine if necessary.

Finally, this contains various changes/fixes to Kingdom of Exploathing, which was a bit broken. 

Fixes # (issue)

## How Has This Been Tested?

Standard HC ascension for the Apriling Band and Spring Shoes stuff. Half a KoE HC ascension for the changes there. This will be fully tested before merging.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
