### PR TITLE
Change Bonerdagon evilness check to include 999

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27832;	// Spring Kick banish management
+since r27897;	// additional monster parts
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -333,7 +333,7 @@ boolean L7_crypt()
 		return autoAdv($location[The Defiled Cranny]);
 	}
 
-	if(get_property("cyrptTotalEvilness").to_int() <= 0)
+	if( (get_property("cyrptTotalEvilness").to_int() <= 0) || (get_property("cyrptTotalEvilness").to_int() == 999) )
 	{
 		if(my_class() == $class[seal clubber] && auto_have_skill($skill[Iron Palm Technique]) && (have_effect($effect[Iron Palms]) == 0))
 		{


### PR DESCRIPTION
Checking for 999 evilness in addition to <= 0 to determine if Bonerdagon is ready to be fought.

# Description

Currently autoscend doesn't kill the Bonerdagon.
It checks totalEvilness to be less than or equal to 0 before trying to adventure in the Haert of the Cyrpt.

This changes the evilness check to include 999 - which should only be reached if all 4 sub-zones are cleared and the Haert is open.

## How Has This Been Tested?

I've run this with only checking 999, as well as the current suggested change which includes a check for 999 evilness, but also keeps the original <= 0 check.

I've monitored the prefs while autoscend is running, and as soon as all 4 sub-bosses are killed, the evilness seems to go straight to 999. 

Before change:
```
[DEBUG] Attempting to execute task 48 L7_crypt
Using 1 Evilometer...
Finished using 1 Evilometer.
Updating inventory...
Preference _concoctionDatabaseRefreshes changed from 430 to 431
[DEBUG] Attempting to execute task 49 L6_friarsGetParts
```
Added some debug statements to check, and its getting to the end of `L7_crypt` function, and returning false.
Current prefs:
```
questL07Cyrptic - started
cyrptAlcoveEvilness - 0
cyrptCrannyEvilness - 0
cyrptNicheEvilness  - 0
cyrptNookEvilness  - 0
cyrptTotalEvilness - 999
```

After change:
```
[DEBUG] Attempting to execute task 48 L7_crypt
Using 1 Evilometer...
Finished using 1 Evilometer.
Updating inventory...
Preference _concoctionDatabaseRefreshes changed from 434 to 435
Enters the bonerdagon prep --> [INFO] Target hp => 901 - Considering restore options at 784/901 HP with 1560/1680 MP
--> [INFO] Active Negative Effects => []
--> [DEBUG] Calculating restore objective values.
--> [INFO] Loading restoration data.
--> [INFO] Using skill cannelloni cocoon as restore.
--> Casting Cannelloni Cocoon 1 times...
--> You gain 117 hit points
--> Cannelloni Cocoon was successfully cast.
--> Preference auto_mcd_target changed from 0 to 10
--> Preference auto_nextEncounter changed from to Bonerdagon
```

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
