### PR TITLE
add additional monsters for free runs

### DIFF
--- a/BUILD/monsters/freerun.dat
+++ b/BUILD/monsters/freerun.dat
@@ -1,12 +1,11 @@
 Foodie Giant
-Possibility Giant
+Possibility Giant	prop:auto_hippyInstead==false
 Procrastination Giant
 Renaissance Giant
 Punk Rock Giant
 Raver Giant
 Steampunk Giant
 Irritating Series of Random Encounters
-MagiMechTech MechaMech
 Protagonist	!class:Ed the Undying
 bar
 spooky mummy
@@ -30,3 +29,5 @@ animated mahogany nightstand
 animated ornate nightstand
 animated rustic nightstand
 Wardröb nightstand
+drunken rat
+bunch of drunken rats

--- a/BUILD/monsters/freerun.dat
+++ b/BUILD/monsters/freerun.dat
@@ -1,0 +1,25 @@
+Foodie Giant
+Possibility Giant
+Procrastination Giant
+Renaissance Giant
+Punk Rock Giant
+Raver Giant
+Steampunk Giant
+Irritating Series of Random Encounters
+MagiMechTech MechaMech
+Protagonist	!class:Ed the Undying
+bar
+spooky mummy
+spooky vampire
+triffid
+warwelf	!class:Ed the Undying
+wolfman	!class:Ed the Undying
+cubist bull
+empty suit of armor
+guy with a pitchfork, and his wife
+claw-foot bathtub
+malevolent hair clog
+toilet papergeist
+Iiti Kitty
+tomb bat
+tomb servant	loc:The Upper Chamber

--- a/BUILD/monsters/freerun.dat
+++ b/BUILD/monsters/freerun.dat
@@ -23,3 +23,10 @@ toilet papergeist
 Iiti Kitty
 tomb bat
 tomb servant	loc:The Upper Chamber
+Knob Goblin Assistant Chef
+sleeping Knob Goblin Guard
+Sub-Assistant Knob Mad Scientist
+animated mahogany nightstand
+animated ornate nightstand
+animated rustic nightstand
+Wardröb nightstand

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -56,6 +56,32 @@ banish	49	Battlesuit Bugbear Type	path:Bugbear Invasion:loc:Engineering;!sniffed
 banish	50	ancient unspeakable bugbear	path:Bugbear Invasion;loc:Navigation;!sniffed:ancient unspeakable bugbear
 banish	51	trendy bugbear chef	path:Bugbear Invasion;loc:Galley;loc:Gallery;!sniffed:trendy bugbear chef
 
+freerun	0	Foodie Giant
+freerun	1	Possibility Giant
+freerun	2	Procrastination Giant
+freerun	3	Renaissance Giant
+freerun	4	Punk Rock Giant
+freerun	5	Raver Giant
+freerun	6	Steampunk Giant
+freerun	7	Irritating Series of Random Encounters
+freerun	8	MagiMechTech MechaMech
+freerun	9	Protagonist	!class:Ed the Undying
+freerun	10	bar
+freerun	11	spooky mummy
+freerun	12	spooky vampire
+freerun	13	triffid
+freerun	14	warwelf	!class:Ed the Undying
+freerun	15	wolfman	!class:Ed the Undying
+freerun	16	cubist bull
+freerun	17	empty suit of armor
+freerun	18	guy with a pitchfork, and his wife
+freerun	19	claw-foot bathtub
+freerun	20	malevolent hair clog
+freerun	21	toilet papergeist
+freerun	22	Iiti Kitty
+freerun	23	tomb bat
+freerun	24	tomb servant	loc:The Upper Chamber
+
 replace	0	Banshee Librarian	item:Killing Jar>0
 replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber;!pathid:41;!path:Wildfire;!path:Fall of the Dinosaurs;!path:Avator of Shadows Over Loathing;!path:Legacy of Loathing
 replace	2	Knob Goblin Madam	item:Knob Goblin Perfume>0

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -64,30 +64,31 @@ freerun	4	Punk Rock Giant
 freerun	5	Raver Giant
 freerun	6	Steampunk Giant
 freerun	7	Irritating Series of Random Encounters
-freerun	8	MagiMechTech MechaMech
-freerun	9	Protagonist	!class:Ed the Undying
-freerun	10	bar
-freerun	11	spooky mummy
-freerun	12	spooky vampire
-freerun	13	triffid
-freerun	14	warwelf	!class:Ed the Undying
-freerun	15	wolfman	!class:Ed the Undying
-freerun	16	cubist bull
-freerun	17	empty suit of armor
-freerun	18	guy with a pitchfork, and his wife
-freerun	19	claw-foot bathtub
-freerun	20	malevolent hair clog
-freerun	21	toilet papergeist
-freerun	22	Iiti Kitty
-freerun	23	tomb bat
-freerun	24	tomb servant	loc:The Upper Chamber
-freerun	25	Knob Goblin Assistant Chef
-freerun	26	sleeping Knob Goblin Guard
-freerun	27	Sub-Assistant Knob Mad Scientist
-freerun	28	animated mahogany nightstand
-freerun	29	animated ornate nightstand
-freerun	30	animated rustic nightstand
-freerun	31	Wardröb nightstand
+freerun	8	Protagonist	!class:Ed the Undying
+freerun	9	bar
+freerun	10	spooky mummy
+freerun	11	spooky vampire
+freerun	12	triffid
+freerun	13	warwelf	!class:Ed the Undying
+freerun	14	wolfman	!class:Ed the Undying
+freerun	15	cubist bull
+freerun	16	empty suit of armor
+freerun	17	guy with a pitchfork, and his wife
+freerun	18	claw-foot bathtub
+freerun	19	malevolent hair clog
+freerun	20	toilet papergeist
+freerun	21	Iiti Kitty
+freerun	22	tomb bat
+freerun	23	tomb servant	loc:The Upper Chamber
+freerun	24	Knob Goblin Assistant Chef
+freerun	25	sleeping Knob Goblin Guard
+freerun	26	Sub-Assistant Knob Mad Scientist
+freerun	27	animated mahogany nightstand
+freerun	28	animated ornate nightstand
+freerun	29	animated rustic nightstand
+freerun	30	Wardröb nightstand
+freerun	31	drunken rat
+freerun	32	bunch of drunken rats
 
 replace	0	Banshee Librarian	item:Killing Jar>0
 replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber;!pathid:41;!path:Wildfire;!path:Fall of the Dinosaurs;!path:Avator of Shadows Over Loathing;!path:Legacy of Loathing

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -57,7 +57,7 @@ banish	50	ancient unspeakable bugbear	path:Bugbear Invasion;loc:Navigation;!snif
 banish	51	trendy bugbear chef	path:Bugbear Invasion;loc:Galley;loc:Gallery;!sniffed:trendy bugbear chef
 
 freerun	0	Foodie Giant
-freerun	1	Possibility Giant
+freerun	1	Possibility Giant	prop:auto_hippyInstead==false
 freerun	2	Procrastination Giant
 freerun	3	Renaissance Giant
 freerun	4	Punk Rock Giant
@@ -81,6 +81,13 @@ freerun	21	toilet papergeist
 freerun	22	Iiti Kitty
 freerun	23	tomb bat
 freerun	24	tomb servant	loc:The Upper Chamber
+freerun	25	Knob Goblin Assistant Chef
+freerun	26	sleeping Knob Goblin Guard
+freerun	27	Sub-Assistant Knob Mad Scientist
+freerun	28	animated mahogany nightstand
+freerun	29	animated ornate nightstand
+freerun	30	animated rustic nightstand
+freerun	31	Wardröb nightstand
 
 replace	0	Banshee Librarian	item:Killing Jar>0
 replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber;!pathid:41;!path:Wildfire;!path:Fall of the Dinosaurs;!path:Avator of Shadows Over Loathing;!path:Legacy of Loathing

--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -2,5 +2,5 @@ github Ezandora/Detective-Solver
 github Ezandora/Helix-Fossil
 github Ezandora/Far-Future
 github Ezandora/Voting-Booth
-github gausie/excavator release
+github loathers/excavator release
 github loathers/combo release

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -394,11 +394,17 @@ boolean auto_pre_adventure()
 				adjustForYellowRayIfPossible(mon);
 				zoneHasWantedMonsters = true;
 			}
-			if(auto_wantToBanish(mon, place))
+			boolean wantToBanish  = auto_wantToBanish(mon, place);
+			boolean wantToFreeRun = auto_wantToFreeRun(mon, place);
+			if(wantToBanish || wantToFreeRun)
 			{
 				// attempt to prepare for banishing, but if we can not try free running
-				boolean canBanish = adjustForBanishIfPossible(mon, place);
-				if(!canBanish)
+				boolean willBanish = false;
+				if (wantToBanish)
+				{
+					willBanish = adjustForBanishIfPossible(mon, place);
+				}
+				if(!willBanish)
 				{
 					adjustForFreeRunIfPossible(mon,place);
 				}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -775,6 +775,19 @@ boolean adjustForBanishIfPossible(monster enemy, location loc)
 	return false;
 }
 
+boolean auto_wantToFreeRun(monster enemy, location loc)
+{
+	if(appearance_rates(loc)[enemy] <= 0)
+	{
+		return false;
+	}
+	location locCache = my_location();
+	set_location(loc);
+	boolean [monster] monstersToFreeRun = auto_getMonsters("freerun");
+	set_location(locCache);
+	return monstersToFreeRun[enemy];
+}
+
 boolean canFreeRun(monster enemy, location loc)
 {
 	// are there any restrictions on free running?

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1665,6 +1665,7 @@ boolean auto_wantToBanish(monster enemy, location loc);
 boolean canBanish(monster enemy, location loc);
 boolean adjustForBanish(string combat_string);
 boolean adjustForBanishIfPossible(monster enemy, location loc);
+boolean auto_wantToFreeRun(monster enemy, location loc);
 boolean canFreeRun(monster enemy, location loc);
 string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inCombat);
 string freeRunCombatString(monster enemy, location loc, boolean inCombat);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -171,8 +171,8 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		combat_status_add("banishercheck");
 	}
 
-	// Free run from monsters we want to banish but are unable to
-	if(!combat_status_check("freeruncheck") && auto_wantToBanish(enemy, my_location()))
+	// Free run from monsters we want to banish but are unable to, or monsters on the free run list
+	if(!combat_status_check("freeruncheck") && (auto_wantToFreeRun(enemy, my_location()) || auto_wantToBanish(enemy, my_location())))
 	{
 		string freeRunAction = freeRunCombatString(enemy, my_location(), true);
 		if(freeRunAction != "")


### PR DESCRIPTION
# Description

At the moment we only use our free runaways against monsters we want to banish, but can't.

This PR adds a separate list of monsters that we don't want to banish, but do want to use free runaways on.

They were selected as having no useful drops, and being in delay zones.

## How Has This Been Tested?

One day of unrestricted HC. It ran away twice against things it wouldn't have otherwise done. I was expecting more, there's still more testing necessary. Bander/boots runaways still barely used.

Update: after another day of HC (completion of d2, new ascension d1), with expanded monsters it now uses tonnes more runaways. I'm happy for it to be merged now. I do intend to update the banish logic so we can free-run after using Spring Kick, but that can easily go in another PR.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
