### PR TITLE
Fix infinite recovery looping in G-Lover

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3001,7 +3001,7 @@ boolean auto_is_valid(skill sk)
 	// Hack for Legacy of Loathing as is_unrestricted returns false for Source Terminal skills
 	if (in_lol() && $skills[Extract, Turbo, Digitize, Duplicate, Portscan, Compress] contains sk) return true;
 	//do not check check for B in bees hate you path. it only restricts items and not skills.
-	return (glover_usable(sk.to_string()) || sk.passive) && bat_skillValid(sk) && plumber_skillValid(sk) && is_unrestricted(sk);
+	return (glover_usable(sk.to_string()) || (sk.passive && sk != $skill[disco nap])) && bat_skillValid(sk) && plumber_skillValid(sk) && is_unrestricted(sk);
 }
 
 boolean auto_is_valid(effect eff)


### PR DESCRIPTION
# Description

Disco Nap is tagged as a passive skill in mafia because it has a passive component that adds a free rest, but auto_is_valid should still return false for it in G-Lover since it's also a noncombat recovery skill and can't be cast.

Fixes the G-Lover infinite recovery loop issue https://github.com/loathers/autoscend/issues/1419)

## How Has This Been Tested?

I waited until I was triggering the infinite loop to implement it to make sure it fixed it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
