### PR TITLE
WereProfessor

### DIFF
--- a/BUILD/familiars/regen.dat
+++ b/BUILD/familiars/regen.dat
@@ -48,6 +48,7 @@ Cotton Candy Carnie
 # Slightly better whelp for saucerors
 Pet Cheezling	class:Sauceror
 # Whelps with a multiplier, why not I guess
+Mini-Trainbot
 #Mutant Gila Monster	grimdark:0
 #Mutant Gila Monster	grimdark:1
 # Marginally special whelps

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -46,7 +46,8 @@ L12_Gremlins	is_werewolf
 L11_forgedDocuments	is_professor
 L11_mcmuffinDiary	is_professor
 L11_getUVCompass	is_professor
-L11_mauriceSpookyraven	is_werewolf
+# Putting Lord Spookyraven here because he is limited but to get to him isn't
+L11_mauriceSpookyraven
 L11_shenCopperhead	is_werewolf
 L9_aBooPeak
 L9_oilPeak

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -42,12 +42,12 @@ LX_spookyravenManorFirstFloor
 L5_getEncryptionKey
 L5_findKnob
 # Quests with Werewolf/Professor specific limitations should have higher priority so we do those when we can
-L12_Gremlins is_werewolf
-L11_forgedDocuments !is_werewolf
-L11_mcmuffinDiary !is_werewolf
-L11_getUVCompass !is_werewolf
-L11_mauriceSpookyraven is_werewolf
-L11_shenCopperhead is_werewolf
+L12_Gremlins	is_werewolf
+L11_forgedDocuments	is_professor
+L11_mcmuffinDiary	is_professor
+L11_getUVCompass	is_professor
+L11_mauriceSpookyraven	is_werewolf
+L11_shenCopperhead	is_werewolf
 L9_aBooPeak
 L9_oilPeak
 L8_trapperGroar

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -92,6 +92,9 @@ L2_mosquito
 setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
 setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# want to do these before we start the tower so we can make sure we have as much werewolf as possible
+LX_getStarKey
+LX_getDigitalKey
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
 L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -1,3 +1,4 @@
+LM_wereprof
 LX_freeCombatsTask
 woods_questStart
 LX_unlockPirateRealm
@@ -25,6 +26,7 @@ LX_goingUnderground
 LX_useBreathitinCharges
 # Guild access.
 LX_guildUnlock
+LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 #	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
 LX_unlockDesert
 LX_lockPicking

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -17,7 +17,7 @@ LX_wereprof_getSmashedEquip
 # make sure we don't waste turns of Ultrahydrated doing something else.
 L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-L11_shenStartQuest
+L11_shenStartQuest is_werewolf
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
 finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.
@@ -41,12 +41,21 @@ LX_spookyravenManorFirstFloor
 # Open up underground zones so they are available for Breathitin.
 L5_getEncryptionKey
 L5_findKnob
+# Quests with Werewolf/Professor specific limitations should have higher priority so we do those when we can
+L12_Gremlins is_werewolf
+L11_forgedDocuments !is_werewolf
+L11_mcmuffinDiary !is_werewolf
+L11_getUVCompass !is_werewolf
+L11_mauriceSpookyraven is_werewolf
+L11_shenCopperhead is_werewolf
+L9_aBooPeak
+L9_oilPeak
+L8_trapperGroar
+L7_crypt
 #	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
 L12_islandWar
 # Start the macguffin quest
 L11_blackMarket
-L11_forgedDocuments
-L11_mcmuffinDiary
 L11_getBeehive
 # open the hidden city up (delay zones)
 L2_mosquito
@@ -58,7 +67,6 @@ L11_hiddenCityZones
 L11_hiddenCity
 # Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
 LX_spookyravenManorSecondFloor
-L11_mauriceSpookyraven
 # Lay the smack down on those Jerk Copperhead twins
 L11_talismanOfNam
 # Open up the top of the beanstalk.
@@ -70,8 +78,6 @@ L9_chasmBuild
 L9_highLandlord
 #  Kill Groar because *we* are the monsters.
 L8_trapperQuest
-# Kill the undead? Is this an oxymoron?
-L7_crypt
 # Cleanse the taint.
 L6_friarsGetParts
 # Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -1,0 +1,94 @@
+LX_freeCombatsTask
+woods_questStart
+LX_unlockPirateRealm
+catBurglarHeist
+auto_breakfastCounterVisit
+chateauPainting
+LX_setWorkshed
+LX_galaktikSubQuest
+L9_leafletQuest
+L5_findKnob
+L12_sonofaPrefix
+LX_burnDelay
+LX_summonMonster
+# Get Smashed Scientific Equipment ASAP
+LX_wereprof_getSmashedEquip
+# make sure we don't waste turns of Ultrahydrated doing something else.
+L11_aridDesert	L11_hasUltrahydrated
+# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+L11_shenStartQuest
+# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+finishBuildingSmutOrcBridge
+# Underground Adventuring for CMC/Breathitin.
+LX_goingUnderground
+# Burn Breathitin charges
+LX_useBreathitinCharges
+# Guild access.
+LX_guildUnlock
+#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
+LX_unlockDesert
+LX_lockPicking
+LX_fatLootToken
+#	Get the Steel Organ if the user wants it (needs L6 quest complete)
+LX_steelOrgan
+# open up delay zones.
+LX_spookyravenManorFirstFloor
+# open up zones where we want to force non-combats.
+# Open up underground zones so they are available for Breathitin.
+L5_getEncryptionKey
+L5_findKnob
+#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
+L12_islandWar
+# Start the macguffin quest
+L11_blackMarket
+L11_forgedDocuments
+L11_mcmuffinDiary
+L11_getBeehive
+# open the hidden city up (delay zones)
+L2_mosquito
+LX_unlockHiddenTemple
+L6_dakotaFanning
+L11_unlockHiddenCity
+# Murder pygmies for the ancient amulet.
+L11_hiddenCityZones
+L11_hiddenCity
+# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+LX_spookyravenManorSecondFloor
+L11_mauriceSpookyraven
+# Lay the smack down on those Jerk Copperhead twins
+L11_talismanOfNam
+# Open up the top of the beanstalk.
+L10_plantThatBean
+# Clean up the plains
+L10_rainOnThePlains
+# Get Black Angus his pizza
+L9_chasmBuild
+L9_highLandlord
+#  Kill Groar because *we* are the monsters.
+L8_trapperQuest
+# Kill the undead? Is this an oxymoron?
+L7_crypt
+# Cleanse the taint.
+L6_friarsGetParts
+# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
+L11_palindome
+L11_aridDesert
+L11_unlockPyramid
+L11_unlockEd
+L11_defeatEd
+#	Finish off the Goblin King.
+L5_slayTheGoblinKing
+# Show the Boss bat who's boss.
+L4_batCave
+# Fix that dripping tap.
+L3_tavern
+# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
+L2_mosquito
+# release the softblock on delay burning
+setSoftblockDelay	allowSoftblockDelay
+# release the softblock on Underground Adventures
+setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
+L13_towerAscent
+# if all else fails, powerlevel like there's no tomorrow.
+LX_attemptPowerLevel

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -17,7 +17,7 @@ LX_wereprof_getSmashedEquip
 # make sure we don't waste turns of Ultrahydrated doing something else.
 L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-L11_shenStartQuest is_werewolf
+L11_shenStartQuest	is_werewolf
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
 finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.

--- a/BUILD/task_order/WereProfessor.dat
+++ b/BUILD/task_order/WereProfessor.dat
@@ -31,6 +31,8 @@ LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 LX_unlockDesert
 LX_lockPicking
 LX_fatLootToken
+# Get access to the island access ASAP because only Professor can do it
+LX_islandAccess
 #	Get the Steel Organ if the user wants it (needs L6 quest complete)
 LX_steelOrgan
 # open up delay zones.

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -301,16 +301,17 @@ regen	27	Cotton Candy Carnie
 # Slightly better whelp for saucerors
 regen	28	Pet Cheezling	class:Sauceror
 # Whelps with a multiplier, why not I guess
+regen	29	Mini-Trainbot
 #Mutant Gila Monster	grimdark:0
 #Mutant Gila Monster	grimdark:1
 # Marginally special whelps
 #Mutant Gila Monster	grimdark:2
-regen	29	Pottery Barn Owl
+regen	30	Pottery Barn Owl
 # Regular old whelps
-regen	30	Pet Cheezling
-regen	31	Ghuol Whelp
+regen	31	Pet Cheezling
+regen	32	Ghuol Whelp
 # The absolute default that everyone should have after their first run
-regen	32	Mosquito
+regen	33	Mosquito
 
 # Sombrero is desirable with a decent amount of ML
 stat	0	Galloping Grill	ML:>=120

--- a/RELEASE/data/autoscend_properties.txt
+++ b/RELEASE/data/autoscend_properties.txt
@@ -219,4 +219,3 @@
 226	auto_aosolLastSkill
 227 auto_skipStage2
 228 auto_skipStage4
-229 auto_skipStage3

--- a/RELEASE/data/autoscend_properties.txt
+++ b/RELEASE/data/autoscend_properties.txt
@@ -219,3 +219,4 @@
 226	auto_aosolLastSkill
 227 auto_skipStage2
 228 auto_skipStage4
+229 auto_skipStage3

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -338,7 +338,7 @@ WereProfessor	14	LX_wereprof_getSmashedEquip
 # make sure we don't waste turns of Ultrahydrated doing something else.
 WereProfessor	15	L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-WereProfessor	16	L11_shenStartQuest
+WereProfessor	16	L11_shenStartQuest is_werewolf
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
 WereProfessor	17	finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.
@@ -362,64 +362,70 @@ WereProfessor	27	LX_spookyravenManorFirstFloor
 # Open up underground zones so they are available for Breathitin.
 WereProfessor	28	L5_getEncryptionKey
 WereProfessor	29	L5_findKnob
+# Quests with Werewolf/Professor specific limitations should have higher priority so we do those when we can
+WereProfessor	30	L12_Gremlins is_werewolf
+WereProfessor	31	L11_forgedDocuments !is_werewolf
+WereProfessor	32	L11_mcmuffinDiary !is_werewolf
+WereProfessor	33	L11_getUVCompass !is_werewolf
+WereProfessor	34	L11_mauriceSpookyraven is_werewolf
+WereProfessor	35	L11_shenCopperhead is_werewolf
+WereProfessor	36	L9_aBooPeak
+WereProfessor	37	L9_oilPeak
+WereProfessor	38	L8_trapperGroar
+WereProfessor	39	L7_crypt
 #	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-WereProfessor	30	L12_islandWar
+WereProfessor	40	L12_islandWar
 # Start the macguffin quest
-WereProfessor	31	L11_blackMarket
-WereProfessor	32	L11_forgedDocuments
-WereProfessor	33	L11_mcmuffinDiary
-WereProfessor	34	L11_getBeehive
+WereProfessor	41	L11_blackMarket
+WereProfessor	42	L11_getBeehive
 # open the hidden city up (delay zones)
-WereProfessor	35	L2_mosquito
-WereProfessor	36	LX_unlockHiddenTemple
-WereProfessor	37	L6_dakotaFanning
-WereProfessor	38	L11_unlockHiddenCity
+WereProfessor	43	L2_mosquito
+WereProfessor	44	LX_unlockHiddenTemple
+WereProfessor	45	L6_dakotaFanning
+WereProfessor	46	L11_unlockHiddenCity
 # Murder pygmies for the ancient amulet.
-WereProfessor	39	L11_hiddenCityZones
-WereProfessor	40	L11_hiddenCity
+WereProfessor	47	L11_hiddenCityZones
+WereProfessor	48	L11_hiddenCity
 # Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-WereProfessor	41	LX_spookyravenManorSecondFloor
-WereProfessor	42	L11_mauriceSpookyraven
+WereProfessor	49	LX_spookyravenManorSecondFloor
 # Lay the smack down on those Jerk Copperhead twins
-WereProfessor	43	L11_talismanOfNam
+WereProfessor	50	L11_talismanOfNam
 # Open up the top of the beanstalk.
-WereProfessor	44	L10_plantThatBean
+WereProfessor	51	L10_plantThatBean
 # Clean up the plains
-WereProfessor	45	L10_rainOnThePlains
+WereProfessor	52	L10_rainOnThePlains
 # Get Black Angus his pizza
-WereProfessor	46	L9_chasmBuild
-WereProfessor	47	L9_highLandlord
+WereProfessor	53	L9_chasmBuild
+WereProfessor	54	L9_highLandlord
 #  Kill Groar because *we* are the monsters.
-WereProfessor	48	L8_trapperQuest
-# Kill the undead? Is this an oxymoron?
-WereProfessor	49	L7_crypt
+WereProfessor	55	L8_trapperQuest
 # Cleanse the taint.
-WereProfessor	50	L6_friarsGetParts
+WereProfessor	56	L6_friarsGetParts
 # Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-WereProfessor	51	L11_palindome
-WereProfessor	52	L11_aridDesert
-WereProfessor	53	L11_unlockPyramid
-WereProfessor	54	L11_unlockEd
-WereProfessor	55	L11_defeatEd
+WereProfessor	57	L11_palindome
+WereProfessor	58	L11_aridDesert
+WereProfessor	59	L11_unlockPyramid
+WereProfessor	60	L11_unlockEd
+WereProfessor	61	L11_defeatEd
 #	Finish off the Goblin King.
-WereProfessor	56	L5_slayTheGoblinKing
+WereProfessor	62	L5_slayTheGoblinKing
 # Show the Boss bat who's boss.
-WereProfessor	57	L4_batCave
+WereProfessor	63	L4_batCave
 # Fix that dripping tap.
-WereProfessor	58	L3_tavern
+WereProfessor	64	L3_tavern
 # Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-WereProfessor	59	L2_mosquito
+WereProfessor	65	L2_mosquito
 # release the softblock on delay burning
-WereProfessor	60	setSoftblockDelay	allowSoftblockDelay
+WereProfessor	66	setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
-WereProfessor	61	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+WereProfessor	67	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 # want to do these before we start the tower so we can make sure we have as much werewolf as possible
-WereProfessor	62	LX_getStarKey
-WereProfessor	63	LX_getDigitalKey
+WereProfessor	68	LX_getStarKey
+WereProfessor	69	LX_getDigitalKey
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-WereProfessor	64	L13_towerAscent
+WereProfessor	70	L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.
-WereProfessor	65	LX_attemptPowerLevel
+WereProfessor	71	LX_attemptPowerLevel
 
 Zombie Slayer	0	LM_zombieSlayer
 Zombie Slayer	1	woods_questStart

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -367,7 +367,8 @@ WereProfessor	30	L12_Gremlins	is_werewolf
 WereProfessor	31	L11_forgedDocuments	is_professor
 WereProfessor	32	L11_mcmuffinDiary	is_professor
 WereProfessor	33	L11_getUVCompass	is_professor
-WereProfessor	34	L11_mauriceSpookyraven	is_werewolf
+# Putting Lord Spookyraven here because he is limited but to get to him isn't
+WereProfessor	34	L11_mauriceSpookyraven
 WereProfessor	35	L11_shenCopperhead	is_werewolf
 WereProfessor	36	L9_aBooPeak
 WereProfessor	37	L9_oilPeak

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -319,100 +319,102 @@ Quantum Terrarium	58	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 Quantum Terrarium	59	L13_towerAscent
 Quantum Terrarium	60	LX_attemptPowerLevel
 
-WereProfessor	0	LX_freeCombatsTask
-WereProfessor	1	woods_questStart
-WereProfessor	2	LX_unlockPirateRealm
-WereProfessor	3	catBurglarHeist
-WereProfessor	4	auto_breakfastCounterVisit
-WereProfessor	5	chateauPainting
-WereProfessor	6	LX_setWorkshed
-WereProfessor	7	LX_galaktikSubQuest
-WereProfessor	8	L9_leafletQuest
-WereProfessor	9	L5_findKnob
-WereProfessor	10	L12_sonofaPrefix
-WereProfessor	11	LX_burnDelay
-WereProfessor	12	LX_summonMonster
+WereProfessor	0	LM_wereprof
+WereProfessor	1	LX_freeCombatsTask
+WereProfessor	2	woods_questStart
+WereProfessor	3	LX_unlockPirateRealm
+WereProfessor	4	catBurglarHeist
+WereProfessor	5	auto_breakfastCounterVisit
+WereProfessor	6	chateauPainting
+WereProfessor	7	LX_setWorkshed
+WereProfessor	8	LX_galaktikSubQuest
+WereProfessor	9	L9_leafletQuest
+WereProfessor	10	L5_findKnob
+WereProfessor	11	L12_sonofaPrefix
+WereProfessor	12	LX_burnDelay
+WereProfessor	13	LX_summonMonster
 # Get Smashed Scientific Equipment ASAP
-WereProfessor	13	LX_wereprof_getSmashedEquip
+WereProfessor	14	LX_wereprof_getSmashedEquip
 # make sure we don't waste turns of Ultrahydrated doing something else.
-WereProfessor	14	L11_aridDesert	L11_hasUltrahydrated
+WereProfessor	15	L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-WereProfessor	15	L11_shenStartQuest
+WereProfessor	16	L11_shenStartQuest
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
-WereProfessor	16	finishBuildingSmutOrcBridge
+WereProfessor	17	finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.
-WereProfessor	17	LX_goingUnderground
+WereProfessor	18	LX_goingUnderground
 # Burn Breathitin charges
-WereProfessor	18	LX_useBreathitinCharges
+WereProfessor	19	LX_useBreathitinCharges
 # Guild access.
-WereProfessor	19	LX_guildUnlock
+WereProfessor	20	LX_guildUnlock
+WereProfessor	21	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 #	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
-WereProfessor	20	LX_unlockDesert
-WereProfessor	21	LX_lockPicking
-WereProfessor	22	LX_fatLootToken
+WereProfessor	22	LX_unlockDesert
+WereProfessor	23	LX_lockPicking
+WereProfessor	24	LX_fatLootToken
 #	Get the Steel Organ if the user wants it (needs L6 quest complete)
-WereProfessor	23	LX_steelOrgan
+WereProfessor	25	LX_steelOrgan
 # open up delay zones.
-WereProfessor	24	LX_spookyravenManorFirstFloor
+WereProfessor	26	LX_spookyravenManorFirstFloor
 # open up zones where we want to force non-combats.
 # Open up underground zones so they are available for Breathitin.
-WereProfessor	25	L5_getEncryptionKey
-WereProfessor	26	L5_findKnob
+WereProfessor	27	L5_getEncryptionKey
+WereProfessor	28	L5_findKnob
 #	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-WereProfessor	27	L12_islandWar
+WereProfessor	29	L12_islandWar
 # Start the macguffin quest
-WereProfessor	28	L11_blackMarket
-WereProfessor	29	L11_forgedDocuments
-WereProfessor	30	L11_mcmuffinDiary
-WereProfessor	31	L11_getBeehive
+WereProfessor	30	L11_blackMarket
+WereProfessor	31	L11_forgedDocuments
+WereProfessor	32	L11_mcmuffinDiary
+WereProfessor	33	L11_getBeehive
 # open the hidden city up (delay zones)
-WereProfessor	32	L2_mosquito
-WereProfessor	33	LX_unlockHiddenTemple
-WereProfessor	34	L6_dakotaFanning
-WereProfessor	35	L11_unlockHiddenCity
+WereProfessor	34	L2_mosquito
+WereProfessor	35	LX_unlockHiddenTemple
+WereProfessor	36	L6_dakotaFanning
+WereProfessor	37	L11_unlockHiddenCity
 # Murder pygmies for the ancient amulet.
-WereProfessor	36	L11_hiddenCityZones
-WereProfessor	37	L11_hiddenCity
+WereProfessor	38	L11_hiddenCityZones
+WereProfessor	39	L11_hiddenCity
 # Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-WereProfessor	38	LX_spookyravenManorSecondFloor
-WereProfessor	39	L11_mauriceSpookyraven
+WereProfessor	40	LX_spookyravenManorSecondFloor
+WereProfessor	41	L11_mauriceSpookyraven
 # Lay the smack down on those Jerk Copperhead twins
-WereProfessor	40	L11_talismanOfNam
+WereProfessor	42	L11_talismanOfNam
 # Open up the top of the beanstalk.
-WereProfessor	41	L10_plantThatBean
+WereProfessor	43	L10_plantThatBean
 # Clean up the plains
-WereProfessor	42	L10_rainOnThePlains
+WereProfessor	44	L10_rainOnThePlains
 # Get Black Angus his pizza
-WereProfessor	43	L9_chasmBuild
-WereProfessor	44	L9_highLandlord
+WereProfessor	45	L9_chasmBuild
+WereProfessor	46	L9_highLandlord
 #  Kill Groar because *we* are the monsters.
-WereProfessor	45	L8_trapperQuest
+WereProfessor	47	L8_trapperQuest
 # Kill the undead? Is this an oxymoron?
-WereProfessor	46	L7_crypt
+WereProfessor	48	L7_crypt
 # Cleanse the taint.
-WereProfessor	47	L6_friarsGetParts
+WereProfessor	49	L6_friarsGetParts
 # Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-WereProfessor	48	L11_palindome
-WereProfessor	49	L11_aridDesert
-WereProfessor	50	L11_unlockPyramid
-WereProfessor	51	L11_unlockEd
-WereProfessor	52	L11_defeatEd
+WereProfessor	50	L11_palindome
+WereProfessor	51	L11_aridDesert
+WereProfessor	52	L11_unlockPyramid
+WereProfessor	53	L11_unlockEd
+WereProfessor	54	L11_defeatEd
 #	Finish off the Goblin King.
-WereProfessor	53	L5_slayTheGoblinKing
+WereProfessor	55	L5_slayTheGoblinKing
 # Show the Boss bat who's boss.
-WereProfessor	54	L4_batCave
+WereProfessor	56	L4_batCave
 # Fix that dripping tap.
-WereProfessor	55	L3_tavern
+WereProfessor	57	L3_tavern
 # Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-WereProfessor	56	L2_mosquito
+WereProfessor	58	L2_mosquito
 # release the softblock on delay burning
-WereProfessor	57	setSoftblockDelay	allowSoftblockDelay
+WereProfessor	59	setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
-WereProfessor	58	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+WereProfessor	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-WereProfessor	59	L13_towerAscent
+WereProfessor	61	L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.
-WereProfessor	60	LX_attemptPowerLevel
+WereProfessor	62	LX_attemptPowerLevel
 
 Zombie Slayer	0	LM_zombieSlayer
 Zombie Slayer	1	woods_questStart

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -413,10 +413,13 @@ WereProfessor	59	L2_mosquito
 WereProfessor	60	setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
 WereProfessor	61	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# want to do these before we start the tower so we can make sure we have as much werewolf as possible
+WereProfessor	62	LX_getStarKey
+WereProfessor	63	LX_getDigitalKey
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-WereProfessor	62	L13_towerAscent
+WereProfessor	64	L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.
-WereProfessor	63	LX_attemptPowerLevel
+WereProfessor	65	LX_attemptPowerLevel
 
 Zombie Slayer	0	LM_zombieSlayer
 Zombie Slayer	1	woods_questStart

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -155,105 +155,6 @@ Avatar of Jarlsberg	54	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 Avatar of Jarlsberg	55	L13_towerAscent
 Avatar of Jarlsberg	56	LX_attemptPowerLevel
 
-default	0	LX_freeCombatsTask
-default	1	woods_questStart
-default	2	LX_unlockPirateRealm
-default	3	catBurglarHeist
-default	4	auto_breakfastCounterVisit
-default	5	chateauPainting
-default	6	LX_setWorkshed
-default	7	LX_galaktikSubQuest
-default	8	L9_leafletQuest
-default	9	L5_findKnob
-default	10	L12_sonofaPrefix
-default	11	LX_burnDelay
-default	12	LX_summonMonster
-# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
-default	13	LM_edTheUndying
-default	14	LX_bugbearInvasion
-default	15	LX_lowkeySummer
-# make sure we don't waste turns of Ultrahydrated doing something else.
-default	16	L11_aridDesert	L11_hasUltrahydrated
-# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-default	17	L11_shenStartQuest
-# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
-default	18	finishBuildingSmutOrcBridge
-# Underground Adventuring for CMC/Breathitin.
-default	19	LX_goingUnderground
-# Burn Breathitin charges
-default	20	LX_useBreathitinCharges
-# Guild access.
-default	21	LX_guildUnlock
-#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
-default	22	LX_unlockDesert
-default	23	LX_lockPicking
-default	24	LX_fatLootToken
-#	Get the Steel Organ if the user wants it (needs L6 quest complete)
-default	25	LX_steelOrgan
-# open up delay zones.
-default	26	LX_spookyravenManorFirstFloor
-# open up zones where we want to force non-combats.
-# Open up underground zones so they are available for Breathitin.
-default	27	L5_getEncryptionKey
-default	28	L5_findKnob
-#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-default	29	L12_islandWar
-# Start the macguffin quest
-default	30	L11_blackMarket
-default	31	L11_forgedDocuments
-default	32	L11_mcmuffinDiary
-default	33	L11_getBeehive
-# open the hidden city up (delay zones)
-default	34	L2_mosquito
-default	35	LX_unlockHiddenTemple
-default	36	L6_dakotaFanning
-default	37	L11_unlockHiddenCity
-# Murder pygmies for the ancient amulet.
-default	38	L11_hiddenCityZones
-default	39	L11_hiddenCity
-# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-default	40	LX_spookyravenManorSecondFloor
-default	41	L11_mauriceSpookyraven
-# Lay the smack down on those Jerk Copperhead twins
-default	42	L11_talismanOfNam
-# Open up the top of the beanstalk.
-default	43	L10_plantThatBean
-# Clean up the plains
-default	44	L10_rainOnThePlains
-# Get Black Angus his pizza
-default	45	L9_chasmBuild
-default	46	L9_highLandlord
-#  Kill Groar because *we* are the monsters.
-default	47	L8_trapperQuest
-# Kill the undead? Is this an oxymoron?
-default	48	L7_crypt
-# Cleanse the taint.
-default	49	L6_friarsGetParts
-# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-default	50	L11_palindome
-default	51	L11_aridDesert
-default	52	L11_unlockPyramid
-default	53	L11_unlockEd
-default	54	L11_defeatEd
-#	Finish off the Goblin King.
-default	55	L5_slayTheGoblinKing
-# Show the Boss bat who's boss.
-default	56	L4_batCave
-# Fix that dripping tap.
-default	57	L3_tavern
-# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-default	58	L2_mosquito
-# release the softblock on delay burning
-default	59	setSoftblockDelay	allowSoftblockDelay
-# release the softblock on Underground Adventures
-default	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
-# There's an extra task in KoE
-default	61	LX_koeInvaderHandler
-# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-default	62	L13_towerAscent
-# if all else fails, powerlevel like there's no tomorrow.
-default	63	LX_attemptPowerLevel
-
 Legacy of Loathing	0	LX_freeCombatsTask
 Legacy of Loathing	1	woods_questStart
 Legacy of Loathing	2	LX_unlockPirateRealm
@@ -418,6 +319,101 @@ Quantum Terrarium	58	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 Quantum Terrarium	59	L13_towerAscent
 Quantum Terrarium	60	LX_attemptPowerLevel
 
+WereProfessor	0	LX_freeCombatsTask
+WereProfessor	1	woods_questStart
+WereProfessor	2	LX_unlockPirateRealm
+WereProfessor	3	catBurglarHeist
+WereProfessor	4	auto_breakfastCounterVisit
+WereProfessor	5	chateauPainting
+WereProfessor	6	LX_setWorkshed
+WereProfessor	7	LX_galaktikSubQuest
+WereProfessor	8	L9_leafletQuest
+WereProfessor	9	L5_findKnob
+WereProfessor	10	L12_sonofaPrefix
+WereProfessor	11	LX_burnDelay
+WereProfessor	12	LX_summonMonster
+# Get Smashed Scientific Equipment ASAP
+WereProfessor	13	LX_wereprof_getSmashedEquip
+# make sure we don't waste turns of Ultrahydrated doing something else.
+WereProfessor	14	L11_aridDesert	L11_hasUltrahydrated
+# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+WereProfessor	15	L11_shenStartQuest
+# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+WereProfessor	16	finishBuildingSmutOrcBridge
+# Underground Adventuring for CMC/Breathitin.
+WereProfessor	17	LX_goingUnderground
+# Burn Breathitin charges
+WereProfessor	18	LX_useBreathitinCharges
+# Guild access.
+WereProfessor	19	LX_guildUnlock
+#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
+WereProfessor	20	LX_unlockDesert
+WereProfessor	21	LX_lockPicking
+WereProfessor	22	LX_fatLootToken
+#	Get the Steel Organ if the user wants it (needs L6 quest complete)
+WereProfessor	23	LX_steelOrgan
+# open up delay zones.
+WereProfessor	24	LX_spookyravenManorFirstFloor
+# open up zones where we want to force non-combats.
+# Open up underground zones so they are available for Breathitin.
+WereProfessor	25	L5_getEncryptionKey
+WereProfessor	26	L5_findKnob
+#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
+WereProfessor	27	L12_islandWar
+# Start the macguffin quest
+WereProfessor	28	L11_blackMarket
+WereProfessor	29	L11_forgedDocuments
+WereProfessor	30	L11_mcmuffinDiary
+WereProfessor	31	L11_getBeehive
+# open the hidden city up (delay zones)
+WereProfessor	32	L2_mosquito
+WereProfessor	33	LX_unlockHiddenTemple
+WereProfessor	34	L6_dakotaFanning
+WereProfessor	35	L11_unlockHiddenCity
+# Murder pygmies for the ancient amulet.
+WereProfessor	36	L11_hiddenCityZones
+WereProfessor	37	L11_hiddenCity
+# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+WereProfessor	38	LX_spookyravenManorSecondFloor
+WereProfessor	39	L11_mauriceSpookyraven
+# Lay the smack down on those Jerk Copperhead twins
+WereProfessor	40	L11_talismanOfNam
+# Open up the top of the beanstalk.
+WereProfessor	41	L10_plantThatBean
+# Clean up the plains
+WereProfessor	42	L10_rainOnThePlains
+# Get Black Angus his pizza
+WereProfessor	43	L9_chasmBuild
+WereProfessor	44	L9_highLandlord
+#  Kill Groar because *we* are the monsters.
+WereProfessor	45	L8_trapperQuest
+# Kill the undead? Is this an oxymoron?
+WereProfessor	46	L7_crypt
+# Cleanse the taint.
+WereProfessor	47	L6_friarsGetParts
+# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
+WereProfessor	48	L11_palindome
+WereProfessor	49	L11_aridDesert
+WereProfessor	50	L11_unlockPyramid
+WereProfessor	51	L11_unlockEd
+WereProfessor	52	L11_defeatEd
+#	Finish off the Goblin King.
+WereProfessor	53	L5_slayTheGoblinKing
+# Show the Boss bat who's boss.
+WereProfessor	54	L4_batCave
+# Fix that dripping tap.
+WereProfessor	55	L3_tavern
+# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
+WereProfessor	56	L2_mosquito
+# release the softblock on delay burning
+WereProfessor	57	setSoftblockDelay	allowSoftblockDelay
+# release the softblock on Underground Adventures
+WereProfessor	58	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
+WereProfessor	59	L13_towerAscent
+# if all else fails, powerlevel like there's no tomorrow.
+WereProfessor	60	LX_attemptPowerLevel
+
 Zombie Slayer	0	LM_zombieSlayer
 Zombie Slayer	1	woods_questStart
 Zombie Slayer	2	LX_unlockPirateRealm
@@ -475,4 +471,103 @@ Zombie Slayer	53	setSoftblockDelay	allowSoftblockDelay
 Zombie Slayer	54	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 Zombie Slayer	55	L13_towerAscent
 Zombie Slayer	56	LX_attemptPowerLevel
+
+default	0	LX_freeCombatsTask
+default	1	woods_questStart
+default	2	LX_unlockPirateRealm
+default	3	catBurglarHeist
+default	4	auto_breakfastCounterVisit
+default	5	chateauPainting
+default	6	LX_setWorkshed
+default	7	LX_galaktikSubQuest
+default	8	L9_leafletQuest
+default	9	L5_findKnob
+default	10	L12_sonofaPrefix
+default	11	LX_burnDelay
+default	12	LX_summonMonster
+# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
+default	13	LM_edTheUndying
+default	14	LX_bugbearInvasion
+default	15	LX_lowkeySummer
+# make sure we don't waste turns of Ultrahydrated doing something else.
+default	16	L11_aridDesert	L11_hasUltrahydrated
+# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+default	17	L11_shenStartQuest
+# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+default	18	finishBuildingSmutOrcBridge
+# Underground Adventuring for CMC/Breathitin.
+default	19	LX_goingUnderground
+# Burn Breathitin charges
+default	20	LX_useBreathitinCharges
+# Guild access.
+default	21	LX_guildUnlock
+#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
+default	22	LX_unlockDesert
+default	23	LX_lockPicking
+default	24	LX_fatLootToken
+#	Get the Steel Organ if the user wants it (needs L6 quest complete)
+default	25	LX_steelOrgan
+# open up delay zones.
+default	26	LX_spookyravenManorFirstFloor
+# open up zones where we want to force non-combats.
+# Open up underground zones so they are available for Breathitin.
+default	27	L5_getEncryptionKey
+default	28	L5_findKnob
+#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
+default	29	L12_islandWar
+# Start the macguffin quest
+default	30	L11_blackMarket
+default	31	L11_forgedDocuments
+default	32	L11_mcmuffinDiary
+default	33	L11_getBeehive
+# open the hidden city up (delay zones)
+default	34	L2_mosquito
+default	35	LX_unlockHiddenTemple
+default	36	L6_dakotaFanning
+default	37	L11_unlockHiddenCity
+# Murder pygmies for the ancient amulet.
+default	38	L11_hiddenCityZones
+default	39	L11_hiddenCity
+# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+default	40	LX_spookyravenManorSecondFloor
+default	41	L11_mauriceSpookyraven
+# Lay the smack down on those Jerk Copperhead twins
+default	42	L11_talismanOfNam
+# Open up the top of the beanstalk.
+default	43	L10_plantThatBean
+# Clean up the plains
+default	44	L10_rainOnThePlains
+# Get Black Angus his pizza
+default	45	L9_chasmBuild
+default	46	L9_highLandlord
+#  Kill Groar because *we* are the monsters.
+default	47	L8_trapperQuest
+# Kill the undead? Is this an oxymoron?
+default	48	L7_crypt
+# Cleanse the taint.
+default	49	L6_friarsGetParts
+# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
+default	50	L11_palindome
+default	51	L11_aridDesert
+default	52	L11_unlockPyramid
+default	53	L11_unlockEd
+default	54	L11_defeatEd
+#	Finish off the Goblin King.
+default	55	L5_slayTheGoblinKing
+# Show the Boss bat who's boss.
+default	56	L4_batCave
+# Fix that dripping tap.
+default	57	L3_tavern
+# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
+default	58	L2_mosquito
+# release the softblock on delay burning
+default	59	setSoftblockDelay	allowSoftblockDelay
+# release the softblock on Underground Adventures
+default	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+# There's an extra task in KoE
+default	61	LX_koeInvaderHandler
+# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
+default	62	L13_towerAscent
+# if all else fails, powerlevel like there's no tomorrow.
+default	63	LX_attemptPowerLevel
 

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -363,12 +363,12 @@ WereProfessor	27	LX_spookyravenManorFirstFloor
 WereProfessor	28	L5_getEncryptionKey
 WereProfessor	29	L5_findKnob
 # Quests with Werewolf/Professor specific limitations should have higher priority so we do those when we can
-WereProfessor	30	L12_Gremlins is_werewolf
-WereProfessor	31	L11_forgedDocuments !is_werewolf
-WereProfessor	32	L11_mcmuffinDiary !is_werewolf
-WereProfessor	33	L11_getUVCompass !is_werewolf
-WereProfessor	34	L11_mauriceSpookyraven is_werewolf
-WereProfessor	35	L11_shenCopperhead is_werewolf
+WereProfessor	30	L12_Gremlins	is_werewolf
+WereProfessor	31	L11_forgedDocuments	is_professor
+WereProfessor	32	L11_mcmuffinDiary	is_professor
+WereProfessor	33	L11_getUVCompass	is_professor
+WereProfessor	34	L11_mauriceSpookyraven	is_werewolf
+WereProfessor	35	L11_shenCopperhead	is_werewolf
 WereProfessor	36	L9_aBooPeak
 WereProfessor	37	L9_oilPeak
 WereProfessor	38	L8_trapperGroar

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -352,69 +352,71 @@ WereProfessor	21	LX_bitchinMeatcar	LX_bitchinMeatcar_condition
 WereProfessor	22	LX_unlockDesert
 WereProfessor	23	LX_lockPicking
 WereProfessor	24	LX_fatLootToken
+# Get access to the island access ASAP because only Professor can do it
+WereProfessor	25	LX_islandAccess
 #	Get the Steel Organ if the user wants it (needs L6 quest complete)
-WereProfessor	25	LX_steelOrgan
+WereProfessor	26	LX_steelOrgan
 # open up delay zones.
-WereProfessor	26	LX_spookyravenManorFirstFloor
+WereProfessor	27	LX_spookyravenManorFirstFloor
 # open up zones where we want to force non-combats.
 # Open up underground zones so they are available for Breathitin.
-WereProfessor	27	L5_getEncryptionKey
-WereProfessor	28	L5_findKnob
+WereProfessor	28	L5_getEncryptionKey
+WereProfessor	29	L5_findKnob
 #	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-WereProfessor	29	L12_islandWar
+WereProfessor	30	L12_islandWar
 # Start the macguffin quest
-WereProfessor	30	L11_blackMarket
-WereProfessor	31	L11_forgedDocuments
-WereProfessor	32	L11_mcmuffinDiary
-WereProfessor	33	L11_getBeehive
+WereProfessor	31	L11_blackMarket
+WereProfessor	32	L11_forgedDocuments
+WereProfessor	33	L11_mcmuffinDiary
+WereProfessor	34	L11_getBeehive
 # open the hidden city up (delay zones)
-WereProfessor	34	L2_mosquito
-WereProfessor	35	LX_unlockHiddenTemple
-WereProfessor	36	L6_dakotaFanning
-WereProfessor	37	L11_unlockHiddenCity
+WereProfessor	35	L2_mosquito
+WereProfessor	36	LX_unlockHiddenTemple
+WereProfessor	37	L6_dakotaFanning
+WereProfessor	38	L11_unlockHiddenCity
 # Murder pygmies for the ancient amulet.
-WereProfessor	38	L11_hiddenCityZones
-WereProfessor	39	L11_hiddenCity
+WereProfessor	39	L11_hiddenCityZones
+WereProfessor	40	L11_hiddenCity
 # Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-WereProfessor	40	LX_spookyravenManorSecondFloor
-WereProfessor	41	L11_mauriceSpookyraven
+WereProfessor	41	LX_spookyravenManorSecondFloor
+WereProfessor	42	L11_mauriceSpookyraven
 # Lay the smack down on those Jerk Copperhead twins
-WereProfessor	42	L11_talismanOfNam
+WereProfessor	43	L11_talismanOfNam
 # Open up the top of the beanstalk.
-WereProfessor	43	L10_plantThatBean
+WereProfessor	44	L10_plantThatBean
 # Clean up the plains
-WereProfessor	44	L10_rainOnThePlains
+WereProfessor	45	L10_rainOnThePlains
 # Get Black Angus his pizza
-WereProfessor	45	L9_chasmBuild
-WereProfessor	46	L9_highLandlord
+WereProfessor	46	L9_chasmBuild
+WereProfessor	47	L9_highLandlord
 #  Kill Groar because *we* are the monsters.
-WereProfessor	47	L8_trapperQuest
+WereProfessor	48	L8_trapperQuest
 # Kill the undead? Is this an oxymoron?
-WereProfessor	48	L7_crypt
+WereProfessor	49	L7_crypt
 # Cleanse the taint.
-WereProfessor	49	L6_friarsGetParts
+WereProfessor	50	L6_friarsGetParts
 # Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-WereProfessor	50	L11_palindome
-WereProfessor	51	L11_aridDesert
-WereProfessor	52	L11_unlockPyramid
-WereProfessor	53	L11_unlockEd
-WereProfessor	54	L11_defeatEd
+WereProfessor	51	L11_palindome
+WereProfessor	52	L11_aridDesert
+WereProfessor	53	L11_unlockPyramid
+WereProfessor	54	L11_unlockEd
+WereProfessor	55	L11_defeatEd
 #	Finish off the Goblin King.
-WereProfessor	55	L5_slayTheGoblinKing
+WereProfessor	56	L5_slayTheGoblinKing
 # Show the Boss bat who's boss.
-WereProfessor	56	L4_batCave
+WereProfessor	57	L4_batCave
 # Fix that dripping tap.
-WereProfessor	57	L3_tavern
+WereProfessor	58	L3_tavern
 # Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-WereProfessor	58	L2_mosquito
+WereProfessor	59	L2_mosquito
 # release the softblock on delay burning
-WereProfessor	59	setSoftblockDelay	allowSoftblockDelay
+WereProfessor	60	setSoftblockDelay	allowSoftblockDelay
 # release the softblock on Underground Adventures
-WereProfessor	60	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
+WereProfessor	61	setSoftblockUndergroundAdvs	allowSoftblockUndergroundAdvs
 # "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-WereProfessor	61	L13_towerAscent
+WereProfessor	62	L13_towerAscent
 # if all else fails, powerlevel like there's no tomorrow.
-WereProfessor	62	LX_attemptPowerLevel
+WereProfessor	63	LX_attemptPowerLevel
 
 Zombie Slayer	0	LM_zombieSlayer
 Zombie Slayer	1	woods_questStart

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -338,7 +338,7 @@ WereProfessor	14	LX_wereprof_getSmashedEquip
 # make sure we don't waste turns of Ultrahydrated doing something else.
 WereProfessor	15	L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-WereProfessor	16	L11_shenStartQuest is_werewolf
+WereProfessor	16	L11_shenStartQuest	is_werewolf
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
 WereProfessor	17	finishBuildingSmutOrcBridge
 # Underground Adventuring for CMC/Breathitin.

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1369,7 +1369,7 @@ boolean adventureFailureHandler()
 		}
 	}
 
-	if(last_monster() == $monster[Crate])
+	if(last_monster() == $monster[Crate] && (!is_werewolf() && $location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
 	{
 		if(get_property("auto_newbieOverride").to_boolean())
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27905;	// Account for TinkeringBenchRequest ability to use equipped items
+since r27943;	// more wereprof boss parts
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27943;	// more wereprof boss parts
+since r27958;	// Remove WereProf stat req exemption
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1369,7 +1369,7 @@ boolean adventureFailureHandler()
 		}
 	}
 
-	if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !$location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
+	if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave as a Werewolf
 	{
 		if(get_property("auto_newbieOverride").to_boolean())
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1397,7 +1397,7 @@ boolean adventureFailureHandler()
 		}
 	}
 
-	if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave as a Werewolf
+	if(last_monster() == $monster[Crate] && (in_wereprof() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave in Wereprof for Smashed Scientific Equipment
 	{
 		if(get_property("auto_newbieOverride").to_boolean())
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -765,7 +765,7 @@ void initializeDay(int day)
 	}
 
 	// Get emotionally chipped if you have the item.  boris\jarlsberg\sneaky pete\zombie slayer\ed cannot use this skill so excluding.
-	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || is_jarlsberg() || is_pete() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte()))
+	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || is_jarlsberg() || is_pete() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte() || in_wereprof()))
 	{
 		use(1, $item[spinal-fluid-covered emotion chip]);
 	}

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1785,6 +1785,8 @@ boolean doTasks()
 	pete_buySkills();
 	zombieSlayer_buySkills();
 	lol_buyReplicas();
+	wereprof_buySkills();
+	wereprof_buyEquip()
 
 	oldPeoplePlantStuff();
 	use_barrels();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -280,6 +280,7 @@ void initializeSettings() {
 	fotd_initializeSettings();
 	lol_initializeSettings();
 	small_initializeSettings();
+	wereprof_initializeSettings();
 
 	set_property("auto_doneInitializePath", my_path().name);		//which path we initialized as
 	set_property("auto_doneInitialize", my_ascensions());
@@ -1833,6 +1834,7 @@ boolean doTasks()
 	if(LM_robot())						return true;
 	if(LM_plumber())					return true;
 	if(LM_zombieSlayer())				return true;
+	if(LM_wereprof())					return true;
 
 	{
 		cheeseWarMachine(0, 0, 0, 0);

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1369,7 +1369,7 @@ boolean adventureFailureHandler()
 		}
 	}
 
-	if(last_monster() == $monster[Crate] && (!is_werewolf() && $location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
+	if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !$location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
 	{
 		if(get_property("auto_newbieOverride").to_boolean())
 		{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27897;	// additional monster parts
+since r27905;	// Account for TinkeringBenchRequest ability to use equipped items
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -84,6 +84,7 @@ import <autoscend/paths/small.ash>
 import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
 import <autoscend/paths/way_of_the_surprising_fist.ash>
+import <autoscend/paths/wereprofessor.ash>
 import <autoscend/paths/wildfire.ash>
 import <autoscend/paths/you_robot.ash>
 import <autoscend/paths/zombie_slayer.ash>

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -843,7 +843,7 @@ void initializeDay(int day)
 			{
 				acquireGumItem($item[disco ball]);
 			}
-			if(!(is_boris() || is_jarlsberg() || is_pete() || isActuallyEd() || in_darkGyffte() || in_plumber()))
+			if(!(is_boris() || is_jarlsberg() || is_pete() || isActuallyEd() || in_darkGyffte() || in_plumber() || in_wereprof()))
 			{
 				if((item_amount($item[Antique Accordion]) == 0) && (item_amount($item[Aerogel Accordion]) == 0) && (auto_predictAccordionTurns() < 5) && ((my_meat() > npc_price($item[Toy Accordion])) && (npc_price($item[Toy Accordion]) != 0)))
 				{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -587,9 +587,9 @@ boolean tophatMaker()
 
 boolean LX_doVacation()
 {
-	if(in_koe())
+	if(in_koe() || is_werewolf())
 	{
-		return false;		//cannot vacation in kingdom of exploathing path
+		return false;		//cannot vacation in kingdom of exploathing path or are a werewolf in wereprofessor
 	}
 	
 	int meat_needed = 500;

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1786,7 +1786,7 @@ boolean doTasks()
 	zombieSlayer_buySkills();
 	lol_buyReplicas();
 	wereprof_buySkills();
-	wereprof_buyEquip()
+	wereprof_buyEquip();
 
 	oldPeoplePlantStuff();
 	use_barrels();

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -489,6 +489,10 @@ boolean acquireHermitItem(item it)
 	{
 		return false;
 	}
+	if(is_werewolf())
+	{
+		return false;
+	}
 	if((item_amount($item[Hermit Permit]) == 0) && (my_meat() >= npc_price($item[Hermit Permit])))
 	{
 		auto_buyUpTo(1, $item[Hermit Permit]);

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -495,7 +495,7 @@ boolean acquireHermitItem(item it)
 	}
 	if(is_werewolf())
 	{
-		return false;
+		return false; //can access the hermit, but can't buy chewing gum as a Werewolf
 	}
 	if((item_amount($item[Hermit Permit]) == 0) && (my_meat() >= npc_price($item[Hermit Permit])))
 	{

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -357,6 +357,10 @@ boolean buyableMaintain(item toMaintain, int howMany, int meatMin, boolean condi
 
 boolean auto_buyUpTo(int num, item it)
 {
+	if(is_werewolf())
+	{
+		return false; //can't buy anything as a werewolf
+	}
 	if(item_amount(it) >= num)
 	{
 		return true;	//we already have the target amount

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -493,10 +493,7 @@ boolean acquireHermitItem(item it)
 	{
 		return false;
 	}
-	if(is_werewolf())
-	{
-		return false; //can access the hermit, but can't buy chewing gum as a Werewolf
-	}
+	
 	if((item_amount($item[Hermit Permit]) == 0) && (my_meat() >= npc_price($item[Hermit Permit])))
 	{
 		auto_buyUpTo(1, $item[Hermit Permit]);
@@ -533,6 +530,10 @@ boolean acquireHermitItem(item it)
 		}
 		else
 		{
+			if(is_werewolf())
+			{
+				return false; //can access the hermit, but can't buy chewing gum as a Werewolf
+			}
 			auto_buyUpTo(1, $item[Chewing Gum on a String]);
 			use(1, $item[Chewing Gum on a String]);
 		}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1233,10 +1233,6 @@ boolean doBedtime()
 		{
 			return false;
 		}
-		if (in_wereprof()) // stooper does not give added benefit in WereProfessor
-		{
-			return false;
-		}
 		if(have_familiar($familiar[Stooper]) &&	//do not use auto_ that returns false in 100run, which stooper drinking does not interrupt.
 		pathAllowsChangingFamiliar() &&		//some paths forbid familiar or dont allow changing it but mafia still indicates you have the familiar
 		my_familiar() != $familiar[Stooper])

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1192,7 +1192,7 @@ boolean doBedtime()
 	// Use up any cursed monkey paw wishes on Frosty (+100% item, +100% meat, +25 ML)
 	// Unless we're limiting ML, then do One Very Clear Eye
 	effect effect_to_wish = $effect[Frosty];
-	if (get_property("auto_MLSafetyLimit")!="")
+	if (get_property("auto_MLSafetyLimit")!="" || in_wereprof())  // Professor hates ML
 	{
 		if (get_property("auto_MLSafetyLimit").to_int() < 25 || in_wereprof()) // We're adding +25 ML that won't be shrugged. Professor hates ML
 		{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1194,7 +1194,7 @@ boolean doBedtime()
 	effect effect_to_wish = $effect[Frosty];
 	if (get_property("auto_MLSafetyLimit")!="")
 	{
-		if (get_property("auto_MLSafetyLimit").to_int() < 25) // We're adding +25 ML that won't be shrugged.
+		if (get_property("auto_MLSafetyLimit").to_int() < 25 || in_wereprof()) // We're adding +25 ML that won't be shrugged. Professor hates ML
 		{
 			effect_to_wish = $effect[One Very Clear Eye];
 		}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -751,7 +751,7 @@ boolean doBedtime()
 		boolean notNeeded = have_effect($effect[Everything Looks Yellow]) > 0 || hasDisintegrate || canYellowRay(); //have a common unlimited source of YR, no need to make viral video
 		boolean baconUnused = item_amount($item[BACON]) >= (100*my_daycount() - 20*(my_daycount() - 1));  //BACON hasn't been used for something else this ascension
 		if(auto_is_valid($item[Viral Video]) && !notNeeded && baconUnused &&
-		!in_koe())	//bacon store is unreachable in kingdom of exploathing
+		!in_koe() && !is_werewolf())	//bacon store is unreachable in kingdom of exploathing or as werewolf
 		{
 			//can only buy 1 per day and more than one a day might be wanted later so buy today's viral video
 			create(1, $item[Viral Video]);
@@ -1230,6 +1230,10 @@ boolean doBedtime()
 	boolean canChangeToStooper()
 	{
 		if (in_small()) // In smol, the stooper can be equipped, but does not modify the liver size
+		{
+			return false;
+		}
+		if (in_wereprof()) // stooper does not give added benefit in WereProfessor
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1229,7 +1229,7 @@ boolean doBedtime()
 
 	boolean canChangeToStooper()
 	{
-		if (in_small()) // In smol, the stooper can be equipped, but does not modify the liver size
+		if (in_small() || in_wereprof()) // In smol and wereprofessor, the stooper can be equipped, but does not modify the liver size
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -489,6 +489,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Loyal Tea]:					useItem = $item[cuppa Loyal Tea];				break;
 	case $effect[Lucky Struck]:					useItem = $item[Lucky Strikes Holo-Record];		break;
 	case $effect[Lycanthropy\, Eh?]:			useItem = $item[Weremoose Spit];				break;
+	case $effect[Keep Free Hate In Your Heart]:	useItem = $item[Daily Affirmation: Keep Free Hate In Your Heart];	break;
 	case $effect[Kindly Resolve]:				useItem = $item[Resolution: Be Kinder];			break;
 	case $effect[Knob Goblin Perfume]:			useItem = $item[Knob Goblin Perfume];			break;
 	case $effect[Knowing Smile]:				useSkill = $skill[Knowing Smile];				break;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -721,6 +721,10 @@ boolean auto_run_choice(int choice, string page)
 		case 1500: // Like a Loded Stone
 			run_choice(2); // only come here to get shadow waters buff
 			break;
+		case 1522: // The Antiscientific Method
+			set_property("auto_wereprof_smashedLoc", get_property("auto_wereprof_smashedLoc") + "," + my_location().to_string())
+			run_choice(1);
+			break;
 		case 1525:
 			dartChoiceHandler(choice, options);
 			break;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -756,6 +756,9 @@ boolean auto_run_choice(int choice, string page)
 		case 1500: // Like a Loded Stone
 			run_choice(2); // only come here to get shadow waters buff
 			break;
+		case 1519: // The coffee was *gasp* decaf!
+			run_choice(1);
+			break;
 		case 1520: // Hang On to Yourself
 			run_choice(1);
 			break;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -721,8 +721,13 @@ boolean auto_run_choice(int choice, string page)
 		case 1500: // Like a Loded Stone
 			run_choice(2); // only come here to get shadow waters buff
 			break;
+		case 1520: // Hang On to Yourself
+			run_choice(1);
+			break;
+		case 1521: // Ch-ch-ch-ch-chaaaanges
+			run_choice(1);
+			break;
 		case 1522: // The Antiscientific Method
-			set_property("auto_wereprof_smashedLoc", get_property("auto_wereprof_smashedLoc") + "," + my_location().to_string());
 			run_choice(1);
 			break;
 		case 1525:

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -722,7 +722,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(2); // only come here to get shadow waters buff
 			break;
 		case 1522: // The Antiscientific Method
-			set_property("auto_wereprof_smashedLoc", get_property("auto_wereprof_smashedLoc") + "," + my_location().to_string())
+			set_property("auto_wereprof_smashedLoc", get_property("auto_wereprof_smashedLoc") + "," + my_location().to_string());
 			run_choice(1);
 			break;
 		case 1525:

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -2009,6 +2009,7 @@ boolean prepare_food_xp_multi()
 	
 	//[Ready to Eat] is gotten by using a red rocket from fireworks shop in VIP clan. it gives +400% XP on next food item
 	if(have_fireworks_shop() &&
+	!in_wereprof() && // don't want to use in WereProfessor
 	have_effect($effect[Ready to Eat]) <= 0 &&
 	auto_is_valid($item[red rocket]))
 	{

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -861,7 +861,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			blacklist[it] = true;
 		}
 	}
-	if(in_wereprof() && (!is_werewolf() || (is_werewolf() && get_property("wereProfessorTransformTurns") < 50)))
+	if(is_professor() || (is_werewolf() && get_property("wereProfessorTransformTurns") < 50))
 	{
 		blacklist[$item[plain calzone]] = true; //because 50 turn buff and can only handle +ML as a werewolf, either blacklist altogether or get lucky and eat ASAP as a werewolf
 	}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -841,6 +841,10 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			blacklist[it] = true;
 		}
 	}
+	if(in_wereprof() && (!is_werewolf() || (is_werewolf() && get_property("wereProfessorTransformTurns") < 50)))
+	{
+		blacklist[$item[plain calzone]] = true;
+	}
 	if(item_amount($item[Wet Stunt Nut Stew]) == 0 && !possessEquipment($item[Mega Gem]) && !isActuallyEd())
 	{
 		blacklist[$item[wet stew]] = true;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -498,6 +498,14 @@ boolean canDrink(item toDrink, boolean checkValidity)
 		// liver size of 1 in small path
 		return false;
 	}
+	if(is_werewolf())
+	{
+		//Can't access Fancy Dan as Werewolf
+		if($items[Champagne Shimmy, Charleston Choo-Choo, Marltini, Mysterious Stranger, Strong\, Silent Type, Velvet Veil] contains toDrink)
+		{
+			return false;
+		}
+	}
 
 	// small path ignores consumable level requirements
 	if(my_level() < toDrink.levelreq && !in_small())

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -843,7 +843,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	}
 	if(in_wereprof() && (!is_werewolf() || (is_werewolf() && get_property("wereProfessorTransformTurns") < 50)))
 	{
-		blacklist[$item[plain calzone]] = true;
+		blacklist[$item[plain calzone]] = true; //because 50 turn buff and can only handle +ML as a werewolf, either blacklist altogether or get lucky and eat ASAP as a werewolf
 	}
 	if(item_amount($item[Wet Stunt Nut Stew]) == 0 && !possessEquipment($item[Mega Gem]) && !isActuallyEd())
 	{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -736,8 +736,10 @@ void finalizeMaximize(boolean speculative)
 		boolean nooculus = false;
 		int monseen = 0;
 		foreach mon in monster_list {
-			if(contains_text(advresearch, monster_list[mon].id)) monseen += 1;
-			auto_log_info(monseen + " monsters researched of " + count(monster_list), "blue");
+			if(contains_text(advresearch, monster_list[mon].id)){
+				monseen += 1;
+				auto_log_info(monseen + " monsters researched of " + count(monster_list), "blue");
+			}
 			if(monseen == count(monster_list)) nooculus = true;
 		}
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -776,7 +776,7 @@ void finalizeMaximize(boolean speculative)
 		{
 			addBonusToMaximize($item[spring shoes], 200);
 		}
-		else if(in_wereprof() && my_hp() < 0.5*my_maxhp() && my_hp() > 0)
+		else if(my_hp() < 0.5*my_maxhp() && my_hp() > 0)
 		{
 			addBonusToMaximize($item[spring shoes], 200); // bonus to heal in wereprof as the werewolf after transition from Professor
 		}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -738,7 +738,7 @@ void finalizeMaximize(boolean speculative)
 		foreach mon in monster_list {
 			if(contains_text(advresearch, monster_list[mon].id)) monseen += 1;
 			auto_log_info(monseen + " monsters researched of " + count(monster_list), "blue");
-			if monseen == count(monster_list) nooculus = true;
+			if(monseen == count(monster_list)) nooculus = true;
 		}
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
 		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -731,16 +731,24 @@ void finalizeMaximize(boolean speculative)
 
 	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[biphasic molecular oculus]) || possessEquipment($item[triphasic molecular oculus]))) //Want that Advanced Research as a professor
 	{
-		monster [int] monster_list = get_monsters(my_location());
+		float [monster] monster_list = appearance_rates(my_location());
 		string advresearch = get_property("wereProfessorAdvancedResearch");
 		boolean nooculus = false;
 		int monseen = 0;
-		foreach mon in monster_list {
-			if(contains_text(advresearch, monster_list[mon].id)){
-				monseen += 1;
-				auto_log_info(monseen + " monsters researched of " + count(monster_list), "blue");
-			}
-			if(monseen == count(monster_list)) nooculus = true;
+		int totalmob = 0;
+		foreach mob, freq in monster_list {
+			if(freq > 0) totalmob += 1;
+		}
+		foreach mob, freq in monster_list {
+			if(freq > 0)
+			{
+				if(contains_text(advresearch, mob.id))
+				{
+					monseen += 1;
+					auto_log_info(monseen + " monsters researched of " + totalmob, "blue");
+				}
+			}			
+			if(monseen == totalmob) nooculus = true;
 		}
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
 		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -736,11 +736,13 @@ void finalizeMaximize(boolean speculative)
 		boolean nooculus = false;
 		int monseen = 0;
 		int totalmob = 0;
+		//calculate total non-boss and non-UR mobs
 		foreach mob, freq in monster_list {
-			if(freq > 0) totalmob += 1;
+			if(freq > 0 && mon.id > 0 && mon.copyable && !mon.boss) totalmob += 1;
 		}
+		//find how many mobs we've already researched and if the count matches total non-boss/non-UR mobs, don't equip the oculus
 		foreach mob, freq in monster_list {
-			if(freq > 0 && mob != monster[none])
+			if(freq > 0 && mon.id > 0 && mon.copyable && !mon.boss)
 			{
 				if(contains_text(advresearch, mob.id))
 				{
@@ -751,9 +753,10 @@ void finalizeMaximize(boolean speculative)
 			if(monseen == totalmob) nooculus = true;
 		}
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
-		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
+		if(($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
 		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
-		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room] contains my_location()) && !nooculus)
+		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room] contains my_location())) nooculus = true;
+		if(!nooculus)
 		{
 			if(possessEquipment($item[biphasic molecular oculus]))
 			{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -724,13 +724,19 @@ void finalizeMaximize(boolean speculative)
 
 	if(in_wereprof() && !is_werewolf() && (item_amount($item[biphasic molecular oculus]) > 0 || item_amount($item[triphasic molecular oculus]) > 0)) //Want that Advanced Research as a professor
 	{
-		if(item_amount($item[biphasic molecular oculus]) > 0)
+		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
+		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
+		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
+		McMillicancuddy's Other Back 40] contains my_location()))
 		{
-			addToMaximize("+equip " + $item[biphasic molecular oculus]);
-		}
-		else
-		{
-			addToMaximize("+equip " + $item[triphasic molecular oculus]);
+			if(item_amount($item[biphasic molecular oculus]) > 0)
+			{
+				addToMaximize("+equip " + $item[biphasic molecular oculus]);
+			}
+			else
+			{
+				addToMaximize("+equip " + $item[triphasic molecular oculus]);
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -727,7 +727,7 @@ void finalizeMaximize(boolean speculative)
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
 		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
 		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
-		McMillicancuddy's Other Back 40] contains my_location()))
+		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room] contains my_location()))
 		{
 			if(possessEquipment($item[biphasic molecular oculus]))
 			{
@@ -742,17 +742,23 @@ void finalizeMaximize(boolean speculative)
 
 	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[high-tension exoskeleton]) || possessEquipment($item[ultra-high-tension exoskeleton]) || possessEquipment($item[irresponsible-tension exoskeleton]))) //Want that damage avoidance
 	{
-		if(possessEquipment($item[high-tension exoskeleton]))
+		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
+		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
+		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
+		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room] contains my_location()))
 		{
-			addToMaximize("+equip " + $item[high-tension exoskeleton]);
-		}
-		else if(possessEquipment($item[ultra-high-tension exoskeleton]))
-		{
-			addToMaximize("+equip " + $item[ultra-high-tension exoskeleton]);
-		}
-		else
-		{
-			addToMaximize("+equip " + $item[irresponsible-tension exoskeleton]);
+			if(possessEquipment($item[high-tension exoskeleton]))
+			{
+				addToMaximize("+equip " + $item[high-tension exoskeleton]);
+			}
+			else if(possessEquipment($item[ultra-high-tension exoskeleton]))
+			{
+				addToMaximize("+equip " + $item[ultra-high-tension exoskeleton]);
+			}
+			else
+			{
+				addToMaximize("+equip " + $item[irresponsible-tension exoskeleton]);
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -719,7 +719,14 @@ void finalizeMaximize(boolean speculative)
 
 	if(in_wereprof() && auto_haveDarts()) //Absolutely need darts for Professor. Should level up darts while Werewolf too
 	{
-		addBonusToMaximize($item[Everfull Dart Holster], 1000);
+		if(is_werewolf())
+		{
+			addBonusToMaximize($item[Everfull Dart Holster], 1000);
+		}
+		else
+		{
+			addToMaximize("+equip " + $item[Everfull Dart Holster]);
+		}
 	}
 
 	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[biphasic molecular oculus]) || possessEquipment($item[triphasic molecular oculus]))) //Want that Advanced Research as a professor

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -740,7 +740,7 @@ void finalizeMaximize(boolean speculative)
 			if(freq > 0) totalmob += 1;
 		}
 		foreach mob, freq in monster_list {
-			if(freq > 0)
+			if(freq > 0 && mob != monster[none])
 			{
 				if(contains_text(advresearch, mob.id))
 				{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -722,14 +722,14 @@ void finalizeMaximize(boolean speculative)
 		addBonusToMaximize($item[Everfull Dart Holster], 1000);
 	}
 
-	if(in_wereprof() && !is_werewolf() && (item_amount($item[biphasic molecular oculus]) > 0 || item_amount($item[triphasic molecular oculus]) > 0)) //Want that Advanced Research as a professor
+	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[biphasic molecular oculus]) || possessEquipment($item[triphasic molecular oculus]))) //Want that Advanced Research as a professor
 	{
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
 		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
 		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
 		McMillicancuddy's Other Back 40] contains my_location()))
 		{
-			if(item_amount($item[biphasic molecular oculus]) > 0)
+			if(possessEquipment($item[biphasic molecular oculus]))
 			{
 				addToMaximize("+equip " + $item[biphasic molecular oculus]);
 			}
@@ -740,13 +740,13 @@ void finalizeMaximize(boolean speculative)
 		}
 	}
 
-	if(in_wereprof() && !is_werewolf() && (item_amount($item[high-tension exoskeleton]) > 0 || item_amount($item[ultra-high-tension exoskeleton]) > 0 || item_amount($item[irresponsible-tension exoskeleton]) > 0)) //Want that damage avoidance
+	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[high-tension exoskeleton]) || possessEquipment($item[ultra-high-tension exoskeleton]) || possessEquipment($item[irresponsible-tension exoskeleton]))) //Want that damage avoidance
 	{
-		if(item_amount($item[high-tension exoskeleton]) > 0)
+		if(possessEquipment($item[high-tension exoskeleton]))
 		{
 			addToMaximize("+equip " + $item[high-tension exoskeleton]);
 		}
-		else if(item_amount($item[ultra-high-tension exoskeleton]) > 0)
+		else if(possessEquipment($item[ultra-high-tension exoskeleton]))
 		{
 			addToMaximize("+equip " + $item[ultra-high-tension exoskeleton]);
 		}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -747,7 +747,6 @@ void finalizeMaximize(boolean speculative)
 				if(contains_text(advresearch, mob.id))
 				{
 					monseen += 1;
-					auto_log_info(monseen + " monsters researched of " + totalmob, "blue");
 				}
 			}			
 			if(monseen == totalmob) nooculus = true;

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -716,6 +716,34 @@ void finalizeMaximize(boolean speculative)
 			addToMaximize("+equip " + toEquip);
 		}
 	}
+
+	if(in_wereprof() && !is_werewolf() && auto_haveDarts()) //Absolutely need darts for Professor
+	{
+		addBonusToMaximize($item[Everfull Dart Holster], 1000);
+	}
+
+	if(in_wereprof() && !is_werewolf() && (item_amount($item[biphasic molecular oculus]) > 0 || item_amount($item[triphasic molecular oculus]) > 0)) //Want that Advanced Research as a professor
+	{
+		if(item_amount($item[biphasic molecular oculus]) > 0)
+		{
+			addBonusToMaximize($item[biphasic molecular oculus], 1000);
+		}
+		addBonusToMaximize($item[triphasic molecular oculus], 1000);
+	}
+
+	if(in_wereprof() && !is_werewolf() && (item_amount($item[high-tension exoskeleton]) > 0 || item_amount($item[ultra-high-tension exoskeleton]) > 0 || item_amount($item[irresponsible-tension exoskeleton]) > 0)) //Want that damage avoidance
+	{
+		if(item_amount($item[high-tension exoskeleton]) > 0)
+		{
+			addBonusToMaximize($item[high-tension exoskeleton], 1000);
+		}
+		if(item_amount($item[ultra-high-tension exoskeleton]) > 0)
+		{
+			addBonusToMaximize($item[ultra-high-tension exoskeleton], 1000);
+		}
+		addBonusToMaximize($item[irresponsible-tension exoskeleton], 1000);
+	}
+
 	
 	if(auto_haveSpringShoes())
 	{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -717,7 +717,7 @@ void finalizeMaximize(boolean speculative)
 		}
 	}
 
-	if(in_wereprof() && auto_haveDarts()) //Absolutely need darts for Professor. Should level up darts while Werewolf
+	if(in_wereprof() && auto_haveDarts()) //Absolutely need darts for Professor. Should level up darts while Werewolf too
 	{
 		addBonusToMaximize($item[Everfull Dart Holster], 1000);
 	}
@@ -765,7 +765,7 @@ void finalizeMaximize(boolean speculative)
 		}
 		else if(in_wereprof() && my_hp() < 0.5*my_maxhp() && my_hp() > 0)
 		{
-			addBonusToMaximize($item[spring shoes], 200); // bonus to heal in wereprof as the werewolf
+			addBonusToMaximize($item[spring shoes], 200); // bonus to heal in wereprof as the werewolf after transition from Professor
 		}
 		else // just add a little bonus for the MP generation
 		{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -729,7 +729,7 @@ void finalizeMaximize(boolean speculative)
 		}
 	}
 
-	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[biphasic molecular oculus]) || possessEquipment($item[triphasic molecular oculus]))) //Want that Advanced Research as a professor
+	if(is_professor() && (possessEquipment($item[biphasic molecular oculus]) || possessEquipment($item[triphasic molecular oculus]))) //Want that Advanced Research as a professor
 	{
 		float [monster] monster_list = appearance_rates(my_location());
 		string advresearch = get_property("wereProfessorAdvancedResearch");
@@ -768,7 +768,7 @@ void finalizeMaximize(boolean speculative)
 		}
 	}
 
-	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[high-tension exoskeleton]) || possessEquipment($item[ultra-high-tension exoskeleton]) || possessEquipment($item[irresponsible-tension exoskeleton]))) //Want that damage avoidance
+	if(is_professor() && (possessEquipment($item[high-tension exoskeleton]) || possessEquipment($item[ultra-high-tension exoskeleton]) || possessEquipment($item[irresponsible-tension exoskeleton]))) //Want that damage avoidance
 	{
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
 		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -738,11 +738,11 @@ void finalizeMaximize(boolean speculative)
 		int totalmob = 0;
 		//calculate total non-boss and non-UR mobs
 		foreach mob, freq in monster_list {
-			if(freq > 0 && mon.id > 0 && mon.copyable && !mon.boss) totalmob += 1;
+			if(freq > 0 && mob.id > 0 && mob.copyable && !mob.boss) totalmob += 1;
 		}
 		//find how many mobs we've already researched and if the count matches total non-boss/non-UR mobs, don't equip the oculus
 		foreach mob, freq in monster_list {
-			if(freq > 0 && mon.id > 0 && mon.copyable && !mon.boss)
+			if(freq > 0 && mob.id > 0 && mob.copyable && !mob.boss)
 			{
 				if(contains_text(advresearch, mob.id))
 				{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -731,10 +731,19 @@ void finalizeMaximize(boolean speculative)
 
 	if(in_wereprof() && !is_werewolf() && (possessEquipment($item[biphasic molecular oculus]) || possessEquipment($item[triphasic molecular oculus]))) //Want that Advanced Research as a professor
 	{
+		monster [int] monster_list = get_monsters(my_location());
+		string advresearch = get_property("wereProfessorAdvancedResearch");
+		boolean nooculus = false;
+		int monseen = 0;
+		foreach mon in monster_list {
+			if(contains_text(advresearch, monster_list[mon].id)) monseen += 1;
+			auto_log_info(monseen + " monsters researched of " + count(monster_list), "blue");
+			if monseen == count(monster_list) nooculus = true;
+		}
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
 		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
 		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
-		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room] contains my_location()))
+		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room] contains my_location()) && !nooculus)
 		{
 			if(possessEquipment($item[biphasic molecular oculus]))
 			{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -717,7 +717,7 @@ void finalizeMaximize(boolean speculative)
 		}
 	}
 
-	if(in_wereprof() && !is_werewolf() && auto_haveDarts()) //Absolutely need darts for Professor
+	if(in_wereprof() && auto_haveDarts()) //Absolutely need darts for Professor. Should level up darts while Werewolf
 	{
 		addBonusToMaximize($item[Everfull Dart Holster], 1000);
 	}
@@ -726,22 +726,28 @@ void finalizeMaximize(boolean speculative)
 	{
 		if(item_amount($item[biphasic molecular oculus]) > 0)
 		{
-			addBonusToMaximize($item[biphasic molecular oculus], 1000);
+			addToMaximize("+equip " + $item[biphasic molecular oculus]);
 		}
-		addBonusToMaximize($item[triphasic molecular oculus], 1000);
+		else
+		{
+			addToMaximize("+equip " + $item[triphasic molecular oculus]);
+		}
 	}
 
 	if(in_wereprof() && !is_werewolf() && (item_amount($item[high-tension exoskeleton]) > 0 || item_amount($item[ultra-high-tension exoskeleton]) > 0 || item_amount($item[irresponsible-tension exoskeleton]) > 0)) //Want that damage avoidance
 	{
 		if(item_amount($item[high-tension exoskeleton]) > 0)
 		{
-			addBonusToMaximize($item[high-tension exoskeleton], 1000);
+			addToMaximize("+equip " + $item[high-tension exoskeleton]);
 		}
-		if(item_amount($item[ultra-high-tension exoskeleton]) > 0)
+		else if(item_amount($item[ultra-high-tension exoskeleton]) > 0)
 		{
-			addBonusToMaximize($item[ultra-high-tension exoskeleton], 1000);
+			addToMaximize("+equip " + $item[ultra-high-tension exoskeleton]);
 		}
-		addBonusToMaximize($item[irresponsible-tension exoskeleton], 1000);
+		else
+		{
+			addToMaximize("+equip " + $item[irresponsible-tension exoskeleton]);
+		}
 	}
 
 	

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -763,6 +763,10 @@ void finalizeMaximize(boolean speculative)
 		{
 			addBonusToMaximize($item[spring shoes], 200);
 		}
+		else if(in_wereprof() && my_hp() < 0.5*my_maxhp() && my_hp() > 0)
+		{
+			addBonusToMaximize($item[spring shoes], 200); // bonus to heal in wereprof as the werewolf
+		}
 		else // just add a little bonus for the MP generation
 		{
 			addBonusToMaximize($item[spring shoes], 50);

--- a/RELEASE/scripts/autoscend/auto_powerlevel.ash
+++ b/RELEASE/scripts/autoscend/auto_powerlevel.ash
@@ -4,6 +4,10 @@ boolean isAboutToPowerlevel() {
 
 location highestScalingZone()
 {
+	if(my_adventures() > 2 && is_professor()) //only give a scaling location as professor if at bedtime
+	{
+		return $location[none];
+	}
 	//all scaling zones have monster level = my_buffedstat($stat[moxie]) + monster_level_adjustment() + enemy_value. up to a cap
 	//returns the zone with the highest enemy_value which we can adventure in
 	if(neverendingPartyAvailable())

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -802,12 +802,12 @@ boolean auto_pre_adventure()
 		purgeML = false;
 	}
 
-	// want as little ML as possible as professor in wereprof
+	// Path Specific Conditions
 	if(in_wereprof() && !is_werewolf())
 	{
 		doML = false;
 		removeML = true;
-		purgeML = false;
+		purgeML = true;
 	}
 
 	// Act on ML settings

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -742,6 +742,14 @@ boolean auto_pre_adventure()
 		purgeML = false;
 	}
 
+	// want as little ML as possible as professor in wereprof
+	if(in_wereprof() && !is_werewolf())
+	{
+		doML = false;
+		removeML = true;
+		purgeML = false;
+	}
+
 		// NOTE: If we aren't quits before we pass L13, let us gain stats.
 	if ((get_property("flyeredML").to_int() > 9999 || internalQuestStatus("questL12War") > 1 || get_property("sidequestArenaCompleted") != "none") && my_level() > 12)
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -748,14 +748,6 @@ boolean auto_pre_adventure()
 		purgeML = false;
 	}
 
-	// want as little ML as possible as professor in wereprof
-	if(in_wereprof() && !is_werewolf())
-	{
-		doML = false;
-		removeML = true;
-		purgeML = false;
-	}
-
 		// NOTE: If we aren't quits before we pass L13, let us gain stats.
 	if ((get_property("flyeredML").to_int() > 9999 || internalQuestStatus("questL12War") > 1 || get_property("sidequestArenaCompleted") != "none") && my_level() > 12)
 	{
@@ -807,6 +799,14 @@ boolean auto_pre_adventure()
 	{
 		doML = true;
 		removeML = false;
+		purgeML = false;
+	}
+
+	// want as little ML as possible as professor in wereprof
+	if(in_wereprof() && !is_werewolf())
+	{
+		doML = false;
+		removeML = true;
 		purgeML = false;
 	}
 

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -219,6 +219,7 @@ boolean auto_pre_adventure()
 		auto_is_valid($item[red rocket]) &&				// or if it's not valid
 		can_eat() &&									// be in a path that can eat
 		my_class() != $class[Pig Skinner] &&			// don't want to use a red rocket in Pig Skinner
+		in_wereprof() &&								// don't use if we are in WereProf
 		!auto_haveDarts() &&							// don't want to use a red rocket if we have darts
 		my_meat() > npc_price($item[red rocket]) + meatReserve())
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -219,7 +219,7 @@ boolean auto_pre_adventure()
 		auto_is_valid($item[red rocket]) &&				// or if it's not valid
 		can_eat() &&									// be in a path that can eat
 		my_class() != $class[Pig Skinner] &&			// don't want to use a red rocket in Pig Skinner
-		in_wereprof() &&								// don't use if we are in WereProf
+		!in_wereprof() &&								// don't use if we are in WereProf
 		!auto_haveDarts() &&							// don't want to use a red rocket if we have darts
 		my_meat() > npc_price($item[red rocket]) + meatReserve())
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -803,7 +803,7 @@ boolean auto_pre_adventure()
 	}
 
 	// Path Specific Conditions
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())  //WereProfessor professor doesn't like ML
 	{
 		doML = false;
 		removeML = true;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -124,6 +124,11 @@ void auto_ghost_prep(location place)
 		}
 		if(canUse(sk)) return;	//we can kill them with a spell
 	}
+	if(auto_haveDarts() && dartEleDmg())
+	{
+		addToMaximize("+equip " + $item[Everfull Dart Holster]); //If we have darts and they have elemental damage buff, might as well use that
+		return;
+	}
 	
 	int m_hot = 1;
 	int m_cold = 1;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -126,7 +126,7 @@ void auto_ghost_prep(location place)
 	}
 	if(auto_haveDarts() && dartEleDmg())
 	{
-		addToMaximize("+equip " + $item[Everfull Dart Holster]); //If we have darts and they have elemental damage buff, might as well use that
+		addToMaximize("+equip " + $item[Everfull Dart Holster]); //If we have darts and an elemental damage buff, might as well use that
 		return;
 	}
 	

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2132,6 +2132,10 @@ int doRest()
 		}
 
 	}
+	else if (!is_werewolf() && in_wereprof())
+	{
+		visit_url("place.php?whichplace=wereprof_cottage&action=wereprof_sleep");
+	}
 	else
 	{
 		set_property("restUsingChateau", false);

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2132,7 +2132,7 @@ int doRest()
 		}
 
 	}
-	else if (!is_werewolf() && in_wereprof())
+	else if(is_professor())
 	{
 		visit_url("place.php?whichplace=wereprof_cottage&action=wereprof_sleep");
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3983,7 +3983,7 @@ boolean auto_MaxMLToCap(int ToML, boolean doAltML)
 
 // 30
 	// Start with the biggest and drill down for max ML
-	tryEffects($effects[Ceaseless Snarling, Punchable Face, Zomg WTF]);
+	tryEffects($effects[Ceaseless Snarling, Punchable Face, Zomg WTF, Keep Free Hate In Your Heart]);
 
 // 29 >= U >= 25
 	UrKelCheck(ToML, 29, 25);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3014,7 +3014,7 @@ boolean auto_is_valid(familiar fam)
 	{
 		return to_familiar(get_property("auto_100familiar")) == fam;
 	}
-	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zombieSlayer_usable(fam) && is_unrestricted(fam);
+	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zombieSlayer_usable(fam) && is_unrestricted(fam) || (in_wereprof() && fam != $familiar[stooper]);
 }
 
 boolean auto_is_valid(skill sk)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3021,8 +3021,8 @@ boolean auto_is_valid(skill sk)
 {
 	// Hack for Legacy of Loathing as is_unrestricted returns false for Source Terminal skills
 	if (in_lol() && $skills[Extract, Turbo, Digitize, Duplicate, Portscan, Compress] contains sk) return true;
-	// No skills for the Professor in WereProf
-	if (in_wereprof() && !is_werewolf()) return false;
+	// No skills for the Professor except Advanced Research in WereProf
+	if (in_wereprof() && !is_werewolf() && sk != to_skill(7512)) return false;
 	//do not check check for B in bees hate you path. it only restricts items and not skills.
 	return (glover_usable(sk.to_string()) || (sk.passive && sk != $skill[disco nap])) && bat_skillValid(sk) && plumber_skillValid(sk) && is_unrestricted(sk);
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -858,6 +858,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		// TODO add fam weight buffing
 		int banderRunsLeft = floor((familiar_weight($familiar[Frumious Bandersnatch]) + weight_adjustment()) / 5) - get_property("_banderRunaways").to_int();
+		if(in_wereprof() && !is_werewolf()) return "";
 		if(!inCombat)
 		{
 			if(auto_have_skill($skill[The Ode to Booze]) &&
@@ -884,6 +885,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		// TODO add fam weight buffing
 		// boots and bander share same counter
 		int banderRunsLeft = floor((familiar_weight($familiar[Pair of Stomping Boots]) + weight_adjustment()) / 5) - get_property("_banderRunaways").to_int();
+		if(in_wereprof() && !is_werewolf()) return "";
 		if(!inCombat)
 		{
 			if(banderRunsLeft > 0 && handleFamiliar($familiar[Pair of Stomping Boots]))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -858,7 +858,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		// TODO add fam weight buffing
 		int banderRunsLeft = floor((familiar_weight($familiar[Frumious Bandersnatch]) + weight_adjustment()) / 5) - get_property("_banderRunaways").to_int();
-		if(in_wereprof() && !is_werewolf()) return "";
+		if(is_professor()) return "";
 		if(!inCombat)
 		{
 			if(auto_have_skill($skill[The Ode to Booze]) &&
@@ -885,7 +885,7 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 		// TODO add fam weight buffing
 		// boots and bander share same counter
 		int banderRunsLeft = floor((familiar_weight($familiar[Pair of Stomping Boots]) + weight_adjustment()) / 5) - get_property("_banderRunaways").to_int();
-		if(in_wereprof() && !is_werewolf()) return "";
+		if(is_professor()) return "";
 		if(!inCombat)
 		{
 			if(banderRunsLeft > 0 && handleFamiliar($familiar[Pair of Stomping Boots]))
@@ -3022,7 +3022,7 @@ boolean auto_is_valid(skill sk)
 	// Hack for Legacy of Loathing as is_unrestricted returns false for Source Terminal skills
 	if (in_lol() && $skills[Extract, Turbo, Digitize, Duplicate, Portscan, Compress] contains sk) return true;
 	// No skills for the Professor except Advanced Research in WereProf
-	if (in_wereprof() && !is_werewolf() && sk != to_skill(7512)) return false;
+	if (is_professor() && sk != to_skill(7512)) return false;
 	//do not check check for B in bees hate you path. it only restricts items and not skills.
 	return (glover_usable(sk.to_string()) || (sk.passive && sk != $skill[disco nap])) && bat_skillValid(sk) && plumber_skillValid(sk) && is_unrestricted(sk);
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3984,10 +3984,6 @@ boolean auto_MaxMLToCap(int ToML, boolean doAltML)
 // 30
 	// Start with the biggest and drill down for max ML
 	tryEffects($effects[Ceaseless Snarling, Punchable Face, Zomg WTF]);
-	if(!in_wereprof())
-	{
-		tryEffects($effects[Keep Free Hate In Your Heart]); // too long of a buff for wereprof
-	}
 
 // 29 >= U >= 25
 	UrKelCheck(ToML, 29, 25);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3019,6 +3019,8 @@ boolean auto_is_valid(skill sk)
 {
 	// Hack for Legacy of Loathing as is_unrestricted returns false for Source Terminal skills
 	if (in_lol() && $skills[Extract, Turbo, Digitize, Duplicate, Portscan, Compress] contains sk) return true;
+	// No skills for the Professor in WereProf
+	if (in_wereprof() && !is_werewolf()) return false;
 	//do not check check for B in bees hate you path. it only restricts items and not skills.
 	return (glover_usable(sk.to_string()) || (sk.passive && sk != $skill[disco nap])) && bat_skillValid(sk) && plumber_skillValid(sk) && is_unrestricted(sk);
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1435,6 +1435,10 @@ boolean isGeneralStoreAvailable()
 	{
 		return false;
 	}
+	if(is_werewolf())
+	{
+		return false;
+	}
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -798,6 +798,7 @@ boolean canFreeRun(monster enemy, location loc)
 string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inCombat)
 {
 	if (isFreeMonster(enemy, loc)) return "";
+	if (is_werewolf()) return ""; //can't freerun as a Werewolf in WereProfessor
 
 	// Prefer some specalized free run items before other sources
 	if (!inAftercore() && have_effect($effect[Everything Looks Green]) == 0)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3014,7 +3014,7 @@ boolean auto_is_valid(familiar fam)
 	{
 		return to_familiar(get_property("auto_100familiar")) == fam;
 	}
-	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zombieSlayer_usable(fam) && is_unrestricted(fam) || (in_wereprof() && fam != $familiar[stooper]);
+	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zombieSlayer_usable(fam) && wereprof_usable(fam.to_string()) && is_unrestricted(fam);
 }
 
 boolean auto_is_valid(skill sk)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -822,6 +822,7 @@ string freeRunCombatStringPreBanish(monster enemy, location loc, boolean inComba
 string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 {
 	if (isFreeMonster(enemy, my_location())) return "";
+	if (is_werewolf()) return ""; //can't freerun as a Werewolf in WereProfessor
 	string pre_banish = freeRunCombatStringPreBanish(enemy, loc, inCombat);
 	if (pre_banish != "") return pre_banish;
 

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3983,7 +3983,11 @@ boolean auto_MaxMLToCap(int ToML, boolean doAltML)
 
 // 30
 	// Start with the biggest and drill down for max ML
-	tryEffects($effects[Ceaseless Snarling, Punchable Face, Zomg WTF, Keep Free Hate In Your Heart]);
+	tryEffects($effects[Ceaseless Snarling, Punchable Face, Zomg WTF]);
+	if(!in_wereprof())
+	{
+		tryEffects($effects[Keep Free Hate In Your Heart]); // too long of a buff for wereprof
+	}
 
 // 29 >= U >= 25
 	UrKelCheck(ToML, 29, 25);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -918,6 +918,7 @@ boolean in_wereprof();
 void wereprof_initializeSettings();
 boolean is_werewolf();
 void wereprof_buySkills();
+boolean wereprof_haveAllEquipment();
 void wereprof_buyEquip();
 boolean wereprof_oculus();
 boolean LM_wereprof();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -932,6 +932,7 @@ void wereprof_buyEquip();
 boolean wereprof_oculus();
 boolean LM_wereprof();
 boolean LX_wereprof_getSmashedEquip();
+boolean wereprof_usable(string str);
 
 ########################################################################################################
 //Defined in autoscend/paths/wildfire.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -556,6 +556,7 @@ void dartChoiceHandler(int choice, string[int] options);
 int dartBullseyeChance();
 int dartELRcd();
 skill dartSkill();
+boolean dartEleDmg()
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -556,7 +556,7 @@ void dartChoiceHandler(int choice, string[int] options);
 int dartBullseyeChance();
 int dartELRcd();
 skill dartSkill();
-boolean dartEleDmg()
+boolean dartEleDmg();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -918,6 +918,7 @@ boolean is_werewolf();
 void wereprof_buySkills();
 void wereprof_buyEquip();
 boolean wereprof_oculus();
+boolean LM_wereprof();
 boolean LX_wereprof_getSmashedEquip();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -925,6 +925,7 @@ boolean in_wotsf();
 boolean in_wereprof();
 void wereprof_initializeSettings();
 boolean is_werewolf();
+boolean is_professor();
 void wereprof_buySkills();
 boolean wereprof_haveAllEquipment();
 void wereprof_buyEquip();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -917,6 +917,7 @@ void wereprof_initializeSettings();
 boolean is_werewolf();
 void wereprof_buySkills();
 void wereprof_buyEquip();
+boolean werewolf_oculus();
 boolean LX_wereprof_getSmashedEquip();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -911,6 +911,15 @@ boolean tcrs_maximize_with_items(string maximizerString);
 boolean in_wotsf();
 
 ########################################################################################################
+//Defined in autoscend/paths/wereprofessor.ash
+boolean in_wereprof();
+void wereprof_initializeSettings();
+boolean is_werewolf();
+void wereprof_buySkills();
+void wereprof_buyEquip();
+boolean LX_wereprof_getSmashedEquip();
+
+########################################################################################################
 //Defined in autoscend/paths/wildfire.ash
 boolean in_wildfire();
 void wildfire_initializeSettings();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -917,7 +917,7 @@ void wereprof_initializeSettings();
 boolean is_werewolf();
 void wereprof_buySkills();
 void wereprof_buyEquip();
-boolean werewolf_oculus();
+boolean wereprof_oculus();
 boolean LX_wereprof_getSmashedEquip();
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -19,6 +19,7 @@ import <autoscend/combat/auto_combat_ocrs.ash>						//path = one crazy random su
 import <autoscend/combat/auto_combat_pete.ash>						//path = avatar of sneaky pete
 import <autoscend/combat/auto_combat_plumber.ash>					//path = path of the plumber
 import <autoscend/combat/auto_combat_the_source.ash>				//path = the source
+import <autoscend/combat/auto_combat_wereprofessor.ash>				//path = wereprofessor
 import <autoscend/combat/auto_combat_wildfire.ash>					//path = wildfire
 import <autoscend/combat/auto_combat_you_robot.ash>					//path = you, robot
 import <autoscend/combat/auto_combat_zombie_slayer.ash>				//path = zombie slayer

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -35,6 +35,10 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	retval = auto_combatFallOfTheDinosaursStage1(round, enemy, text);
 	if(retval != "") return retval;
 
+	// Path = WereProfessor
+	retval = auto_combatWereProfessorStage1(round, enemy, text);
+	if(retval != "") return retval;
+
 	if(enemy == $monster[Your Shadow])
 	{
 		if(in_plumber())

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -158,6 +158,10 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		{
 			return "item " + $item[Electric Boning Knife];
 		}
+		if(canUse($skill[Slaughter]) && have_effect($effect[Everything Looks Red]) == 0)
+		{
+			return useSkill($skill[Slaughter]);
+		}
 		if(((my_hp() * 4) < my_maxhp()) && (have_effect($effect[Takin\' It Greasy]) > 0))
 		{
 			return useSkill($skill[Unleash The Greash], false);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -34,7 +34,7 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 	// Path = Fall of the Dinosaurs
 	retval = auto_combatFallOfTheDinosaursStage1(round, enemy, text);
 	if(retval != "") return retval;
-	
+
 	if(enemy == $monster[Your Shadow])
 	{
 		if(in_plumber())

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage1.ash
@@ -158,10 +158,6 @@ string auto_combatDefaultStage1(int round, monster enemy, string text)
 		{
 			return "item " + $item[Electric Boning Knife];
 		}
-		if(canUse($skill[Slaughter]) && have_effect($effect[Everything Looks Red]) == 0)
-		{
-			return useSkill($skill[Slaughter]);
-		}
 		if(((my_hp() * 4) < my_maxhp()) && (have_effect($effect[Takin\' It Greasy]) > 0))
 		{
 			return useSkill($skill[Unleash The Greash], false);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -3,7 +3,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 	// stage 2 = enders: escape, replace, instakill, yellowray and other actions that instantly end combat
 	string retval;
 
-	// Skip if have drones out
+	// Skip if have auto_skipStage2 is set
 	if(get_property("auto_skipStage2").to_boolean()) return "";
 	
 	//if we want to olfact in stage 4 then we should delay stage 2 until we olfact.

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -369,6 +369,15 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			loopHandlerDelayAll();
 			return useSkill($skill[Darts: Aim for the Bullseye]);
 		}
+
+		if(canUse($skill[Slaughter]) && have_effect($effect[Everything Looks Red]) == 0)
+		{
+			set_property("auto_instakillSource", "slaughter");
+			set_property("auto_instakillSuccess", true);
+			loopHandlerDelayAll();
+			return useSkill($skill[Slaughter]);
+		}
+
 		if(canUse($skill[Chest X-Ray]) && equipped_amount($item[Lil\' Doctor&trade; bag]) > 0 && (get_property("_chestXRayUsed").to_int() < 3))
 		{
 			if((wantFreeKillNowEspecially || my_adventures() < 20) || inAftercore() || (my_daycount() >= 3))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -8,6 +8,9 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 
 	//Unskip stage 2
 	if(get_property("auto_skipStage2").to_boolean()) set_property("auto_skipStage2", false);
+
+	//Skip stage 3 if set
+	if(get_property("auto_skipStage3").to_boolean()) return "";
 	
 	// Path = Heavy Rains
 	retval = auto_combatHeavyRainsStage3(round, enemy, text);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -15,6 +15,10 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 	retval = auto_combatZombieSlayerStage4(round, enemy, text);
 	if(retval != "") return retval;
 
+	// Path = WereProfessor
+	retval = auto_combatWereProfessorStage4(round, enemy, text);
+	if(retval != "") return retval;
+	
 	// Skip if have drones out
 	if(get_property("auto_skipStage4").to_boolean()) return "";
 	

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage4.ash
@@ -2,6 +2,9 @@ string auto_combatDefaultStage4(int round, monster enemy, string text)
 {
 	// stage 4 = prekill. copy, sing along, flyer and other things that need to be done after delevel but before killing
 	string retval;
+
+	//Unskip stage 3
+	if(get_property("auto_skipStage3").to_boolean()) set_property("auto_skipStage3", false);
 	
 	// Path = The Source
 	retval = auto_combatTheSourceStage4(round, enemy, text);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -163,7 +163,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	//Everfull Dart Holder
 	if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0)
 	{
-		return useSkill(dartSkill());
+		return useSkill(dartSkill(), false);
 	}
     
 	//mortar shell is amazing. it really should not be limited to sauceror only.

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -34,6 +34,10 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 	retval = auto_combatFallOfTheDinosaursStage5(round, enemy, text);
 	if(retval != "") return retval;
 
+	// Path = Wereprofessor
+	retval = auto_combatWereProfessorStage5(round, enemy, text);
+	if(retval != "") return retval;
+
 	//with loofah, you can stagger and deal cold or hot damage
 	if(canUse($skill[loofah stew]) && monster_element(enemy) != $element[cold])
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -148,7 +148,7 @@ string auto_combatBHYStage1(int round, monster enemy, string text);
 
 #####################################################
 //defined in /autoscend/combat/auto_combat_wereprofessor.ash
-string auto_combatWereProfessorStage1(int round, monster enemy, string text);
+string auto_combatWereProfessorStage4(int round, monster enemy, string text);
 string auto_combatWereProfessorStage5(int round, monster enemy, string text);
 
 #####################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -147,6 +147,11 @@ string auto_combatTheSourceStage4(int round, monster enemy, string text);
 string auto_combatBHYStage1(int round, monster enemy, string text);
 
 #####################################################
+//defined in /autoscend/combat/auto_combat_wereprofessor.ash
+string auto_combatWereProfessorStage1(int round, monster enemy, string text);
+string auto_combatWereProfessorStage5(int round, monster enemy, string text);
+
+#####################################################
 //defined in /autoscend/combat/auto_combat_wildfire.ash
 string auto_combatWildfireStage1(int round, monster enemy, string text);
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -148,6 +148,7 @@ string auto_combatBHYStage1(int round, monster enemy, string text);
 
 #####################################################
 //defined in /autoscend/combat/auto_combat_wereprofessor.ash
+string auto_combatWereProfessorStage1(int round, monster enemy, string text);
 string auto_combatWereProfessorStage4(int round, monster enemy, string text);
 string auto_combatWereProfessorStage5(int round, monster enemy, string text);
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -239,7 +239,7 @@ boolean isSniffed(monster enemy, skill sk)
 boolean isSniffed(monster enemy)
 {
 	//checks if the monster enemy is currently sniffed using any of the sniff skills
-	foreach sk in $skills[Transcendent Olfaction, Make Friends, Long Con, Perceive Soul, Gallapagosian Mating Call, Monkey Point, Offer Latte to Opponent, Motif, Hunt]
+	foreach sk in $skills[Transcendent Olfaction, Make Friends, Long Con, Perceive Soul, Gallapagosian Mating Call, Monkey Point, Offer Latte to Opponent, Motif]
 	{
 		if(isSniffed(enemy, sk)) return true;
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -259,6 +259,10 @@ skill getSniffer(monster enemy, boolean inCombat)
 	{
 		return $skill[Make Friends];		//avatar of sneaky pete specific skill
 	}
+	if(canUse($skill[Hunt], true, inCombat) && have_effect($effect[Everything Looks Red!]) == 0 && !isSniffed(enemy, $skill[Hunt]))
+	{
+		return $skill[Hunt];				//WereProfessor Werewolf specific skill
+	}
 	if(canUse($skill[Long Con], true , inCombat) && get_property("_longConUsed").to_int() < 5 && !isSniffed(enemy, $skill[Long Con]))
 	{
 		return $skill[Long Con];
@@ -636,6 +640,11 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	if(auto_canFeelHatred() && auto_is_valid($skill[Feel Hatred]) && !(used contains "Feel Hatred"))
 	{
 		return "skill " + $skill[Feel Hatred];
+	}
+
+	if(auto_have_skill($skill[[7510]Punt]) && !(used contains "Punt"))
+	{
+		return "skill " + $skill[[7510]Punt];
 	}
 	
 	if(auto_have_skill($skill[[28021]Punt]) && (my_mp() > mp_cost($skill[[28021]Punt])) && !(used contains "Punt"))

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -515,6 +515,12 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	if(inCombat)
 		auto_log_info("Finding a banisher to use on " + enemy + " at " + loc, "green");
 
+	boolean useFree = true; // use banisher that is a freerun
+	if(is_werewolf())
+	{
+		useFree = false; // werewolves don't run
+	}
+
 	//src/net/sourceforge/kolmafia/session/BanishManager.java
 	boolean[string] used = auto_banishesUsedAt(loc);
 
@@ -549,7 +555,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Spring Kick];
 	}
 
-	if(auto_have_skill($skill[Peel Out]) && pete_peelOutRemaining() > 0 && get_property("peteMotorbikeMuffler") == "Extra-Smelly Muffler" && !(used contains "Peel Out"))
+	if(auto_have_skill($skill[Peel Out]) && pete_peelOutRemaining() > 0 && get_property("peteMotorbikeMuffler") == "Extra-Smelly Muffler" && !(used contains "Peel Out") && useFree)
 	{
 		return "skill " + $skill[Peel Out];
 	}
@@ -559,22 +565,22 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Howl of the Alpha];
 	}
 
-	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member\'s mug])) && auto_is_valid($skill[Throw Latte On Opponent]) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent"))
+	if((inCombat ? auto_have_skill($skill[Throw Latte on Opponent]) : possessEquipment($item[latte lovers member\'s mug])) && auto_is_valid($skill[Throw Latte On Opponent]) && !get_property("_latteBanishUsed").to_boolean() && !(used contains "Throw Latte on Opponent") && useFree)
 	{
 		return "skill " + $skill[Throw Latte on Opponent];
 	}
 
-	if((inCombat ? auto_have_skill($skill[Give Your Opponent The Stinkeye]) : possessEquipment($item[stinky cheese eye])) && auto_is_valid($skill[Give Your Opponent The Stinkeye]) && !get_property("_stinkyCheeseBanisherUsed").to_boolean() && (my_mp() >= mp_cost($skill[Give Your Opponent The Stinkeye])))
+	if((inCombat ? auto_have_skill($skill[Give Your Opponent The Stinkeye]) : possessEquipment($item[stinky cheese eye])) && auto_is_valid($skill[Give Your Opponent The Stinkeye]) && !get_property("_stinkyCheeseBanisherUsed").to_boolean() && (my_mp() >= mp_cost($skill[Give Your Opponent The Stinkeye])) && useFree)
 	{
 		return "skill " + $skill[Give Your Opponent The Stinkeye];
 	}
 
-	if((inCombat ? auto_have_skill($skill[Creepy Grin]) : possessEquipment($item[V for Vivala mask])) && auto_is_valid($skill[Creepy Grin]) && !get_property("_vmaskBanisherUsed").to_boolean() && (my_mp() >= mp_cost($skill[Creepy Grin])))
+	if((inCombat ? auto_have_skill($skill[Creepy Grin]) : possessEquipment($item[V for Vivala mask])) && auto_is_valid($skill[Creepy Grin]) && !get_property("_vmaskBanisherUsed").to_boolean() && (my_mp() >= mp_cost($skill[Creepy Grin])) && useFree)
 	{
 		return "skill " + $skill[Creepy Grin];
 	}
 
-	if(auto_have_skill($skill[Baleful Howl]) && my_hp() > hp_cost($skill[Baleful Howl]) && get_property("_balefulHowlUses").to_int() < 10 && !(used contains "baleful howl"))
+	if(auto_have_skill($skill[Baleful Howl]) && my_hp() > hp_cost($skill[Baleful Howl]) && get_property("_balefulHowlUses").to_int() < 10 && !(used contains "baleful howl") && useFree)
 	{
 		loopHandlerDelayAll();
 		return "skill " + $skill[Baleful Howl];
@@ -584,7 +590,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		return "skill " + $skill[Thunder Clap];
 	}
-	if(auto_have_skill($skill[Asdon Martin: Spring-Loaded Front Bumper]) && auto_is_valid($skill[Asdon Martin: Spring-Loaded Front Bumper]) && (get_fuel() >= fuel_cost($skill[Asdon Martin: Spring-Loaded Front Bumper])) && (!(used contains "Spring-Loaded Front Bumper")))
+	if(auto_have_skill($skill[Asdon Martin: Spring-Loaded Front Bumper]) && auto_is_valid($skill[Asdon Martin: Spring-Loaded Front Bumper]) && (get_fuel() >= fuel_cost($skill[Asdon Martin: Spring-Loaded Front Bumper])) && (!(used contains "Spring-Loaded Front Bumper")) && useFree)
 	{
 		if(!contains_text(get_property("banishedMonsters"), "Spring-Loaded Front Bumper"))
 		{
@@ -596,11 +602,11 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Curse Of Vacation];
 	}
 
-	if((inCombat ? auto_have_skill($skill[Show Them Your Ring]) : possessEquipment($item[Mafia middle finger ring])) && auto_is_valid($skill[Show Them Your Ring]) && can_equip($item[Mafia middle finger ring]) && !get_property("_mafiaMiddleFingerRingUsed").to_boolean() && (my_mp() >= mp_cost($skill[Show Them Your Ring])))
+	if((inCombat ? auto_have_skill($skill[Show Them Your Ring]) : possessEquipment($item[Mafia middle finger ring])) && auto_is_valid($skill[Show Them Your Ring]) && can_equip($item[Mafia middle finger ring]) && !get_property("_mafiaMiddleFingerRingUsed").to_boolean() && (my_mp() >= mp_cost($skill[Show Them Your Ring])) && useFree)
 	{
 		return "skill " + $skill[Show Them Your Ring];
 	}
-	if(auto_have_skill($skill[Breathe Out]) && auto_is_valid($skill[Breathe Out]) && (!(used contains "breathe out")))
+	if(auto_have_skill($skill[Breathe Out]) && auto_is_valid($skill[Breathe Out]) && (!(used contains "breathe out")) && useFree)
 	{
 		return "skill " + $skill[Breathe Out];
 	}
@@ -622,22 +628,22 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		return "skill " + $skill[Talk About Politics];
 	}
-	if((inCombat ? auto_have_skill($skill[Reflex Hammer]) : possessEquipment($item[Lil\' Doctor&trade; bag])) && auto_is_valid($skill[Reflex Hammer]) && get_property("_reflexHammerUsed").to_int() < 3 && !(used contains "Reflex Hammer"))
+	if((inCombat ? auto_have_skill($skill[Reflex Hammer]) : possessEquipment($item[Lil\' Doctor&trade; bag])) && auto_is_valid($skill[Reflex Hammer]) && get_property("_reflexHammerUsed").to_int() < 3 && !(used contains "Reflex Hammer") && useFree)
 	{
 		return "skill " + $skill[Reflex Hammer];
 	}
-	if((inCombat ? auto_have_skill($skill[Show Your Boring Familiar Pictures]) : possessEquipment($item[familiar scrapbook])) && auto_is_valid($skill[Show Your Boring Familiar Pictures]) && (get_property("scrapbookCharges").to_int() >= 200 || (get_property("scrapbookCharges").to_int() >= 100 && my_level() >= 13)) && !(used contains "Show Your Boring Familiar Pictures"))
+	if((inCombat ? auto_have_skill($skill[Show Your Boring Familiar Pictures]) : possessEquipment($item[familiar scrapbook])) && auto_is_valid($skill[Show Your Boring Familiar Pictures]) && (get_property("scrapbookCharges").to_int() >= 200 || (get_property("scrapbookCharges").to_int() >= 100 && my_level() >= 13)) && !(used contains "Show Your Boring Familiar Pictures") && useFree)
 	{
 		return "skill " + $skill[Show Your Boring Familiar Pictures];
 	}
 
 	// bowling ball is only in inventory if it is available to use in combat. While on cooldown, it is not in inventory
-	if((inCombat ? auto_have_skill($skill[Bowl a Curveball]) : item_amount($item[Cosmic Bowling Ball]) > 0) && auto_is_valid($skill[Bowl a Curveball]) && !(used contains "Bowl a Curveball"))
+	if((inCombat ? auto_have_skill($skill[Bowl a Curveball]) : item_amount($item[Cosmic Bowling Ball]) > 0) && auto_is_valid($skill[Bowl a Curveball]) && !(used contains "Bowl a Curveball") && useFree)
 	{
 		return "skill " + $skill[Bowl a Curveball];
 	}
 
-	if(auto_canFeelHatred() && auto_is_valid($skill[Feel Hatred]) && !(used contains "Feel Hatred"))
+	if(auto_canFeelHatred() && auto_is_valid($skill[Feel Hatred]) && !(used contains "Feel Hatred") && useFree)
 	{
 		return "skill " + $skill[Feel Hatred];
 	}
@@ -662,7 +668,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		}
 	}
 
-	if((inCombat ? auto_have_skill($skill[KGB Tranquilizer Dart]) : possessEquipment($item[Kremlin\'s Greatest Briefcase])) && auto_is_valid($skill[KGB Tranquilizer Dart]) && (get_property("_kgbTranquilizerDartUses").to_int() < 3) && (my_mp() >= mp_cost($skill[KGB Tranquilizer Dart])) && (!(used contains "KGB tranquilizer dart")))
+	if((inCombat ? auto_have_skill($skill[KGB Tranquilizer Dart]) : possessEquipment($item[Kremlin\'s Greatest Briefcase])) && auto_is_valid($skill[KGB Tranquilizer Dart]) && (get_property("_kgbTranquilizerDartUses").to_int() < 3) && (my_mp() >= mp_cost($skill[KGB Tranquilizer Dart])) && (!(used contains "KGB tranquilizer dart")) && useFree)
 	{
 		boolean useIt = true;
 		if(get_property("sidequestJunkyardCompleted") != "none" && my_daycount() >= 2 && get_property("_kgbTranquilizerDartUses").to_int() >= 2)
@@ -675,7 +681,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 			return "skill " + $skill[KGB Tranquilizer Dart];
 		}
 	}
-	if(auto_have_skill($skill[Snokebomb]) && auto_is_valid($skill[Snokebomb]) && (get_property("_snokebombUsed").to_int() < 3) && ((my_mp() - 20) >= mp_cost($skill[Snokebomb])) && (!(used contains "snokebomb")))
+	if(auto_have_skill($skill[Snokebomb]) && auto_is_valid($skill[Snokebomb]) && (get_property("_snokebombUsed").to_int() < 3) && ((my_mp() - 20) >= mp_cost($skill[Snokebomb])) && (!(used contains "snokebomb")) && useFree)
 	{
 		return "skill " + $skill[Snokebomb];
 	}
@@ -708,7 +714,7 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		}
 	}
 
-	if(item_amount($item[human musk]) > 0 && (!(used contains "human musk")) && auto_is_valid($item[human musk]) && get_property("_humanMuskUses").to_int() < 3)
+	if(item_amount($item[human musk]) > 0 && (!(used contains "human musk")) && auto_is_valid($item[human musk]) && (get_property("_humanMuskUses").to_int() < 3 && useFree)) //first 3 are free
 	{
 		return "item " + $item[human musk];
 	}
@@ -725,19 +731,19 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		keep = 0;
 	}
 
-	if((item_amount($item[Louder Than Bomb]) > keep) && (!(used contains "louder than bomb")) && auto_is_valid($item[Louder Than Bomb]))
+	if((item_amount($item[Louder Than Bomb]) > keep) && (!(used contains "louder than bomb")) && auto_is_valid($item[Louder Than Bomb]) && useFree)
 	{
 		return "item " + $item[Louder Than Bomb];
 	}
-	if((item_amount($item[Tennis Ball]) > keep) && (!(used contains "tennis ball")) && auto_is_valid($item[Tennis Ball]))
+	if((item_amount($item[Tennis Ball]) > keep) && (!(used contains "tennis ball")) && auto_is_valid($item[Tennis Ball]) && useFree)
 	{
 		return "item " + $item[Tennis Ball];
 	}
-	if((item_amount($item[Deathchucks]) > keep) && (!(used contains "deathchucks"))&& auto_is_valid($item[Deathchucks]))
+	if((item_amount($item[Deathchucks]) > keep) && (!(used contains "deathchucks"))&& auto_is_valid($item[Deathchucks]) && useFree)
 	{
 		return "item " + $item[Deathchucks];
 	}
-	if((item_amount($item[divine champagne popper]) > keep) && (!(used contains "divine champagne popper"))&& auto_is_valid($item[divine champagne popper]))
+	if((item_amount($item[divine champagne popper]) > keep) && (!(used contains "divine champagne popper"))&& auto_is_valid($item[divine champagne popper]) && useFree)
 	{
 		return "item " + $item[divine champagne popper];
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -239,7 +239,7 @@ boolean isSniffed(monster enemy, skill sk)
 boolean isSniffed(monster enemy)
 {
 	//checks if the monster enemy is currently sniffed using any of the sniff skills
-	foreach sk in $skills[Transcendent Olfaction, Make Friends, Long Con, Perceive Soul, Gallapagosian Mating Call, Monkey Point, Offer Latte to Opponent, Motif]
+	foreach sk in $skills[Transcendent Olfaction, Make Friends, Long Con, Perceive Soul, Gallapagosian Mating Call, Monkey Point, Offer Latte to Opponent, Motif, Hunt]
 	{
 		if(isSniffed(enemy, sk)) return true;
 	}
@@ -259,10 +259,11 @@ skill getSniffer(monster enemy, boolean inCombat)
 	{
 		return $skill[Make Friends];		//avatar of sneaky pete specific skill
 	}
-	if(canUse($skill[Hunt], true, inCombat) && have_effect($effect[Everything Looks Red]) == 0 && !isSniffed(enemy, $skill[Hunt]))
+	//commented out because Mafia doesn't track Hunt yet
+	/*if(canUse($skill[Hunt], true, inCombat) && have_effect($effect[Everything Looks Red]) == 0 && !isSniffed(enemy, $skill[Hunt]))
 	{
 		return $skill[Hunt];				//WereProfessor Werewolf specific skill
-	}
+	}*/
 	if(canUse($skill[Long Con], true , inCombat) && get_property("_longConUsed").to_int() < 5 && !isSniffed(enemy, $skill[Long Con]))
 	{
 		return $skill[Long Con];

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -259,7 +259,7 @@ skill getSniffer(monster enemy, boolean inCombat)
 	{
 		return $skill[Make Friends];		//avatar of sneaky pete specific skill
 	}
-	if(canUse($skill[Hunt], true, inCombat) && have_effect($effect[Everything Looks Red!]) == 0 && !isSniffed(enemy, $skill[Hunt]))
+	if(canUse($skill[Hunt], true, inCombat) && have_effect($effect[Everything Looks Red]) == 0 && !isSniffed(enemy, $skill[Hunt]))
 	{
 		return $skill[Hunt];				//WereProfessor Werewolf specific skill
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -1,0 +1,55 @@
+string auto_combatWereProfessorStage1(int round, monster enemy, string text)
+{
+	if(!in_wereprof())
+	{
+		return "";
+	}
+	if(!is_werewolf())
+	{
+		if(canUse(to_skill(7512))) //Advanced Research
+		{
+			return(to_skill(7512));
+		}
+	}
+	return "";
+}
+
+string auto_combatWereProfessorStage5(int round, monster enemy, string text)
+{
+	if(!in_wereprof())
+	{
+		return "";
+	}
+
+	boolean enemy_physical_immune = enemy.physical_resistance > 99;
+	float enemy_physical_res = 1 - (enemy.physical_resistance * 0.01);	//convert % into float
+	float dmg;
+
+	if(is_werewolf())
+	{
+		if(enemy_physical_immune && canUse($skill[Bite]))
+		{
+			return(use_skill($skill[Bite]));
+		}
+		else if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
+		{
+			return useSkill(dartSkill());
+		}
+		if(canUse($skill[Rend]))
+		{
+			return useSkill($skill[Rend]);
+		}
+	}
+	if(!is_werewolf())
+	{
+		if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
+		{
+			return useSkill(dartSkill());
+		}
+		else
+		{
+			return "runaway"; //Can't do anything further as Professor other than using items/running away
+		}
+	}
+	return "";
+}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -7,6 +7,7 @@ string auto_combatWereProfessorStage1(int round, monster enemy, string text)
 
 	if(!is_werewolf())
 	{
+		set_property("auto_skipStage2", true); //Don't even want to try Stage 2 as a Professor
 		set_property("auto_skipStage3", true); //Don't even want to try Stage 3 as a Professor
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -1,10 +1,10 @@
-string auto_combatWereProfessorStage1(int round, monster enemy, string text)
+string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 {
 	if(!in_wereprof())
 	{
 		return "";
 	}
-	if(!is_werewolf())
+	if(!is_werewolf() && werewolf_oculus())
 	{
 		if(canUse(to_skill(7512))) //Advanced Research
 		{
@@ -44,7 +44,7 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 	{
 		if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
 		{
-			return useSkill(dartSkill());
+			return useSkill(dartSkill(), false);
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -27,12 +27,10 @@ string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 	{
 		return "";
 	}
-	if(!is_werewolf() && wereprof_oculus())
+	if(!is_werewolf() && wereprof_oculus() && !haveUsed(to_skill(7512)))
 	{
-		if(canUse(to_skill(7512))) //Advanced Research
-		{
-			return(to_skill(7512));
-		}
+		markAsUsed(to_skill(7512));
+		return(to_skill(7512));
 	}
 	return "";
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -19,7 +19,7 @@ string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 	{
 		return "";
 	}
-	if(!is_werewolf() && werewolf_oculus())
+	if(!is_werewolf() && wereprof_oculus())
 	{
 		if(canUse(to_skill(7512))) //Advanced Research
 		{
@@ -60,6 +60,10 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 		if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
 		{
 			return useSkill(dartSkill());
+		}
+		else if(auto_haveCosmicBowlingBall() && canUse($item[cosmic bowling ball]) && monster_hp() < 100)
+		{
+			return useItem($item[cosmic bowling ball]);
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -45,7 +45,7 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 	{
 		if(enemy_physical_immune && canUse($skill[Bite]))
 		{
-			return(use_skill($skill[Bite]));
+			return(use_skill($skill[Bite])); // elemental damage skill
 		}
 		else if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
 		{
@@ -62,9 +62,9 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 		{
 			return useSkill(dartSkill());
 		}
-		else if(auto_haveCosmicBowlingBall() && canUse($item[cosmic bowling ball]) && monster_hp() < 100)
+		else if(auto_haveCosmicBowlingBall() && canUse($item[cosmic bowling ball]) && !enemy_physical_immune && monster_hp() < 100)
 		{
-			return useItem($item[cosmic bowling ball]);
+			return useItem($item[cosmic bowling ball]); // 100 physical damage
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -23,10 +23,18 @@ string auto_combatWereProfessorStage1(int round, monster enemy, string text)
 
 string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 {
+	//only care about Advanced Research as a Professor
 	if(!in_wereprof())
 	{
 		return "";
 	}
+
+	string advresearch = get_property("wereProfessorAdvancedResearch");
+	if(contains_text(advresearch, enemy.id))
+	{
+		return "";
+	}
+
 	if(!is_werewolf() && wereprof_oculus() && !haveUsed(to_skill(7512)))
 	{
 		markAsUsed(to_skill(7512));

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -50,7 +50,7 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 		{
 			return useSkill(dartSkill());
 		}
-		if(canUse($skill[Rend], false))
+		if(!enemy_physical_immune && canUse($skill[Rend], false))
 		{
 			return useSkill($skill[Rend], true);
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -7,7 +7,6 @@ string auto_combatWereProfessorStage1(int round, monster enemy, string text)
 
 	if(!is_werewolf())
 	{
-		set_property("auto_skipStage2", true); //Don't even want to try Stage 2 as a Professor
 		set_property("auto_skipStage3", true); //Don't even want to try Stage 3 as a Professor
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -1,3 +1,18 @@
+string auto_combatWereProfessorStage1(int round, monster enemy, string text)
+{
+	if(!in_wereprof())
+	{
+		return "";
+	}
+
+	if(!is_werewolf())
+	{
+		set_property("auto_skipStage3", true); //Don't even want to try Stage 3 as a Professor
+	}
+
+	return "";
+}
+
 string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 {
 	if(!in_wereprof())
@@ -44,7 +59,7 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 	{
 		if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
 		{
-			return useSkill(dartSkill(), false);
+			return useSkill(dartSkill());
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -5,7 +5,7 @@ string auto_combatWereProfessorStage1(int round, monster enemy, string text)
 		return "";
 	}
 
-	if(!is_werewolf())
+	if(is_professor())
 	{
 		set_property("auto_skipStage3", true); //Don't even want to try Stage 3 as a Professor
 	}
@@ -35,7 +35,7 @@ string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 		return "";
 	}
 
-	if(!is_werewolf() && wereprof_oculus() && !haveUsed(to_skill(7512)))
+	if(is_professor() && wereprof_oculus() && !haveUsed(to_skill(7512)))
 	{
 		markAsUsed(to_skill(7512));
 		return(to_skill(7512));
@@ -70,7 +70,7 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 		}
 		return "attack with weapon"; //worst case scenario just use this
 	}
-	if(!is_werewolf())
+	if(is_professor())
 	{
 		if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -42,18 +42,19 @@ string auto_combatWereProfessorStage5(int round, monster enemy, string text)
 
 	if(is_werewolf())
 	{
-		if(enemy_physical_immune && canUse($skill[Bite]))
+		if(enemy_physical_immune && canUse($skill[Bite], true))
 		{
-			return(use_skill($skill[Bite])); // elemental damage skill
+			return(useSkill($skill[Bite], true)); // elemental damage skill
 		}
 		else if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0) //want dart skill as high as possible for Professor
 		{
 			return useSkill(dartSkill());
 		}
-		if(canUse($skill[Rend]))
+		if(canUse($skill[Rend], false))
 		{
-			return useSkill($skill[Rend]);
+			return useSkill($skill[Rend], true);
 		}
+		return "attack with weapon"; //worst case scenario just use this
 	}
 	if(!is_werewolf())
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -10,6 +10,14 @@ string auto_combatWereProfessorStage1(int round, monster enemy, string text)
 		set_property("auto_skipStage3", true); //Don't even want to try Stage 3 as a Professor
 	}
 
+	if(enemy == $monster[Wall Of Bones])
+	{
+		if(canUse($skill[Slaughter]) && have_effect($effect[Everything Looks Red]) == 0)
+		{
+			return useSkill($skill[Slaughter]);
+		}
+	}
+
 	return "";
 }
 

--- a/RELEASE/scripts/autoscend/iotms/mr2013.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2013.ash
@@ -117,6 +117,15 @@ void oldPeoplePlantStuff()
 	{
 		return;
 	}
+	boolean addml = true;
+	if((monster_level_adjustment() > get_property("auto_MLSafetyLimit").to_int() && get_property("auto_MLSafetyLimit") != "") || get_property("auto_MLSafetyLimit").to_int() == -1)
+	{
+		addml = false;
+	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		addml = false;
+	}
 
 	if((my_location() == $location[The Outskirts of Cobb\'s Knob]))
 	{
@@ -131,7 +140,9 @@ void oldPeoplePlantStuff()
 	}
 	else if((my_location() == $location[The Haunted Bathroom]))
 	{
-		cli_execute("florist plant war lily");
+		if(addml){
+			cli_execute("florist plant war lily");
+		}
 		cli_execute("florist plant Impatiens");
 		cli_execute("florist plant arctic moss");
 	}
@@ -155,7 +166,9 @@ void oldPeoplePlantStuff()
 	}
 	else if((my_location() == $location[The Obligatory Pirate\'s Cove]))
 	{
-		cli_execute("florist plant rabid dogwood");
+		if(addml){
+			cli_execute("florist plant rabid dogwood");
+		}
 		cli_execute("florist plant artichoker");
 	}
 	else if((my_location() == $location[Barrrney\'s Barrr]) && (my_class() != $class[Ed the Undying]))
@@ -172,7 +185,9 @@ void oldPeoplePlantStuff()
 	}
 	else if((my_location() == $location[The Castle in the Clouds in the Sky (Basement)]) && (my_daycount() == 1))
 	{
-		cli_execute("florist plant blustery puffball");
+		if(addml){
+			cli_execute("florist plant blustery puffball");
+		}
 		cli_execute("florist plant dis lichen");
 		cli_execute("florist plant max headshroom");
 	}
@@ -182,13 +197,17 @@ void oldPeoplePlantStuff()
 	}
 	else if((my_location() == $location[Oil Peak]))
 	{
-		cli_execute("florist plant rabid dogwood");
+		if(addml){
+			cli_execute("florist plant rabid dogwood");
+		}
 		cli_execute("florist plant artichoker");
 		cli_execute("florist plant celery stalker");
 	}
 	else if((my_location() == $location[The Haunted Boiler Room]))
 	{
-		cli_execute("florist plant war lily");
+		if(addml){
+			cli_execute("florist plant war lily");
+		}
 		cli_execute("florist plant red fern");
 		cli_execute("florist plant arctic moss");
 	}
@@ -223,7 +242,9 @@ void oldPeoplePlantStuff()
 	}
 	else if((my_location() == $location[The Upper Chamber]))
 	{
-		cli_execute("florist plant Blustery Puffball");
+		if(addml){
+			cli_execute("florist plant Blustery Puffball");
+		}
 		cli_execute("florist plant Loose Morels");
 		cli_execute("florist plant Foul Toadstool");
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2013.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2013.ash
@@ -122,7 +122,7 @@ void oldPeoplePlantStuff()
 	{
 		addml = false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		addml = false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -428,6 +428,10 @@ boolean auto_advWitchess(string target, string option)
 	{
 		return false;
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false;
+	}
 
 	if(my_adventures() == 0)
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -1004,6 +1004,10 @@ boolean LX_ghostBusting()
 	{
 		return false;
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false;
+	}
 	
 	//zone unlocks which require no adv spent. ghost will not show up here unless zone is available. no need to skip ghost if zone unavailable.
 	startHippyBoatmanSubQuest();	//unlocks $location[The Old Landfill].

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -428,7 +428,7 @@ boolean auto_advWitchess(string target, string option)
 	{
 		return false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false;
 	}
@@ -1008,7 +1008,7 @@ boolean LX_ghostBusting()
 	{
 		return false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2016.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2016.ash
@@ -428,10 +428,6 @@ boolean auto_advWitchess(string target, string option)
 	{
 		return false;
 	}
-	if(is_professor())
-	{
-		return false;
-	}
 
 	if(my_adventures() == 0)
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -304,6 +304,10 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	{
 		return false;
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false;
+	}
 
 	string temp = visit_url("place.php?whichplace=town_wrong");
 	if(!(contains_text(temp, "townwrong_tunnel")))

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -304,7 +304,7 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	{
 		return false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2017.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2017.ash
@@ -304,10 +304,6 @@ boolean loveTunnelAcquire(boolean enforcer, stat statItem, boolean engineer, int
 	{
 		return false;
 	}
-	if(is_professor())
-	{
-		return false;
-	}
 
 	string temp = visit_url("place.php?whichplace=town_wrong");
 	if(!(contains_text(temp, "townwrong_tunnel")))

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -788,6 +788,11 @@ boolean neverendingPartyCombat()
 		return false;
 	}
 
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false;
+	}
+
 	if(in_glover()) // only non stat effect is valid in G-Lover
 	{
 		fightClubSpa($effect[Flagrantly Fragrant]);

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -788,7 +788,7 @@ boolean neverendingPartyCombat()
 		return false;
 	}
 
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -788,11 +788,6 @@ boolean neverendingPartyCombat()
 		return false;
 	}
 
-	if(is_professor())
-	{
-		return false;
-	}
-
 	if(in_glover()) // only non stat effect is valid in G-Lover
 	{
 		fightClubSpa($effect[Flagrantly Fragrant]);

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -821,7 +821,7 @@ boolean auto_beachUseFreeCombs() {
 // place.php?whichplace=campaway
 boolean auto_campawayAvailable()
 {
-	return is_unrestricted($item[Distant Woods Getaway Brochure]) && get_property("getawayCampsiteUnlocked").to_boolean() && !is_werewolf();
+	return is_unrestricted($item[Distant Woods Getaway Brochure]) && get_property("getawayCampsiteUnlocked").to_boolean();
 }
 
 boolean auto_campawayGrabBuffs()

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -305,7 +305,7 @@ boolean auto_sausageGoblin(location loc, string option)
 	{
 		return false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -305,10 +305,6 @@ boolean auto_sausageGoblin(location loc, string option)
 	{
 		return false;
 	}
-	if(is_professor())
-	{
-		return false;
-	}
 
 	if(loc == $location[none])
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -305,6 +305,10 @@ boolean auto_sausageGoblin(location loc, string option)
 	{
 		return false;
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false;
+	}
 
 	if(loc == $location[none])
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -821,7 +821,7 @@ boolean auto_beachUseFreeCombs() {
 // place.php?whichplace=campaway
 boolean auto_campawayAvailable()
 {
-	return is_unrestricted($item[Distant Woods Getaway Brochure]) && get_property("getawayCampsiteUnlocked").to_boolean();
+	return is_unrestricted($item[Distant Woods Getaway Brochure]) && get_property("getawayCampsiteUnlocked").to_boolean() && !is_werewolf();
 }
 
 boolean auto_campawayGrabBuffs()

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -778,7 +778,7 @@ int auto_fireExtinguisherCharges()
 // returns zone specific skill if in usable zone and hasn't been used yet there this ascension. Otherwise returns empty string
 string auto_FireExtinguisherCombatString(location place)
 {
-	if(auto_fireExtinguisherCharges() < 20)
+	if(auto_fireExtinguisherCharges() < 20 && auto_is_valid($skill[Fire Extinguisher: Zone Specific]))
 	{
 		return "";
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -739,7 +739,7 @@ boolean auto_buyFireworksHat()
 	}
 
 	// +combat hat is second most useful but has no effect in LAR
-	if(auto_can_equip($item[sombrero-mounted sparkler]) && !in_lar())
+	if(auto_can_equip($item[sombrero-mounted sparkler]) && (!in_lar() || !in_wereprof()))
 	{
 		float simCombat = providePlusCombat(25, $location[noob cave], true, true);
 		if(simCombat < 25.0)

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -738,8 +738,8 @@ boolean auto_buyFireworksHat()
 		}
 	}
 
-	// +combat hat is second most useful but has no effect in LAR
-	if(auto_can_equip($item[sombrero-mounted sparkler]) && (!in_lar() || !in_wereprof()))
+	// +combat hat is second most useful but has no effect in LAR and kills the professor
+	if(auto_can_equip($item[sombrero-mounted sparkler]) && (!in_lar() || (in_wereprof() && is_werewolf())))
 	{
 		float simCombat = providePlusCombat(25, $location[noob cave], true, true);
 		if(simCombat < 25.0)

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -688,6 +688,10 @@ boolean have_fireworks_shop()
 		// can't access fireworks shop in kindom of exploathing
 		return false;
 	}
+	if(is_werewolf())
+	{
+		return false; //can't access fireworks shop as a werewolf
+	}
 	if(item_amount($item[Clan VIP Lounge Key]) == 0)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -778,7 +778,7 @@ int auto_fireExtinguisherCharges()
 // returns zone specific skill if in usable zone and hasn't been used yet there this ascension. Otherwise returns empty string
 string auto_FireExtinguisherCombatString(location place)
 {
-	if(auto_fireExtinguisherCharges() < 20 && auto_is_valid($skill[Fire Extinguisher: Zone Specific]))
+	if(auto_fireExtinguisherCharges() < 20 || auto_is_valid($skill[Fire Extinguisher: Zone Specific]))
 	{
 		return "";
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -783,6 +783,11 @@ string auto_FireExtinguisherCombatString(location place)
 		return "";
 	}
 
+	if(in_wereprof())
+	{
+		return "";
+	}
+
 	// once per ascension uses
 	if($locations[Guano Junction, The Batrat and Ratbat Burrow, The Beanbat Chamber] contains place && !get_property("fireExtinguisherBatHoleUsed").to_boolean())
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -778,7 +778,7 @@ int auto_fireExtinguisherCharges()
 // returns zone specific skill if in usable zone and hasn't been used yet there this ascension. Otherwise returns empty string
 string auto_FireExtinguisherCombatString(location place)
 {
-	if(auto_fireExtinguisherCharges() < 20 || auto_is_valid($skill[Fire Extinguisher: Zone Specific]))
+	if(auto_fireExtinguisherCharges() < 20 || !auto_is_valid($skill[Fire Extinguisher: Zone Specific]))
 	{
 		return "";
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -22,6 +22,11 @@ boolean auto_voidMonster(location loc)
 		return false;
 	}
 
+	if (in_wereprof() && !is_werewolf())
+	{
+		return false; //can't beat the void guys as a professor
+	}
+
 	// return false if we've fought the 5 free void monsters already today or we're still charging up the counter
 	if (get_property("_voidFreeFights").to_int() >= 5 || get_property("cursedMagnifyingGlassCount").to_int() != 13)
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -62,7 +62,7 @@ string auto_bowlingBallCombatString(location place, boolean speculation)
 
 	if(!is_werewolf() && in_wereprof())
 	{
-		return "";
+		return ""; //Handle specially in WereProf Combat file
 	}
 
 	if(place == $location[The Hidden Bowling Alley] && get_property("auto_bowledAtAlley").to_int() != my_ascensions())

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -22,7 +22,7 @@ boolean auto_voidMonster(location loc)
 		return false;
 	}
 
-	if (in_wereprof() && !is_werewolf())
+	if (is_professor())
 	{
 		return false; //can't beat the void guys as a professor
 	}
@@ -60,7 +60,7 @@ string auto_bowlingBallCombatString(location place, boolean speculation)
 		return "";
 	}
 
-	if(!is_werewolf() && in_wereprof())
+	if(is_professor())
 	{
 		return ""; //Handle specially in WereProf Combat file
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -234,7 +234,7 @@ void prioritizeGoose() //prioritize Goose only if we still have things to get
 			((needStarKey() && (item_amount($item[star]) < 7 && item_amount($item[line]) < 6)) && gooseExpectedDrones() < 4) ||
 			(internalQuestStatus("questL11Ron") < 5 && gooseExpectedDrones() < 2) ||
 			((get_property("hiddenBowlingAlleyProgress").to_int() + item_amount($item[Bowling Ball])) < 5 && gooseExpectedDrones() < 2) ||
-			(((item_amount($item[Crumbling Wooden Wheel]) + item_amount($item[Tomb Ratchet])) < 9) && gooseExpectedDrones() < 3))
+			(((item_amount($item[Crumbling Wooden Wheel]) + item_amount($item[Tomb Ratchet])) < 9) && item_amount($item[Tangle of Rat Tails]) > 0 && gooseExpectedDrones() < 3))
 	{
 		set_property("auto_prioritizeGoose", true);
 		return;

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -55,6 +55,11 @@ string auto_bowlingBallCombatString(location place, boolean speculation)
 		return "";
 	}
 
+	if(!is_werewolf() && in_wereprof())
+	{
+		return "";
+	}
+
 	if(place == $location[The Hidden Bowling Alley] && get_property("auto_bowledAtAlley").to_int() != my_ascensions())
 	{
 		if(!speculation)

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -348,7 +348,7 @@ boolean auto_getCinch(int goal)
 	}
 
 	// go for cinch as a professor. commented out for now because mafia tracking of free rests as a prof MAY not be working as expected
-	/*while(auto_currentCinch() < goal && haveFreeRestAvailable() && !is_werewolf() && in_wereprof())
+	/*while(auto_currentCinch() < goal && haveFreeRestAvailable() && is_professor())
 	{
 		visit_url("place.php?whichplace=wereprof_cottage&action=wereprof_sleep"); //just visit the cottage to sleep as professor
 	}*/

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -317,6 +317,10 @@ boolean auto_nextRestOverCinch()
 
 boolean auto_getCinch(int goal)
 {
+	if(is_werewolf())
+	{
+		return false;
+	}
 	if(auto_currentCinch() >= goal)
 	{
 		return true;

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -338,13 +338,19 @@ boolean auto_getCinch(int goal)
 		return false;
 	}
 	// use free rests until have enough cinch or out of rests
-	while(auto_currentCinch() < goal && haveFreeRestAvailable())
+	while(auto_currentCinch() < goal && haveFreeRestAvailable() && !in_wereprof())
 	{
 		if(!doFreeRest())
 		{
 			abort("Failed to rest to charge cincho");
 		}
 	}
+
+	// go for cinch as a professor
+	/*while(auto_currentCinch() < goal && !is_werewolf() && in_wereprof())
+	{
+		visit_url("place.php?whichplace=wereprof_cottage&action=wereprof_sleep"); //just visit the cottage to sleep as professor
+	}*/
 
 	// see if we got enough cinch after using free rests
 	if(auto_currentCinch() >= goal)

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -319,7 +319,7 @@ boolean auto_getCinch(int goal)
 {
 	if(is_werewolf())
 	{
-		return false;
+		return false; //can't rest as werewolf
 	}
 	if(auto_currentCinch() >= goal)
 	{
@@ -346,8 +346,8 @@ boolean auto_getCinch(int goal)
 		}
 	}
 
-	// go for cinch as a professor
-	/*while(auto_currentCinch() < goal && !is_werewolf() && in_wereprof())
+	// go for cinch as a professor. commented out for now because mafia tracking of free rests as a prof MAY not be working as expected
+	/*while(auto_currentCinch() < goal && haveFreeRestAvailable() && !is_werewolf() && in_wereprof())
 	{
 		visit_url("place.php?whichplace=wereprof_cottage&action=wereprof_sleep"); //just visit the cottage to sleep as professor
 	}*/

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -220,8 +220,8 @@ skill dartSkill()
 
 boolean dartEleDmg()
 {
-	string perks = get_property("everfullDartPerks").to_string(),to_lower_case();
-	if (contains_text(perks, "add ")) // Only ele dmg perks have "add " in their perk description so as long as we have 1, we are good
+	string perks = get_property("everfullDartPerks").to_string().to_lower_case();
+	if(contains_text(perks, "add ")) // Only ele dmg perks have "add " in their perk description so as long as we have 1, we are good
 	{
 		return true;
 	}	

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -174,7 +174,7 @@ boolean dartEleDmg()
 	perks = split_string(get_property("everfullDartPerks").to_string().to_lower_case(), ",");
 	foreach perk in perks
 	{
-		if (contains_text(perks[perk], "Add ")) // Only ele dmg perks have "Add " in their perk description so as long as we have 1, we are good
+		if (contains_text(perks[perk], "add ")) // Only ele dmg perks have "add " in their perk description so as long as we have 1, we are good
 		{
 			return true;
 		}	

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -167,3 +167,17 @@ skill dartSkill()
 	}
 	return to_skill(7513); // If there aren't any darts available return the Darts: Throw at %PART1
 }
+
+boolean dartEleDmg()
+{
+	string[int] perks;
+	perks = split_string(get_property("everfullDartPerks").to_string().to_lower_case(), ",");
+	foreach perk in perks
+	{
+		if (contains_text(perks[perk], "Add ")) // Only ele dmg perks have "Add " in their perk description so as long as we have 1, we are good
+		{
+			return true;
+		}	
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -170,14 +170,10 @@ skill dartSkill()
 
 boolean dartEleDmg()
 {
-	string[int] perks;
-	perks = split_string(get_property("everfullDartPerks").to_string().to_lower_case(), ",");
-	foreach perk in perks
+	string perks = get_property("everfullDartPerks").to_string(),to_lower_case();
+	if (contains_text(perks, "add ")) // Only ele dmg perks have "add " in their perk description so as long as we have 1, we are good
 	{
-		if (contains_text(perks[perk], "add ")) // Only ele dmg perks have "add " in their perk description so as long as we have 1, we are good
-		{
-			return true;
-		}	
-	}
+		return true;
+	}	
 	return false;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -218,6 +218,16 @@ skill dartSkill()
 	return to_skill(7513); // If there aren't any darts available return the Darts: Throw at %PART1
 }
 
+boolean dartEleDmg()
+{
+	string perks = get_property("everfullDartPerks").to_string().to_lower_case();
+	if(contains_text(perks, "add ")) // Only ele dmg perks have "add " in their perk description so as long as we have 1, we are good
+	{
+		return true;
+	}	
+	return false;
+}
+
 boolean auto_haveMayamCalendar()
 {
 	if(auto_is_valid($item[Mayam Calendar]) && available_amount($item[Mayam Calendar]) > 0 )
@@ -338,14 +348,4 @@ boolean auto_MayamClaimAll()
 	auto_MayamClaimWhatever();
 	auto_MayamClaimWhatever();
 	return true;
-}
-
-boolean dartEleDmg()
-{
-	string perks = get_property("everfullDartPerks").to_string().to_lower_case();
-	if(contains_text(perks, "add ")) // Only ele dmg perks have "add " in their perk description so as long as we have 1, we are good
-	{
-		return true;
-	}	
-	return false;
 }

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -42,6 +42,10 @@ void wereprof_buySkills()
 	{
 		do_skills = false; //Want as many RP as possible before looping through the skills
 	}
+	if((!is_werewolf() && turns_played() == 0))
+	{
+		do_skills = true; //Do skills before we do anything else
+	}
 	if(!is_werewolf() && organsFull() && my_adventures() <= auto_advToReserve() && (!contains_text(get_property("beastSkillsKnown").to_string(), "stomach3") || !contains_text(get_property("beastSkillsKnown").to_string(), "liver3")))
 	{
 		do_skills = true; //If organs are full, should do skills if we need more organ space and don't have all organ expanding skills and limited adventures left

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -197,6 +197,7 @@ boolean LM_wereprof()
 
 	wereprof_buySkills();
 	ovenHandle(); //buy an oven ASAP
+	return true;
 }
 
 boolean LX_wereprof_getSmashedEquip()

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -33,9 +33,18 @@ void wereprof_buySkills()
 		return;
 	}
 	int rp = get_property("wereProfessorResearchPoints").to_int();
-	if(is_werewolf() || (!is_werewolf() && get_property("wereProfessorTransformTurns") > 1 && rp >= 10) || rp == 0) //Want as many RP as possible before looping through the skills
+	if(is_werewolf() || rp == 0)
 	{
 		return;
+	}
+	boolean do_skills = true;
+	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 1))
+	{
+		do_skills = false; //Want as many RP as possible before looping through the skills
+	}
+	if(!is_werewolf() && organsFull() && my_adventures() <= auto_advToReserve() && (!contains_text(get_property("beastSkillsKnown").to_string(), "stomach3") || !contains_text(get_property("beastSkillsKnown").to_string(), "liver3")))
+	{
+		do_skills = true; //If organs are full, should do skills if we need more organ space and don't have all organ expanding skills and limited adventures left
 	}
 	/* Taken from wereprofessor.txt in Mafia src
 	# Muscle Skill Tree
@@ -103,17 +112,20 @@ void wereprof_buySkills()
 	"kick1": 20, "rend3": 40, "rend2": 30, "rend1": 20, "items3": 60, "items2": 50, "items1": 40, "res3": 40, "res2": 30, "res1": 20, "myst3": 30, "myst2": 20, "myst1": 10,
 	"bite3": 40, "bite2": 30, "bite1": 20, "perfecthair": 100, "meat3": 60, "meat2": 50, "meat1": 40, "ml3": 60, "ml2": 50, "ml1": 40, "skin3": 60, "skin2": 50, "skin1": 40,
 	"pureblood": 100, "feasting": 100, "skinheal": 100, "howl": 100, "feed": 100};
-	while(rp > 0)
+	if(do_skills)
 	{
-		foreach sk, cost in rpcost
+		while(rp > 0)
 		{
-			if(contains_text(get_property("beastSkillsAvailable").to_string(), sk) && cost < rp)
+			foreach sk, cost in rpcost
 			{
-				cli_execute('wereprofessor research ' + sk);
-				break;
+				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk) && cost < rp)
+				{
+					cli_execute('wereprofessor research ' + sk);
+					break;
+				}
 			}
+			break;
 		}
-		break;
 	}
 }
 

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -124,6 +124,7 @@ void wereprof_buySkills()
 					break;
 				}
 			}
+			return;
 		}
 	}
 }
@@ -194,10 +195,20 @@ boolean LM_wereprof()
 	{
 		return false;
 	}
+	if(get_property("auto_wereprof_init").to_boolean())
+	{
+		return false;
+	}
 
+	auto_log_info("Getting skills", "blue");
 	wereprof_buySkills();
-	ovenHandle(); //buy an oven ASAP
-	return true;
+	auto_log_info("Buying an oven", "blue");
+	if(ovenHandle()) //buy an oven ASAP
+	{
+		set_property("auto_wereprof_init", true);
+		return true;
+	}
+	return false;
 }
 
 boolean LX_wereprof_getSmashedEquip()

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -27,6 +27,19 @@ boolean is_werewolf()
 	return false;
 }
 
+boolean is_professor()
+{
+	if(!in_wereprof())
+	{
+		return false;
+	}
+	if(have_effect($effect[Mild-Mannered Professor]) > 0)
+	{
+		return true;
+	}
+	return false;
+}
+
 void wereprof_buySkills()
 {
 	if(!in_wereprof())
@@ -47,7 +60,7 @@ void wereprof_buySkills()
 	{
 		do_skills = false; //Want as many RP as possible before looping through the skills
 	}
-	if((!is_werewolf() && turns_played() == 0))
+	if((is_professor() && turns_played() == 0))
 	{
 		auto_log_info("Buy skills first", "blue");
 		do_skills = true; //Do skills before we do anything else
@@ -256,7 +269,7 @@ boolean LX_wereprof_getSmashedEquip()
 	{
 		return false;
 	}
-	if(!is_werewolf() || wereprof_haveAllEquipment())
+	if(is_professor() || wereprof_haveAllEquipment())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -32,7 +32,8 @@ void wereprof_buySkills()
 	{
 		return;
 	}
-	if(is_werewolf())
+	int rp = get_property("wereProfessorResearchPoints").to_int();
+	if(is_werewolf() || (!is_werewolf() && get_property("wereProfessorTransformTurns") > 1 && rp >= 10) || rp == 0) //Want as many RP as possible before looping through the skills
 	{
 		return;
 	}
@@ -97,19 +98,22 @@ void wereprof_buySkills()
 	liver3	60	liver2	Synthetic aldosterone	Liver +3
 	pureblood	100	liver3	Synthroid-parathormone cocktail	Shorten ELR
 	*/
-	int rp = get_property("wereProfessorResearchPoints").to_int();
+	int[string] rpcost = {"stomach3": 60, "liver3": 60, "stomach2": 50, "liver2":50, "stomach1": 40, "liver1": 40, "hp3": 40, "init3": 40, "hp2": 30, "init2": 30,
+	"hp1": 20, "init1": 20, "mus3": 30, "mox3": 30, "mus2": 20, "mox2": 20, "mus1": 10, "mox1": 10, "punt": 100, "slaughter": 100, "hunt": 100, "kick3": 40, "kick2": 30,
+	"kick1": 20, "rend3": 40, "rend2": 30, "rend1": 20, "items3": 60, "items2": 50, "items1": 40, "res3": 40, "res2": 30, "res1": 20, "myst3": 30, "myst2": 20, "myst1": 10,
+	"bite3": 40, "bite2": 30, "bite1": 20, "perfecthair": 100, "meat3": 60, "meat2": 50, "meat1": 40, "ml3": 60, "ml2": 50, "ml1": 40, "skin3": 60, "skin2": 50, "skin1": 40,
+	"pureblood": 100, "feasting": 100, "skinheal": 100, "howl": 100, "feed": 100};
 	while(rp > 0)
 	{
-		foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3, mox3, mus2,
-		mox2, mus1, mox1, punt, slaughter, hunt, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1, res3, res2, res1, myst3,
-		myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3, skin2, skin1, pureblood, feasting,
-		skinheal, howl, feed]
+		foreach sk, cost in rpcost
 		{
-			if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
+			if(contains_text(get_property("beastSkillsAvailable").to_string(), sk) && cost < rp)
 			{
 				cli_execute('wereprofessor research ' + sk);
+				break;
 			}
 		}
+		break;
 	}
 }
 
@@ -146,6 +150,19 @@ void wereprof_buyEquip()
 	}
 }
 
+boolean werewolf_oculus()
+{
+	if(!in_wereprof())
+	{
+		return false;
+	}
+	if(have_equipped($item[biphasic molecular oculus]) || have_equipped($item[triphasic molecular oculus]))
+	{
+		return true;
+	}
+	return false;
+}
+
 boolean LX_wereprof_getSmashedEquip()
 {
 	if(!in_wereprof())
@@ -158,9 +175,9 @@ boolean LX_wereprof_getSmashedEquip()
 	}
 
 	location[int] smashedLocs;
-	string alreadySmashedLocs = get_property("auto_wereprof_smashedLoc").to_string();
+	string alreadySmashedLocs = get_property("antiScientificMethod").to_string();
 	//There's a couple other locations, but we shouldn't EVER visit them
-	foreach sl in $locations[Noob Cave, The Haunted Pantry, The Thinknerd Warehouse, Vanya's Castle, The Castle in the Clouds in the Sky (Top Floor), Hidden Hospital]
+	foreach sl in $locations[Noob Cave, The Haunted Pantry, The Thinknerd Warehouse, Vanya's Castle, The Castle in the Clouds in the Sky (Top Floor), The Hidden Hospital]
 	{
 		if(!contains_text(alreadySmashedLocs,sl.to_string()))
 		{

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -1,0 +1,172 @@
+boolean in_wereprof()
+{
+	return my_path() == $path[WereProfessor];
+}
+
+void wereprof_initializeSettings()
+{
+	if(!in_wereprof())
+	{
+		return;
+	}
+	set_property("auto_wandOfNagamar", false);		//wand not used in this path
+	set_property("auto_wereprof_smashedequip", ""); //string used for when we find smashed equipment so we know we don't need to look there
+}
+
+boolean is_werewolf()
+{
+	if(!in_wereprof())
+	{
+		return false;
+	}
+	if(have_effect($effect[Savage Beast]) > 0)
+	{
+		return true;
+	}
+	return false;
+}
+
+void wereprof_buySkills()
+{
+	if(!in_wereprof())
+	{
+		return;
+	}
+	if(is_werewolf())
+	{
+		return;
+	}
+	/* Taken from wereprofessor.txt in Mafia src
+	# Muscle Skill Tree
+	mus1	10	none	Osteocalcin injection	Mus +20%
+	mus2	20	mus1	Somatostatin catalyst	Mus +30%
+	mus3	30	mus2	Endothelin suspension	Mus +50%
+	rend1	20	mus3	Ultraprogesterone potion	Rend (Phys)
+	rend2	30	rend1	Lactide blocker	Increase damage
+	rend3	40	rend2	Haemostatic membrane treatment	Restores HP
+	slaughter	100	rend3	Norepinephrine transfusion	Slaughter (Instant)
+	hp1	20	mus3	Synthetic prostaglandin	Max HP +20%
+	hp2	30	hp1	Leukotriene elixir	Max HP +30%
+	hp3	40	hp2	Thromboxane inhibitor	Max HP +50%
+	skin1	40	hp3	Calcitonin powder	DR 5
+	skin2	50	skin1	Enkephalin activator	DR 10
+	skin3	60	skin2	Oxytocin inversion	DR 15
+	skinheal	100	skin3	Hemostatic accelerant	Regen 8-10 HP
+	stomach1	40	hp3	Triiodothyronine accelerator	Stomach +3
+	stomach2	50	stomach1	Thyroxine supplements	Stomach +3
+	stomach3	60	stomach2	Amyloid polypeptide mixture	Stomach +3
+	feed	100	stomach3	Cholecystokinin antagonist	(Unimplemented)
+
+	# Mysticality Skill Tree
+	myst1	10	none	Galanin precipitate	Myst +20%
+	myst2	20	myst1	Cortistatin blocker	Myst +30%
+	myst3	30	myst2	Prolactin inhibitor	Myst +50%
+	bite1	20	myst3	Fluoride rinse	Bite (Stench)
+	bite2	30	bite1	Proton pump eliminator	Add (Sleaze)
+	bite3	40	bite2	Bisphosphonate drip	Increase damage
+	howl	100	bite3	Albuterol innundation	Howl (Stun)
+	res1	20	myst3	Omega-3 megadose	Resist All +20%
+	res2	30	res1	Omega-6 hyperdose	Resist All +20%
+	res3	40	res2	Omega-9 omegadose	Resist All +20%
+	items1	40	res3	Diphenhydramine eyedrops	Item Drop 25%
+	items2	50	items1	Carbinoxamine eye wash	Item Drop +25%
+	items3	60	items2	Intraocular cyproheptadine injections	Item Drop +25%
+	hunt	100	items3	Phantosmic tincture	Hunt (Olfaction)
+	ml1	40	res3	Anabolic megatestosterone	ML +10
+	ml2	50	ml1	Hyperadrenal Pheremones	ML +15
+	ml3	60	ml2	Synthetic Rhabdovirus	ML +25
+	feasting	100	ml3	Peptide catalyst	Regain more HP
+
+	# Moxie Skill Tree
+	mox1	10	none	Dopamine slurry	Mox +20% 
+	mox2	20	mox1	Relaxin balm	Mox +30%
+	mox3	30	mox2	Melatonin suppositories	Mox +50%
+	kick1	20	mox3	Hamstring-tightening solution	Kick (Delevel)
+	kick2	30	kick1	Gluteal 4-Androstenediol inection	Improve Kick
+	kick3	40	kick2	Subcutaneous dimethandrolone implant	Kick (Stun)
+	punt	100	kick3	Novel catecholamine synthesis	Punt (Banish)
+	init1	20	mox3	Adrenal decoction	Init +50%
+	init2	30	init1	Adrenal distillate	Init +50%
+	init3	40	init2	Concentrated adrenaline extract	Init +100%
+	meat1	40	init3	Leptin modulator	Meat Drop +25%
+	meat2	50	meat1	Carnal dehydrogenase infusion	Meat Drop +50%
+	meat3	60	meat2	Dihydrobenzophenanthridine injection	Meat Drop +75%
+	perfecthair	100	meat3	Janus kinase blockers	+5 Stats/Fight
+	liver1	40	init3	Glucagon condensate	Liver +3
+	liver2	50	liver1	Secretin agonist	Liver +3
+	liver3	60	liver2	Synthetic aldosterone	Liver +3
+	pureblood	100	liver3	Synthroid-parathormone cocktail	Shorten ELR
+	*/
+	int rp = get_property("wereProfessorResearchPoints").to_int();
+	while rp > 0
+	{
+		foreach sk in $skills[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3, mox3, mus2,
+		mox2, mus1, mox1, punt, slaughter, hunt, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1, res3, res2, res1, myst3,
+		myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3, skin2, skin1, pureblood, feasting,
+		skinheal, howl, feed]
+		{
+			if(!have_skill(sk))
+			{
+				cli_execute('wereprofessor research ' + sk);
+			}
+		}
+	}
+}
+
+void wereprof_buyEquip()
+{
+	if(is_werewolf())
+	{
+		return;
+	}
+	
+	//There's probably a better way to do this
+	while(item_amount($item[smashed scientific equipment]) > 0)
+	{
+		if(item_amount($item[biphasic molecular oculus]) == 0 && item_amount($item[triphasic molecular oculus]) == 0)
+		{
+			cli_execute('tinker biphasic molecular oculus');
+		}
+		if(item_amount($item[biphasic molecular oculus]) > 0 && item_amount($item[triphasic molecular oculus]) == 0)
+		{
+			cli_execute('tinker triphasic molecular oculus');
+		}
+		if(item_amount($item[high-tension exoskeleton]) == 0 && item_amount($item[ultra-high-tension exoskeleton]) == 0 && item_amount($item[irresponsible-tension exoskeleton]) == 0)
+		{
+			cli_execute('tinker high-tension exoskeleton');
+		}
+		if(item_amount($item[high-tension exoskeleton]) > 0 && item_amount($item[ultra-high-tension exoskeleton]) == 0 && item_amount($item[irresponsible-tension exoskeleton]) == 0)
+		{
+			cli_execute('tinker ultra-high-tension exoskeleton');
+		}
+		if(item_amount($item[high-tension exoskeleton]) == 0 && item_amount($item[ultra-high-tension exoskeleton]) > 0 && item_amount($item[irresponsible-tension exoskeleton]) == 0)
+		{
+			cli_execute('tinker irresponsible-tension exoskeleton');
+		}
+	}
+}
+
+boolean LX_wereprof_getSmashedEquip()
+{
+	if(!in_wereprof())
+	{
+		return false;
+	}
+	if(!is_werewolf())
+	{
+		return false;
+	}
+
+	location[int] smashedLocs;
+	alreadySmashedLocs = get_property("auto_wereprof_smashedLoc").to_string();
+	//There's a couple other locations, but we shouldn't EVER visit them
+	foreach sl in $locations[Noob Cave, The Haunted Pantry, The Thinknerd Warehouse, Vanya's Castle, The Castle in the Clouds in the Sky (Top Floor), Hidden Hospital]
+	{
+		if(!contains_text(alreadySmasedLocs,sl.to_string()))
+		{
+			auto_log_info("Going for Smashed Scientific Equipment in " + sl.to_string(), "blue");
+			return autoAdv(1, sl);
+		}
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -11,6 +11,7 @@ void wereprof_initializeSettings()
 	}
 	set_property("auto_wandOfNagamar", false);		//wand not used in this path
 	set_property("auto_wereprof_init", false); 		//string used for when we find smashed equipment so we know we don't need to look there
+	cli_execute('wereprofessor research');			//parse the research bench
 }
 
 boolean is_werewolf()
@@ -38,16 +39,19 @@ void wereprof_buySkills()
 		return;
 	}
 	boolean do_skills = true;
-	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 2))
+	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 3))
 	{
+		auto_log_info("Too many turns remaining", "blue");
 		do_skills = false; //Want as many RP as possible before looping through the skills
 	}
 	if((!is_werewolf() && turns_played() == 0))
 	{
+		auto_log_info("Buy skills first", "blue");
 		do_skills = true; //Do skills before we do anything else
 	}
 	if(!is_werewolf() && organsFull() && my_adventures() <= auto_advToReserve() && (!contains_text(get_property("beastSkillsKnown").to_string(), "stomach3") || !contains_text(get_property("beastSkillsKnown").to_string(), "liver3")))
 	{
+		auto_log_info("Need more organs", "blue");
 		do_skills = true; //If organs are full, should do skills if we need more organ space and don't have all organ expanding skills and limited adventures left
 	}
 	/* Taken from wereprofessor.txt in Mafia src
@@ -111,26 +115,26 @@ void wereprof_buySkills()
 	liver3	60	liver2	Synthetic aldosterone	Liver +3
 	pureblood	100	liver3	Synthroid-parathormone cocktail	Shorten ELR
 	*/
-	int[string] rpcost = {"stomach3": 60, "liver3": 60, "stomach2": 50, "liver2":50, "stomach1": 40, "liver1": 40, "hp3": 40, "init3": 40, "hp2": 30, "init2": 30,
-	"hp1": 20, "init1": 20, "mus3": 30, "mox3": 30, "mus2": 20, "mox2": 20, "mus1": 10, "mox1": 10, "punt": 100, "slaughter": 100, "hunt": 100, "kick3": 40, "kick2": 30,
-	"kick1": 20, "rend3": 40, "rend2": 30, "rend1": 20, "items3": 60, "items2": 50, "items1": 40, "res3": 40, "res2": 30, "res1": 20, "myst3": 30, "myst2": 20, "myst1": 10,
-	"bite3": 40, "bite2": 30, "bite1": 20, "perfecthair": 100, "meat3": 60, "meat2": 50, "meat1": 40, "ml3": 60, "ml2": 50, "ml1": 40, "skin3": 60, "skin2": 50, "skin1": 40,
-	"pureblood": 100, "feasting": 100, "skinheal": 100, "howl": 100, "feed": 100};
 	if(do_skills)
 	{
+		auto_log_info("Buying skills", "blue");
 		while(rp > 1)
 		{
-			foreach sk, cost in rpcost
+			foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3,
+			mox3, mus2, mox2, mus1, mox1, punt, slaughter, hunt, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1,
+			res3, res2, res1, myst3, myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3,
+			skin2, skin1, pureblood, feasting, skinheal, howl, feed]
 			{
-				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk) && cost < rp)
+				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
 				{
+					auto_log_info("Buying " + sk, "blue");
 					cli_execute('wereprofessor research ' + sk);
 					break;
 				}
 			}
-			return;
 		}
 	}
+	return;
 }
 
 boolean wereprof_haveEquip()

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -39,7 +39,7 @@ void wereprof_buySkills()
 		return; // can't access the research bench as a werewolf and don't care about it when we have less than 10 RP
 	}
 	boolean do_skills = true;
-	if((!is_werewolf() && get_property("wereProfessorTransformTurns").to_int() > 3))
+	if(get_property("wereProfessorTransformTurns").to_int() > 3)
 	{
 		do_skills = false; //Want as many RP as possible before looping through the skills
 	}
@@ -48,11 +48,12 @@ void wereprof_buySkills()
 		auto_log_info("Buy skills first", "blue");
 		do_skills = true; //Do skills before we do anything else
 	}
-	if(!is_werewolf() && organsFull() && my_adventures() <= auto_advToReserve() && !(contains_text(get_property("beastSkillsKnown").to_string(), "stomach3") && contains_text(get_property("beastSkillsKnown").to_string(), "liver3")))
+	if(organsFull() && my_adventures() <= auto_advToReserve() && !(contains_text(get_property("beastSkillsKnown").to_string(), "stomach3") && contains_text(get_property("beastSkillsKnown").to_string(), "liver3")))
 	{
 		auto_log_info("Need more organs", "blue");
 		do_skills = true; //If organs are full, should do skills if we need more organ space and don't have all organ expanding skills and limited adventures left
 	}
+	int cantbuy;
 	/* Taken from wereprofessor.txt in Mafia src
 	# Muscle Skill Tree
 	mus1	10	none	Osteocalcin injection	Mus +20%
@@ -122,32 +123,29 @@ void wereprof_buySkills()
 	if(do_skills)
 	{
 		auto_log_info("Buying skills", "blue");
-		int cantbuy;
-		while(rp >= 10)
+		cantbuy = 0;
+		//Priority is: Expanding organs, useful skills (banish, instakill, ELR CD), stat gains, +meat, DR, relatively useless skills and waiting on Mafia support skills
+		foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3,
+		mox3, mus2, mox2, mus1, mox1, punt, slaughter, pureblood, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1,
+		res3, res2, res1, myst3, myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3,
+		skin2, skin1, hunt, feasting, skinheal, howl, feed]
 		{
-			cantbuy = 0;
-			foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3,
-			mox3, mus2, mox2, mus1, mox1, punt, slaughter, hunt, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1,
-			res3, res2, res1, myst3, myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3,
-			skin2, skin1, pureblood, feasting, skinheal, howl, feed]
+			if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
 			{
-				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
+				if(rpcost[sk] >= rp)
 				{
-					if(rpcost[sk] > rp)
+					cantbuy += 1;
+					if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))
 					{
-						cantbuy += 1;
-						if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))
-						{
-							return; //return if we can't buy any beast skills
-						}
+						return; //return if we can't buy any beast skills
 					}
-					else
-					{
-						auto_log_info("Buying " + sk, "blue");
-						cli_execute('wereprofessor research ' + sk);
-						rp = get_property("wereProfessorResearchPoints").to_int();
-						break; //break on buy to reset the foreach loop to look from the top
-					}
+				}
+				else
+				{
+					auto_log_info("Buying " + sk, "blue");
+					cli_execute('wereprofessor research ' + sk);
+					rp = get_property("wereProfessorResearchPoints").to_int();
+					break; //break on buy to reset the foreach loop to look from the top
 				}
 			}
 		}
@@ -155,7 +153,7 @@ void wereprof_buySkills()
 	return;
 }
 
-boolean wereprof_haveEquip()
+boolean wereprof_haveAllEquipment()
 {
 	//Only care about the final equipment
 	if(!possessEquipment($item[triphasic molecular oculus]) || !possessEquipment($item[irresponsible-tension exoskeleton]))
@@ -167,7 +165,7 @@ boolean wereprof_haveEquip()
 
 void wereprof_buyEquip()
 {
-	if(is_werewolf() || wereprof_haveEquip())
+	if(is_werewolf() || wereprof_haveAllEquipment())
 	{
 		return; // can't tinker if we are a werewolf and don't care about anything but the best oculus and exoskeleton
 	}
@@ -251,7 +249,7 @@ boolean LX_wereprof_getSmashedEquip()
 	{
 		return false;
 	}
-	if(!is_werewolf() || wereprof_haveEquip())
+	if(!is_werewolf() || wereprof_haveAllEquipment())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -98,7 +98,7 @@ void wereprof_buySkills()
 	pureblood	100	liver3	Synthroid-parathormone cocktail	Shorten ELR
 	*/
 	int rp = get_property("wereProfessorResearchPoints").to_int();
-	while rp > 0
+	while(rp > 0)
 	{
 		foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3, mox3, mus2,
 		mox2, mus1, mox1, punt, slaughter, hunt, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1, res3, res2, res1, myst3,
@@ -158,11 +158,11 @@ boolean LX_wereprof_getSmashedEquip()
 	}
 
 	location[int] smashedLocs;
-	alreadySmashedLocs = get_property("auto_wereprof_smashedLoc").to_string();
+	string alreadySmashedLocs = get_property("auto_wereprof_smashedLoc").to_string();
 	//There's a couple other locations, but we shouldn't EVER visit them
 	foreach sl in $locations[Noob Cave, The Haunted Pantry, The Thinknerd Warehouse, Vanya's Castle, The Castle in the Clouds in the Sky (Top Floor), Hidden Hospital]
 	{
-		if(!contains_text(alreadySmasedLocs,sl.to_string()))
+		if(!contains_text(alreadySmashedLocs,sl.to_string()))
 		{
 			auto_log_info("Going for Smashed Scientific Equipment in " + sl.to_string(), "blue");
 			return autoAdv(1, sl);

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -125,25 +125,25 @@ void wereprof_buyEquip()
 	}
 	
 	//There's probably a better way to do this
-	while(item_amount($item[smashed scientific equipment]) > 0)
+	while(item_amount($item[smashed scientific equipment]) > 0 && !possessEquipment($item[triphasic molecular oculus]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
 	{
-		if(item_amount($item[biphasic molecular oculus]) == 0 && item_amount($item[triphasic molecular oculus]) == 0)
+		if(!possessEquipment($item[biphasic molecular oculus]) && !possessEquipment($item[triphasic molecular oculus]))
 		{
 			cli_execute('tinker biphasic molecular oculus');
 		}
-		if(item_amount($item[biphasic molecular oculus]) > 0 && item_amount($item[triphasic molecular oculus]) == 0)
+		if(possessEquipment($item[biphasic molecular oculus]) && !possessEquipment($item[triphasic molecular oculus]))
 		{
 			cli_execute('tinker triphasic molecular oculus');
 		}
-		if(item_amount($item[high-tension exoskeleton]) == 0 && item_amount($item[ultra-high-tension exoskeleton]) == 0 && item_amount($item[irresponsible-tension exoskeleton]) == 0)
+		if(!possessEquipment($item[high-tension exoskeleton]) && !possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
 		{
 			cli_execute('tinker high-tension exoskeleton');
 		}
-		if(item_amount($item[high-tension exoskeleton]) > 0 && item_amount($item[ultra-high-tension exoskeleton]) == 0 && item_amount($item[irresponsible-tension exoskeleton]) == 0)
+		if(possessEquipment($item[high-tension exoskeleton]) && !possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
 		{
 			cli_execute('tinker ultra-high-tension exoskeleton');
 		}
-		if(item_amount($item[high-tension exoskeleton]) == 0 && item_amount($item[ultra-high-tension exoskeleton]) > 0 && item_amount($item[irresponsible-tension exoskeleton]) == 0)
+		if(!possessEquipment($item[high-tension exoskeleton]) && possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
 		{
 			cli_execute('tinker irresponsible-tension exoskeleton');
 		}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -287,3 +287,16 @@ boolean LX_wereprof_getSmashedEquip()
 	}
 	return false;
 }
+
+boolean wereprof_usable(string str)
+{
+	if(!in_wereprof())
+	{
+		return true;
+	}
+	if(str == "Stooper") //currently only thing we don't want at all
+	{
+		return false;
+	}
+	return true;
+}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -117,9 +117,19 @@ void wereprof_buySkills()
 	}
 }
 
+boolean wereprof_haveEquip()
+{
+	//Only care about the final equipment
+	if(!possessEquipment($item[triphasic molecular oculus]) || !possessEquipment($item[irresponsible-tension exoskeleton]))
+	{
+		return false;
+	}
+	return true;
+}
+
 void wereprof_buyEquip()
 {
-	if(is_werewolf())
+	if(is_werewolf() || wereprof_haveEquip())
 	{
 		return;
 	}
@@ -150,7 +160,7 @@ void wereprof_buyEquip()
 	}
 }
 
-boolean werewolf_oculus()
+boolean wereprof_oculus()
 {
 	if(!in_wereprof())
 	{
@@ -169,7 +179,7 @@ boolean LX_wereprof_getSmashedEquip()
 	{
 		return false;
 	}
-	if(!is_werewolf())
+	if(!is_werewolf() || wereprof_haveEquip())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -189,7 +189,7 @@ boolean LX_wereprof_getSmashedEquip()
 	//There's a couple other locations, but we shouldn't EVER visit them
 	foreach sl in $locations[The Hidden Hospital, The Castle in the Clouds in the Sky (Top Floor), Noob Cave, The Haunted Pantry, The Thinknerd Warehouse, Vanya's Castle]
 	{
-		if(!contains_text(alreadySmashedLocs,sl.to_string()))
+		if(!contains_text(alreadySmashedLocs,sl.to_string()) && zone_available(sl))
 		{
 			auto_log_info("Going for Smashed Scientific Equipment in " + sl.to_string(), "blue");
 			return autoAdv(1, sl);

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -114,7 +114,7 @@ void wereprof_buySkills()
 	"pureblood": 100, "feasting": 100, "skinheal": 100, "howl": 100, "feed": 100};
 	if(do_skills)
 	{
-		while(rp > 0)
+		while(rp > 1)
 		{
 			foreach sk, cost in rpcost
 			{
@@ -147,7 +147,7 @@ void wereprof_buyEquip()
 	}
 	
 	//There's probably a better way to do this
-	while(item_amount($item[smashed scientific equipment]) > 0 && !possessEquipment($item[triphasic molecular oculus]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
+	while(item_amount($item[smashed scientific equipment]) > 1 && !possessEquipment($item[triphasic molecular oculus]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
 	{
 		if(!possessEquipment($item[biphasic molecular oculus]) && !possessEquipment($item[triphasic molecular oculus]))
 		{

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -48,7 +48,7 @@ void wereprof_buySkills()
 		auto_log_info("Buy skills first", "blue");
 		do_skills = true; //Do skills before we do anything else
 	}
-	if(!is_werewolf() && organsFull() && my_adventures() <= auto_advToReserve() && (!contains_text(get_property("beastSkillsKnown").to_string(), "stomach3") || !contains_text(get_property("beastSkillsKnown").to_string(), "liver3")))
+	if(!is_werewolf() && organsFull() && my_adventures() <= auto_advToReserve() && !(contains_text(get_property("beastSkillsKnown").to_string(), "stomach3") && contains_text(get_property("beastSkillsKnown").to_string(), "liver3")))
 	{
 		auto_log_info("Need more organs", "blue");
 		do_skills = true; //If organs are full, should do skills if we need more organ space and don't have all organ expanding skills and limited adventures left

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -115,6 +115,11 @@ void wereprof_buySkills()
 	liver3	60	liver2	Synthetic aldosterone	Liver +3
 	pureblood	100	liver3	Synthroid-parathormone cocktail	Shorten ELR
 	*/
+	int[string] rpcost = {"stomach3": 60, "liver3": 60, "stomach2": 50, "liver2":50, "stomach1": 40, "liver1": 40, "hp3": 40, "init3": 40, "hp2": 30, "init2": 30,
+	"hp1": 20, "init1": 20, "mus3": 30, "mox3": 30, "mus2": 20, "mox2": 20, "mus1": 10, "mox1": 10, "punt": 100, "slaughter": 100, "hunt": 100, "kick3": 40, "kick2": 30,
+	"kick1": 20, "rend3": 40, "rend2": 30, "rend1": 20, "items3": 60, "items2": 50, "items1": 40, "res3": 40, "res2": 30, "res1": 20, "myst3": 30, "myst2": 20, "myst1": 10,
+	"bite3": 40, "bite2": 30, "bite1": 20, "perfecthair": 100, "meat3": 60, "meat2": 50, "meat1": 40, "ml3": 60, "ml2": 50, "ml1": 40, "skin3": 60, "skin2": 50, "skin1": 40,
+	"pureblood": 100, "feasting": 100, "skinheal": 100, "howl": 100, "feed": 100};
 	if(do_skills)
 	{
 		auto_log_info("Buying skills", "blue");
@@ -127,11 +132,20 @@ void wereprof_buySkills()
 			{
 				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
 				{
-					auto_log_info("Buying " + sk, "blue");
-					cli_execute('wereprofessor research ' + sk);
+					boolean canbuy = true;
+					if(rpcost[sk] > rp)
+					{
+						canbuy = false;
+					}
+					if(canbuy)
+					{
+						auto_log_info("Buying " + sk, "blue");
+						cli_execute('wereprofessor research ' + sk);
+					}
 					break;
 				}
 			}
+			break;
 		}
 	}
 	return;

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -187,7 +187,7 @@ boolean LX_wereprof_getSmashedEquip()
 	location[int] smashedLocs;
 	string alreadySmashedLocs = get_property("antiScientificMethod").to_string();
 	//There's a couple other locations, but we shouldn't EVER visit them
-	foreach sl in $locations[Noob Cave, The Haunted Pantry, The Thinknerd Warehouse, Vanya's Castle, The Castle in the Clouds in the Sky (Top Floor), The Hidden Hospital]
+	foreach sl in $locations[The Hidden Hospital, The Castle in the Clouds in the Sky (Top Floor), Noob Cave, The Haunted Pantry, The Thinknerd Warehouse, Vanya's Castle]
 	{
 		if(!contains_text(alreadySmashedLocs,sl.to_string()))
 		{

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -34,9 +34,9 @@ void wereprof_buySkills()
 		return;
 	}
 	int rp = get_property("wereProfessorResearchPoints").to_int();
-	if(is_werewolf() || rp == 0)
+	if(is_werewolf() || rp < 10)
 	{
-		return;
+		return; // can't access the research bench as a werewolf and don't care about it when we have less than 10 RP
 	}
 	boolean do_skills = true;
 	if((!is_werewolf() && get_property("wereProfessorTransformTurns").to_int() > 3))
@@ -123,7 +123,7 @@ void wereprof_buySkills()
 	{
 		auto_log_info("Buying skills", "blue");
 		int cantbuy;
-		while(rp > 1)
+		while(rp >= 10)
 		{
 			cantbuy = 0;
 			foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3,
@@ -138,7 +138,7 @@ void wereprof_buySkills()
 						cantbuy += 1;
 						if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))
 						{
-							return; //break if we can't buy the same amount of beast skills available
+							return; //return if we can't buy any beast skills
 						}
 					}
 					else
@@ -146,7 +146,7 @@ void wereprof_buySkills()
 						auto_log_info("Buying " + sk, "blue");
 						cli_execute('wereprofessor research ' + sk);
 						rp = get_property("wereProfessorResearchPoints").to_int();
-						break; //break on buy to reset the foreach loop
+						break; //break on buy to reset the foreach loop to look from the top
 					}
 				}
 			}
@@ -169,7 +169,7 @@ void wereprof_buyEquip()
 {
 	if(is_werewolf() || wereprof_haveEquip())
 	{
-		return;
+		return; // can't tinker if we are a werewolf and don't care about anything but the best oculus and exoskeleton
 	}
 	
 	//There's probably a better way to do this

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -123,29 +123,32 @@ void wereprof_buySkills()
 	if(do_skills)
 	{
 		auto_log_info("Buying skills", "blue");
-		cantbuy = 0;
-		//Priority is: Expanding organs, useful skills (banish, instakill, ELR CD), stat gains, +meat, DR, relatively useless skills and waiting on Mafia support skills
-		foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3,
-		mox3, mus2, mox2, mus1, mox1, punt, slaughter, pureblood, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1,
-		res3, res2, res1, myst3, myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3,
-		skin2, skin1, hunt, feasting, skinheal, howl, feed]
+		while(rp >= 10)
 		{
-			if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
+			cantbuy = 0;
+			//Priority is: Expanding organs, useful skills (banish, instakill, ELR CD), stat gains, +meat, DR, relatively useless skills and waiting on Mafia support skills
+			foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3,
+			mox3, mus2, mox2, mus1, mox1, punt, slaughter, pureblood, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1,
+			res3, res2, res1, myst3, myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3,
+			skin2, skin1, hunt, feasting, skinheal, howl, feed]
 			{
-				if(rpcost[sk] >= rp)
+				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
 				{
-					cantbuy += 1;
-					if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))
+					if(rpcost[sk] >= rp)
 					{
-						return; //return if we can't buy any beast skills
+						cantbuy += 1;
+						if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))
+						{
+							return; //return if we can't buy any beast skills
+						}
 					}
-				}
-				else
-				{
-					auto_log_info("Buying " + sk, "blue");
-					cli_execute('wereprofessor research ' + sk);
-					rp = get_property("wereProfessorResearchPoints").to_int();
-					break; //break on buy to reset the foreach loop to look from the top
+					else
+					{
+						auto_log_info("Buying " + sk, "blue");
+						cli_execute('wereprofessor research ' + sk);
+						rp = get_property("wereProfessorResearchPoints").to_int();
+						break; //break on buy to reset the foreach loop to look from the top
+					}
 				}
 			}
 		}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -10,7 +10,7 @@ void wereprof_initializeSettings()
 		return;
 	}
 	set_property("auto_wandOfNagamar", false);		//wand not used in this path
-	set_property("auto_wereprof_smashedequip", ""); //string used for when we find smashed equipment so we know we don't need to look there
+	set_property("auto_wereprof_init", false); 		//string used for when we find smashed equipment so we know we don't need to look there
 }
 
 boolean is_werewolf()

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -100,12 +100,12 @@ void wereprof_buySkills()
 	int rp = get_property("wereProfessorResearchPoints").to_int();
 	while rp > 0
 	{
-		foreach sk in $skills[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3, mox3, mus2,
+		foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3, mox3, mus2,
 		mox2, mus1, mox1, punt, slaughter, hunt, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1, res3, res2, res1, myst3,
 		myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3, skin2, skin1, pureblood, feasting,
 		skinheal, howl, feed]
 		{
-			if(!have_skill(sk))
+			if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
 			{
 				cli_execute('wereprofessor research ' + sk);
 			}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -38,7 +38,7 @@ void wereprof_buySkills()
 		return;
 	}
 	boolean do_skills = true;
-	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 1))
+	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 2))
 	{
 		do_skills = false; //Want as many RP as possible before looping through the skills
 	}

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -38,6 +38,10 @@ void wereprof_buySkills()
 		return;
 	}
 	boolean do_skills = true;
+	if(get_property("auto_wereprof_init").to_boolean())
+	{
+		do_skills = false;
+	}
 	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 2))
 	{
 		do_skills = false; //Want as many RP as possible before looping through the skills

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -39,7 +39,7 @@ void wereprof_buySkills()
 		return;
 	}
 	boolean do_skills = true;
-	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 3))
+	if((!is_werewolf() && get_property("wereProfessorTransformTurns").to_int() > 3))
 	{
 		auto_log_info("Too many turns remaining", "blue");
 		do_skills = false; //Want as many RP as possible before looping through the skills
@@ -123,8 +123,10 @@ void wereprof_buySkills()
 	if(do_skills)
 	{
 		auto_log_info("Buying skills", "blue");
+		int cantbuy;
 		while(rp > 1)
 		{
+			cantbuy = 0;
 			foreach sk in $strings[stomach3, liver3, stomach2, liver2, stomach1, liver1, hp3, init3, hp2, init2, hp1, init1, mus3,
 			mox3, mus2, mox2, mus1, mox1, punt, slaughter, hunt, kick3, kick2, kick1, rend3, rend2, rend1, items3, items2, items1,
 			res3, res2, res1, myst3, myst2, myst1, bite3, bite2, bite1, perfecthair, meat3, meat2, meat1, ml3, ml2, ml1, skin3,
@@ -132,20 +134,22 @@ void wereprof_buySkills()
 			{
 				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
 				{
-					boolean canbuy = true;
 					if(rpcost[sk] > rp)
 					{
-						canbuy = false;
+						cantbuy += 1;
+						if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))
+						{
+							return; //return if we can't buy the same amount of beast skills available
+						}
 					}
-					if(canbuy)
+					else
 					{
 						auto_log_info("Buying " + sk, "blue");
 						cli_execute('wereprofessor research ' + sk);
+						break; //break on buy to reset the foreach loop
 					}
-					break;
 				}
 			}
-			break;
 		}
 	}
 	return;
@@ -169,27 +173,35 @@ void wereprof_buyEquip()
 	}
 	
 	//There's probably a better way to do this
-	while(item_amount($item[smashed scientific equipment]) > 1 && !possessEquipment($item[triphasic molecular oculus]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
+	while(item_amount($item[smashed scientific equipment]) >= 1)
 	{
-		if(!possessEquipment($item[biphasic molecular oculus]) && !possessEquipment($item[triphasic molecular oculus]))
+		while(!possessEquipment($item[triphasic molecular oculus]) || !possessEquipment($item[irresponsible-tension exoskeleton]))
 		{
-			cli_execute('tinker biphasic molecular oculus');
-		}
-		if(possessEquipment($item[biphasic molecular oculus]) && !possessEquipment($item[triphasic molecular oculus]))
-		{
-			cli_execute('tinker triphasic molecular oculus');
-		}
-		if(!possessEquipment($item[high-tension exoskeleton]) && !possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
-		{
-			cli_execute('tinker high-tension exoskeleton');
-		}
-		if(possessEquipment($item[high-tension exoskeleton]) && !possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
-		{
-			cli_execute('tinker ultra-high-tension exoskeleton');
-		}
-		if(!possessEquipment($item[high-tension exoskeleton]) && possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
-		{
-			cli_execute('tinker irresponsible-tension exoskeleton');
+			if(!possessEquipment($item[biphasic molecular oculus]) && !possessEquipment($item[triphasic molecular oculus]))
+			{
+				cli_execute('tinker biphasic molecular oculus');
+				break;
+			}
+			if(possessEquipment($item[biphasic molecular oculus]) && !possessEquipment($item[triphasic molecular oculus]))
+			{
+				cli_execute('tinker triphasic molecular oculus');
+				break;
+			}
+			if(!possessEquipment($item[high-tension exoskeleton]) && !possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
+			{
+				cli_execute('tinker high-tension exoskeleton');
+				break;
+			}
+			if(possessEquipment($item[high-tension exoskeleton]) && !possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
+			{
+				cli_execute('tinker ultra-high-tension exoskeleton');
+				break;
+			}
+			if(!possessEquipment($item[high-tension exoskeleton]) && possessEquipment($item[ultra-high-tension exoskeleton]) && !possessEquipment($item[irresponsible-tension exoskeleton]))
+			{
+				cli_execute('tinker irresponsible-tension exoskeleton');
+				break;
+			}
 		}
 	}
 }

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -124,7 +124,6 @@ void wereprof_buySkills()
 					break;
 				}
 			}
-			break;
 		}
 	}
 }
@@ -183,6 +182,21 @@ boolean wereprof_oculus()
 		return true;
 	}
 	return false;
+}
+
+boolean LM_wereprof()
+{
+	if(!in_wereprof())
+	{
+		return false;
+	}
+	if(is_werewolf())
+	{
+		return false;
+	}
+
+	wereprof_buySkills();
+	ovenHandle(); //buy an oven ASAP
 }
 
 boolean LX_wereprof_getSmashedEquip()

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -38,6 +38,10 @@ void wereprof_buySkills()
 	{
 		return; // can't access the research bench as a werewolf and don't care about it when we have less than 10 RP
 	}
+	if(get_property("beastSkillsAvailable") == "")
+	{
+		cli_execute('wereprofessor research');			//parse the research bench
+	}
 	boolean do_skills = true;
 	if(get_property("wereProfessorTransformTurns").to_int() > 3)
 	{

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -38,10 +38,6 @@ void wereprof_buySkills()
 		return;
 	}
 	boolean do_skills = true;
-	if(get_property("auto_wereprof_init").to_boolean())
-	{
-		do_skills = false;
-	}
 	if((!is_werewolf() && get_property("wereProfessorTransformTurns") > 2))
 	{
 		do_skills = false; //Want as many RP as possible before looping through the skills

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -41,7 +41,6 @@ void wereprof_buySkills()
 	boolean do_skills = true;
 	if((!is_werewolf() && get_property("wereProfessorTransformTurns").to_int() > 3))
 	{
-		auto_log_info("Too many turns remaining", "blue");
 		do_skills = false; //Want as many RP as possible before looping through the skills
 	}
 	if((!is_werewolf() && turns_played() == 0))
@@ -139,13 +138,14 @@ void wereprof_buySkills()
 						cantbuy += 1;
 						if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))
 						{
-							return; //return if we can't buy the same amount of beast skills available
+							return; //break if we can't buy the same amount of beast skills available
 						}
 					}
 					else
 					{
 						auto_log_info("Buying " + sk, "blue");
 						cli_execute('wereprofessor research ' + sk);
+						rp = get_property("wereProfessorResearchPoints").to_int();
 						break; //break on buy to reset the foreach loop
 					}
 				}

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -166,7 +166,7 @@ boolean auto_tavern()
 				auto_log_warning("Tavern handler: You are RL drunk, you should not be here.", "red");
 				autoAdv(1, $location[Noob Cave]);
 			}
-			if(last_monster() == $monster[Crate] && !is_werewolf()) //want 8 turns of Noob Cave as a Werewolf
+			if(last_monster() == $monster[Crate] && (!is_werewolf() && $location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
 			{
 				if(get_property("auto_newbieOverride").to_boolean())
 				{

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -166,7 +166,7 @@ boolean auto_tavern()
 				auto_log_warning("Tavern handler: You are RL drunk, you should not be here.", "red");
 				autoAdv(1, $location[Noob Cave]);
 			}
-			if(last_monster() == $monster[Crate] || (in_wereprof() && !is_werewolf() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave as a Werewolf
+			if(last_monster() == $monster[Crate] || (in_wereprof() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave in WereProfessor for Smashed Scientific Equipment
 			{
 				if(get_property("auto_newbieOverride").to_boolean())
 				{

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -167,6 +167,7 @@ boolean auto_tavern()
 				autoAdv(1, $location[Noob Cave]);
 			}
 			if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave as a Werewolf
+			{
 				if(get_property("auto_newbieOverride").to_boolean())
 				{
 					set_property("auto_newbieOverride", false);

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -166,7 +166,7 @@ boolean auto_tavern()
 				auto_log_warning("Tavern handler: You are RL drunk, you should not be here.", "red");
 				autoAdv(1, $location[Noob Cave]);
 			}
-			if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !$location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
+			if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave as a Werewolf
 				if(get_property("auto_newbieOverride").to_boolean())
 				{
 					set_property("auto_newbieOverride", false);

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -166,8 +166,7 @@ boolean auto_tavern()
 				auto_log_warning("Tavern handler: You are RL drunk, you should not be here.", "red");
 				autoAdv(1, $location[Noob Cave]);
 			}
-			if(last_monster() == $monster[Crate] && (!is_werewolf() && $location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
-			{
+			if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !$location[Noob Cave].turns_spent < 8)) //want 7 turns of Noob Cave as a Werewolf
 				if(get_property("auto_newbieOverride").to_boolean())
 				{
 					set_property("auto_newbieOverride", false);

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -166,7 +166,7 @@ boolean auto_tavern()
 				auto_log_warning("Tavern handler: You are RL drunk, you should not be here.", "red");
 				autoAdv(1, $location[Noob Cave]);
 			}
-			if(last_monster() == $monster[Crate])
+			if(last_monster() == $monster[Crate] && !is_werewolf()) //want 8 turns of Noob Cave as a Werewolf
 			{
 				if(get_property("auto_newbieOverride").to_boolean())
 				{

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -166,7 +166,7 @@ boolean auto_tavern()
 				auto_log_warning("Tavern handler: You are RL drunk, you should not be here.", "red");
 				autoAdv(1, $location[Noob Cave]);
 			}
-			if(last_monster() == $monster[Crate] && (in_wereprof() && !is_werewolf() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave as a Werewolf
+			if(last_monster() == $monster[Crate] || (in_wereprof() && !is_werewolf() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave as a Werewolf
 			{
 				if(get_property("auto_newbieOverride").to_boolean())
 				{

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -297,7 +297,7 @@ boolean L7_crypt()
 
 	if(get_property("cyrptCrannyEvilness").to_int() > 0)
 	{
-		if(in_wereprof() && !is_werewolf()) //don't do if we are the Professor. Death Rattlin' = Beaten Up
+		if(is_professor()) //don't do if we are the Professor. Death Rattlin' = Beaten Up
 		{
 			return false;
 		}

--- a/RELEASE/scripts/autoscend/quests/level_07.ash
+++ b/RELEASE/scripts/autoscend/quests/level_07.ash
@@ -297,6 +297,10 @@ boolean L7_crypt()
 
 	if(get_property("cyrptCrannyEvilness").to_int() > 0)
 	{
+		if(in_wereprof() && !is_werewolf()) //don't do if we are the Professor. Death Rattlin' = Beaten Up
+		{
+			return false;
+		}
 		auto_log_info("The Cranny!", "blue");
 
 		if(my_mp() > 60)

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -696,7 +696,7 @@ boolean L8_trapperGroar()
 	{
 		return false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false; //don't try for Groar as Professor
 	}

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -696,6 +696,10 @@ boolean L8_trapperGroar()
 	{
 		return false;
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false; //don't try for Groar as Professor
+	}
 	
 	// we need 5 cold res to be allowed to adventure in [Mist-shrouded Peak]
 	int [element] resGoal;

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -444,7 +444,7 @@ boolean L9_aBooPeak()
 
 		//	Do we need to manually adjust for the parrot?
 
-		if(black_market_available() && (item_amount($item[Can of Black Paint]) == 0) && (have_effect($effect[Red Door Syndrome]) == 0) && (my_meat() >= npc_price($item[Can of Black Paint])))
+		if(black_market_available() && (item_amount($item[Can of Black Paint]) == 0) && (have_effect($effect[Red Door Syndrome]) == 0) && (my_meat() >= npc_price($item[Can of Black Paint])) && !is_werewolf())
 		{
 			auto_buyUpTo(1, $item[Can of Black Paint]);
 			coldResist += 2;

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -877,6 +877,11 @@ boolean L9_oilPeak()
 		return false;
 	}
 
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false; //can't do Oil Peak as a Professor
+	}
+
 	if(contains_text(visit_url("place.php?whichplace=highlands"), "fire3.gif"))
 	{
 		int oilProgress = get_property("twinPeakProgress").to_int();

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -359,6 +359,11 @@ boolean L9_aBooPeak()
 		return false;
 	}
 
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false;
+	}
+
 	item clue = $item[A-Boo Clue];
 	if(in_glover())
 	{

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -359,11 +359,6 @@ boolean L9_aBooPeak()
 		return false;
 	}
 
-	if(in_wereprof() && !is_werewolf())
-	{
-		return false; // Not worth trying when we only have 1 hp
-	}
-
 	item clue = $item[A-Boo Clue];
 	if(in_glover())
 	{
@@ -374,6 +369,11 @@ boolean L9_aBooPeak()
 		clue = $item[Glued A-Boo Clue];
 	}
 	int clueAmt = item_amount(clue);
+
+	if(in_wereprof() && !is_werewolf() && clueAmt >= 3)
+	{
+		return false; // We have clues but we can't survive them so not worth trying when we only have 1 hp
+	}
 
 	if (get_property("booPeakProgress").to_int() > 90)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -370,7 +370,7 @@ boolean L9_aBooPeak()
 	}
 	int clueAmt = item_amount(clue);
 
-	if(in_wereprof() && !is_werewolf() && clueAmt >= 3)
+	if(is_professor() && clueAmt >= 3)
 	{
 		return false; // We have clues but we can't survive them so not worth trying when we only have 1 hp
 	}
@@ -882,7 +882,7 @@ boolean L9_oilPeak()
 		return false;
 	}
 
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false; //can't do Oil Peak as a Professor
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -361,7 +361,7 @@ boolean L9_aBooPeak()
 
 	if(in_wereprof() && !is_werewolf())
 	{
-		return false;
+		return false; // Not worth trying when we only have 1 hp
 	}
 
 	item clue = $item[A-Boo Clue];

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2260,7 +2260,7 @@ boolean L11_mauriceSpookyraven()
 
 	if (internalQuestStatus("questL11Manor") > 2)
 	{
-		if(in_wereprof() && !is_werewolf())
+		if(is_professor())
 		{
 			return false;		//Can't beat Lord Spookyraven as the Professor
 		}
@@ -2432,7 +2432,7 @@ boolean L11_mauriceSpookyraven()
 			autoEquip($slot[acc2], $item[gumshoes]);
 		}
 		
-		if(in_wereprof() && !is_werewolf())
+		if(is_professor())
 		{
 			// +ML is BAD for professor
 			auto_change_mcd(0);
@@ -2686,7 +2686,7 @@ boolean L11_shenStartQuest()
 		return false;
 	}
 	
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false; //can't do Copperhead Club as a Professor
 	}
@@ -2726,7 +2726,7 @@ boolean L11_shenCopperhead()
 		return false;
 	}
 
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
 		return false; //can't do Copperhead Club as a Professor
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -205,6 +205,11 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 		{
 			zones_to_avoid[$location[The Batrat and Ratbat Burrow]] = false;
 		}
+		// don't delay Hole in the Sky in WereProf if ran out of stuff to do
+		if(get_property("auto_powerLevelLastAttempted").to_int() == my_turncount() && in_wereprof())
+		{
+			zones_to_avoid[$location[The Hole in the Sky]] = false;
+		}
 		return zones_to_avoid;
 	}
 }

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2685,12 +2685,7 @@ boolean L11_shenStartQuest()
 	{
 		return false;
 	}
-	
-	if(is_professor())
-	{
-		return false; //can't do Copperhead Club as a Professor
-	}
-	
+		
 	auto_log_info("Going to see the World's Biggest Jerk about some snakes and stones and stuff.", "blue");
 	if (autoAdv($location[The Copperhead Club]))
 	{
@@ -2726,14 +2721,12 @@ boolean L11_shenCopperhead()
 		return false;
 	}
 
-	if(is_professor())
-	{
-		return false; //can't do Copperhead Club as a Professor
-	}
-
-
 	if (internalQuestStatus("questL11Shen") == 2 || internalQuestStatus("questL11Shen") == 4 || internalQuestStatus("questL11Shen") == 6)
 	{
+		if(is_professor())
+		{
+			return false; //can't do Copperhead Club as a Professor but can do other parts of Shen quest
+		}
 		if (item_amount($item[Crappy Waiter Disguise]) > 0 && have_effect($effect[Crappily Disguised as a Waiter]) == 0 && !in_tcrs())
 		{
 			use(1, $item[Crappy Waiter Disguise]);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2231,10 +2231,6 @@ boolean L11_mauriceSpookyraven()
 	{
 		return false;		//delay fight so we can make sure we are strong enough to beat him
 	}
-	if(in_wereprof() && !is_werewolf())
-	{
-		return false;		//Can't beat Lord Spookyraven as the Professor
-	}
 
 	if (internalQuestStatus("questL11Manor") < 1)
 	{
@@ -2264,6 +2260,10 @@ boolean L11_mauriceSpookyraven()
 
 	if (internalQuestStatus("questL11Manor") > 2)
 	{
+		if(in_wereprof() && !is_werewolf())
+		{
+			return false;		//Can't beat Lord Spookyraven as the Professor
+		}
 		auto_log_info("Down with the tyrant of Spookyraven!", "blue");
 		//AoSOL buffs
 		if(in_aosol())
@@ -2430,6 +2430,13 @@ boolean L11_mauriceSpookyraven()
 		{
 			auto_change_mcd(0);
 			autoEquip($slot[acc2], $item[gumshoes]);
+		}
+		
+		if(in_wereprof() && !is_werewolf())
+		{
+			// +ML is BAD for professor
+			auto_change_mcd(0);
+			removeFromMaximize("500ml " + auto_convertDesiredML(82) + "max");
 		}
 		
 		if(monster_level_adjustment() < 57)

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2608,10 +2608,6 @@ boolean L11_ronCopperhead()
 		return false;
 	}
 
-	if(in_wereprof() && !is_werewolf())
-	{
-		return false; //can't do Copperhead Club as a Professor
-	}
 
 
 	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
@@ -2676,6 +2672,11 @@ boolean L11_shenStartQuest()
 		return false;
 	}
 	
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false; //can't do Copperhead Club as a Professor
+	}
+	
 	auto_log_info("Going to see the World's Biggest Jerk about some snakes and stones and stuff.", "blue");
 	if (autoAdv($location[The Copperhead Club]))
 	{
@@ -2710,6 +2711,12 @@ boolean L11_shenCopperhead()
 		// if we haven't spoke to Shen for the first time yet, don't try to handle the quest.
 		return false;
 	}
+
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false; //can't do Copperhead Club as a Professor
+	}
+
 
 	if (internalQuestStatus("questL11Shen") == 2 || internalQuestStatus("questL11Shen") == 4 || internalQuestStatus("questL11Shen") == 6)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2608,6 +2608,11 @@ boolean L11_ronCopperhead()
 		return false;
 	}
 
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false; //can't do Copperhead Club as a Professor
+	}
+
 
 	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1764,7 +1764,7 @@ boolean L11_hiddenCity()
 
 
 	//can we handle this zone?
-	if(!in_pokefam() && !in_darkGyffte() && !in_aosol())
+	if(!in_pokefam() && !in_darkGyffte() && !in_aosol() && !in_wereprof())
 	{
 		if(!acquireHP())	//try to restore HP to max.
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2612,8 +2612,6 @@ boolean L11_ronCopperhead()
 		return false;
 	}
 
-
-
 	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
 	{
 		if (item_amount($item[Red Zeppelin Ticket]) < 1 && !in_wotsf() && !is_werewolf()) // no black market in wotsf, can't access as werewolf

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -929,6 +929,10 @@ boolean L11_mcmuffinDiary()
 	{
 		return false;
 	}
+	if(is_werewolf())
+	{
+		return false; //can't access stores as werewolf which includes the shore
+	}
 	if(in_koe() && item_amount($item[Forged Identification Documents]) > 0)
 	{
 		council(); // Shore doesn't exist in Exploathing so we acquire diary from the council
@@ -1892,7 +1896,7 @@ boolean L11_hiddenCity()
 				if(canDrinkCursedPunch)
 				{
 					L11_hiddenTavernUnlock(true);
-					if(my_ascensions() == get_property("hiddenTavernUnlock").to_int())
+					if(my_ascensions() == get_property("hiddenTavernUnlock").to_int() && !is_werewolf())
 					{
 						auto_buyUpTo(cursesNeeded, $item[Cursed Punch]);
 						if(item_amount($item[Cursed Punch]) < cursesNeeded)

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2226,6 +2226,10 @@ boolean L11_mauriceSpookyraven()
 	{
 		return false;		//delay fight so we can make sure we are strong enough to beat him
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false;		//Can't beat Lord Spookyraven as the Professor
+	}
 
 	if (internalQuestStatus("questL11Manor") < 1)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -914,6 +914,10 @@ boolean L11_forgedDocuments()
 		pages[1] = "shop.php?whichshop=blackmarket&action=fightbmguy";
 		return autoAdvBypass(0, pages, $location[Noob Cave], "");
 	}
+	if(is_werewolf())
+	{
+		return false; // can't access shops as a werewolf
+	}
 	auto_buyUpTo(1, $item[Forged Identification Documents]);
 	if(item_amount($item[Forged Identification Documents]) > 0)
 	{
@@ -1000,6 +1004,10 @@ boolean L11_getUVCompass()
 	if(in_koe())
 	{
 		return false;		//impossible to get compass in this path. [The Shore, Inc] is unavailable
+	}
+	if(is_werewolf())
+	{
+		return false; // can't access shore as a werewolf
 	}
 
 	pullXWhenHaveY($item[Shore Inc. Ship Trip Scrip], 1, 0);
@@ -1098,7 +1106,7 @@ boolean L11_aridDesert()
 		if((get_property("gnasirProgress").to_int() & 2) != 2)
 		{
 			boolean canBuyPaint = true;
-			if(in_wotsf() || in_nuclear())
+			if(in_wotsf() || in_nuclear() || is_werewolf())
 			{
 				canBuyPaint = false;
 			}
@@ -1842,7 +1850,7 @@ boolean L11_hiddenCity()
 				//can drink and inebriety allows it
 				if(canDrinkCursedPunch)
 				{
-					boolean canBuyCursedPunch = (my_meat() >= cursesNeeded*500*npcStoreDiscountMulti());
+					boolean canBuyCursedPunch = (my_meat() >= cursesNeeded*500*npcStoreDiscountMulti() && !is_werewolf()); //can't buy cursed punch as a werewolf
 					
 					if(canBuyCursedPunch)
 					{
@@ -1993,7 +2001,7 @@ boolean L11_hiddenCity()
 		L11_hiddenTavernUnlock(true);
 		if(my_ascensions() == get_property("hiddenTavernUnlock").to_int())
 		{
-			if(item_amount($item[Bowl Of Scorpions]) == 0)
+			if(item_amount($item[Bowl Of Scorpions]) == 0 && !is_werewolf()) //can't access shops as werewolf
 			{
 				auto_buyUpTo(1, $item[Bowl Of Scorpions]);
 				if(in_ocrs())
@@ -2603,7 +2611,7 @@ boolean L11_ronCopperhead()
 
 	if (internalQuestStatus("questL11Ron") > 1 && internalQuestStatus("questL11Ron") < 5)
 	{
-		if (item_amount($item[Red Zeppelin Ticket]) < 1 && !in_wotsf()) // no black market in wotsf
+		if (item_amount($item[Red Zeppelin Ticket]) < 1 && !in_wotsf() && !is_werewolf()) // no black market in wotsf, can't access as werewolf
 		{
 			// use the priceless diamond since we go to the effort of trying to get one in the Copperhead Club
 			// and it saves us 4.5k meat.

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1078,8 +1078,16 @@ boolean L12_orchardFinalize()
 		pulverizeThing($item[A Light that Never Goes Out]);
 	}
 	equipWarOutfit();
-	visit_url("bigisland.php?place=orchard&action=stand&pwd=");
-	visit_url("shop.php?whichshop=hippy");
+	if(is_werewolf())
+	{
+		visit_url("bigisland.php?place=orchard&action=stand&pwd=");
+		return true; // can't access the shop as a werewolf so just want to return after done
+	}
+	else
+	{
+		visit_url("bigisland.php?place=orchard&action=stand&pwd=");
+		visit_url("shop.php?whichshop=hippy");
+	}
 	return true;
 }
 
@@ -1713,7 +1721,17 @@ boolean L12_themtharHills()
 
 	if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
 	{
-		outfit("Frat Warrior Fatigues");
+		if(!is_werewolf() && in_wereprof())
+		{
+			//Need to manually equip because professor
+			if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
+			if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
+			if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
+		}
+		else
+		{
+			outfit("Frat Warrior Fatigues");
+		}
 		cli_execute("concert 2");
 	}
 
@@ -2227,7 +2245,17 @@ boolean L12_finalizeWar()
 	if(possessOutfit("War Hippy Fatigues"))
 	{
 		auto_log_info("Getting dimes.", "blue");
-		outfit("War Hippy Fatigues");
+		if(in_wereprof())
+		{
+			//Need to manually equip because professor
+			if(!have_equipped($item[bullet-proof corduroys])) equip($item[bullet-proof corduroys]);
+			if(!have_equipped($item[round purple sunglasses])) equip($item[round purple sunglasses]);
+			if(!have_equipped($item[reinforced beaded headband])) equip($item[reinforced beaded headband]);
+		}
+		else
+		{
+			outfit("War Hippy Fatigues");
+		}
 		foreach it in $items[padl phone, red class ring, blue class ring, white class ring]
 		{
 			sell(it.buyer, item_amount(it), it);
@@ -2247,7 +2275,17 @@ boolean L12_finalizeWar()
 	if(possessOutfit("Frat Warrior Fatigues"))
 	{
 		auto_log_info("Getting quarters.", "blue");
-		outfit("Frat Warrior Fatigues");
+		if(in_wereprof())
+		{
+			//Need to manually equip because professor
+			if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
+			if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
+			if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
+		}
+		else
+		{
+			outfit("Frat Warrior Fatigues");
+		}
 		foreach it in $items[pink clay bead, purple clay bead, green clay bead, communications windchimes]
 		{
 			sell(it.buyer, item_amount(it), it);
@@ -2303,6 +2341,13 @@ boolean L12_finalizeWar()
 
 	if(possessOutfit("War Hippy Fatigues"))
 	{
+		if(in_wereprof())
+		{
+			//Need to manually equip because professor
+			if(!have_equipped($item[bullet-proof corduroys])) equip($item[bullet-proof corduroys]);
+			if(!have_equipped($item[round purple sunglasses])) equip($item[round purple sunglasses]);
+			if(!have_equipped($item[reinforced beaded headband])) equip($item[reinforced beaded headband]);
+		}
 		while($coinmaster[Dimemaster].available_tokens >= 5)
 		{
 			cli_execute("make " + $coinmaster[Dimemaster].available_tokens/5 + " fancy seashell necklace");
@@ -2319,6 +2364,13 @@ boolean L12_finalizeWar()
 
 	if(possessOutfit("Frat Warrior Fatigues"))
 	{
+		if(in_wereprof())
+		{
+			//Need to manually equip because professor
+			if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
+			if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
+			if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
+		}
 		while($coinmaster[Quartersmaster].available_tokens >= 5)
 		{
 			cli_execute("make " + $coinmaster[Quartersmaster].available_tokens/5 + " commemorative war stein");
@@ -2363,6 +2415,11 @@ boolean L12_finalizeWar()
 	pages[0] = "bigisland.php?place=camp&whichcamp=1";
 	pages[1] = "bigisland.php?place=camp&whichcamp=2";
 	pages[2] = "bigisland.php?action=bossfight&pwd";
+	//Shouldn't fight boss if Professor in WereProfessor so burn turns until Werewolf
+	if(!is_werewolf() && in_wereprof())
+	{
+		autoAdvBypass("place.php?whichplace=wereprof_cottage&action=wereprof_bookshelf");
+	}
 	if(!autoAdvBypass(0, pages, bossFight, ""))
 	{
 		auto_log_warning("Boss already defeated, ignoring", "red");

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1153,9 +1153,9 @@ boolean L12_gremlins()
 	{
 		return false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
-		return false; //Only 1 HP as a professor
+		return false; //Only 1 HP as a professor so can't stasis long enough
 	}
 	if(get_property("auto_hippyInstead").to_boolean() && (get_property("fratboysDefeated").to_int() < 192))
 	{
@@ -1725,7 +1725,7 @@ boolean L12_themtharHills()
 
 	if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
 	{
-		if(!is_werewolf() && in_wereprof())
+		if(is_professor())
 		{
 			//Need to manually equip because professor
 			if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
@@ -2245,9 +2245,9 @@ boolean L12_finalizeWar()
 	{
 		return false;
 	}
-	if(in_wereprof() && !is_werewolf())
+	if(is_professor())
 	{
-		return false; //need to wait until werewolf because can't kill Boss as a Prof
+		return false; //need to wait until werewolf because can't survive combat long enough as a Prof
 	}
 
 	if(possessOutfit("War Hippy Fatigues"))

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -966,7 +966,7 @@ boolean L12_filthworms()
 		asdonBuff($effect[Driving Observantly]);
 		bat_formBats();
 
-		buffMaintain($effect[Frosty]);
+		if(!in_wereprof()) buffMaintain($effect[Frosty]);
 		
 		//craft IOTM derivative that gives high item bonus
 		if((!possessEquipment($item[A Light That Never Goes Out])) && (item_amount($item[Lump of Brituminous Coal]) > 0))
@@ -1766,7 +1766,7 @@ boolean L12_themtharHills()
 	handleFamiliar("meat");
 	addToMaximize("200meat drop");
 
-	if(have_effect($effect[Frosty])==0)
+	if(have_effect($effect[Frosty])==0 && !in_wereprof())
 	{
 		auto_wishForEffect($effect[Frosty]);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -2245,6 +2245,10 @@ boolean L12_finalizeWar()
 	{
 		return false;
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false; //need to wait until werewolf because can't kill Boss as a Prof
+	}
 
 	if(possessOutfit("War Hippy Fatigues"))
 	{
@@ -2419,13 +2423,6 @@ boolean L12_finalizeWar()
 	pages[0] = "bigisland.php?place=camp&whichcamp=1";
 	pages[1] = "bigisland.php?place=camp&whichcamp=2";
 	pages[2] = "bigisland.php?action=bossfight&pwd";
-	//Shouldn't fight boss if Professor in WereProfessor so burn turns until Werewolf
-	if(!is_werewolf() && in_wereprof())
-	{
-		auto_log_info("Can't beat the Boss as a Professor so skipping for now", "blue");
-		//autoAdvBypass("place.php?whichplace=wereprof_cottage&action=wereprof_bookshelf");
-		return false;
-	}
 	if(!autoAdvBypass(0, pages, bossFight, ""))
 	{
 		auto_log_warning("Boss already defeated, ignoring", "red");

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -966,7 +966,7 @@ boolean L12_filthworms()
 		asdonBuff($effect[Driving Observantly]);
 		bat_formBats();
 
-		if(!in_wereprof()) buffMaintain($effect[Frosty]);
+		if(!in_wereprof()) buffMaintain($effect[Frosty]); //wereprof doesn't like +ML effects outside of Werewolf
 		
 		//craft IOTM derivative that gives high item bonus
 		if((!possessEquipment($item[A Light That Never Goes Out])) && (item_amount($item[Lump of Brituminous Coal]) > 0))

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1153,6 +1153,10 @@ boolean L12_gremlins()
 	{
 		return false;
 	}
+	if(in_wereprof() && !is_werewolf())
+	{
+		return false; //Only 1 HP as a professor
+	}
 	if(get_property("auto_hippyInstead").to_boolean() && (get_property("fratboysDefeated").to_int() < 192))
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -2422,7 +2422,7 @@ boolean L12_finalizeWar()
 	//Shouldn't fight boss if Professor in WereProfessor so burn turns until Werewolf
 	if(!is_werewolf() && in_wereprof())
 	{
-		auto_log_info("Can't beat the Boss as a Professor so skipping for now", blue);
+		auto_log_info("Can't beat the Boss as a Professor so skipping for now", "blue");
 		//autoAdvBypass("place.php?whichplace=wereprof_cottage&action=wereprof_bookshelf");
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -2422,7 +2422,9 @@ boolean L12_finalizeWar()
 	//Shouldn't fight boss if Professor in WereProfessor so burn turns until Werewolf
 	if(!is_werewolf() && in_wereprof())
 	{
-		autoAdvBypass("place.php?whichplace=wereprof_cottage&action=wereprof_bookshelf");
+		auto_log_info("Can't beat the Boss as a Professor so skipping for now", blue);
+		//autoAdvBypass("place.php?whichplace=wereprof_cottage&action=wereprof_bookshelf");
+		return false;
 	}
 	if(!autoAdvBypass(0, pages, bossFight, ""))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1493,7 +1493,7 @@ boolean L13_towerNSTower()
 		familiar hundred_fam = to_familiar(get_property("auto_100familiar"));
 		boolean has_boning_knife = item_amount($item[Electric Boning Knife]) > 0;
 		
-		if(has_boning_knife || in_pokefam())		//I have everything I need. just go fight
+		if(has_boning_knife || in_pokefam() || (in_wereprof() && canUse($skill[Slaughter]) && have_effect($effect[Everything Looks Red]) == 0))		//I have everything I need. just go fight
 		{
 			return autoAdvBypass("place.php?whichplace=nstower&action=ns_07_monster3", $location[Noob Cave]);
 		}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1826,7 +1826,7 @@ boolean L13_towerNSFinal()
 		abort("Freeing the king will result in losing all your replica IOTM. Enjoy them while you have them!");
 	}
 
-	if(in_wereprof())
+	if(in_wereprof() && (0 < item_amount($item[Thwaitgold wolf spider statuette])))
 	{
 		abort("Freeing the king will result in a path change. Go howl at the moon some more if you want.");
 	}

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -73,6 +73,7 @@ boolean EightBitRealmHandler()
 	boolean adv_spent = false;
 
 	string color = get_property("8BitColor");
+	if(!woods_questStart()) return false;
 	switch(color)
 	{
 		case "black":

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -73,7 +73,11 @@ boolean EightBitRealmHandler()
 	boolean adv_spent = false;
 
 	string color = get_property("8BitColor");
-	if(!woods_questStart()) return false;
+	if((internalQuestStatus("questL02Larva") < 0 && internalQuestStatus("questG02Whitecastle") < 0) && available_amount($item[Continuum Transfunctioner]) == 0)
+	{
+		// need distant woods and continuum transfunctioner
+		return false;
+	}
 	switch(color)
 	{
 		case "black":

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -391,6 +391,12 @@ boolean L13_towerNSContests()
 
 	if(contains_text(visit_url("place.php?whichplace=nstower"), "ns_01_contestbooth"))
 	{
+		if(in_wereprof() && get_property("wereProfessorTransformTurns") < 48)
+		{
+			visit_url("place.php?whichplace=nstower&action=ns_01_contestbooth");
+			visit_url("choice.php?pwd=&whichchoice=1003&option=5", true);
+			visit_url("main.php");
+		}
 		if(get_property("nsContestants1").to_int() == -1)
 		{
 			resetMaximize();
@@ -1818,6 +1824,11 @@ boolean L13_towerNSFinal()
 	if(in_lol())
 	{
 		abort("Freeing the king will result in losing all your replica IOTM. Enjoy them while you have them!");
+	}
+
+	if(in_wereprof())
+	{
+		abort("Freeing the king will result in a path change. Go howl at the moon some more if you want.");
 	}
 
 	if(!($classes[Seal Clubber, Turtle Tamer, Pastamancer, Sauceror, Disco Bandit, Accordion Thief] contains my_class()))

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -394,7 +394,7 @@ boolean L13_towerNSContests()
 		if(in_wereprof() && get_property("wereProfessorTransformTurns") < 48)
 		{
 			visit_url("place.php?whichplace=nstower&action=ns_01_contestbooth");
-			visit_url("choice.php?pwd=&whichchoice=1003&option=5", true);
+			visit_url("choice.php?pwd=&whichchoice=1003&option=5", true); //want as many turns of werewolf as possible at the contest booth so refresh with this choice
 			visit_url("main.php");
 		}
 		if(get_property("nsContestants1").to_int() == -1)

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -854,7 +854,7 @@ boolean LX_setWorkshed(){
 	boolean workshedChanged = get_property("_workshedItemUsed").to_boolean();
 
 	if (workshedChanged) return false; //Don't even try if the workshed has already been changed once
-	if (isActuallyEd() || in_robot() || in_nuclear()) return false; //Not usable in Ed, Nuclear Autumn, or You, Robot
+	if (isActuallyEd() || in_robot() || in_nuclear() || in_wereprof()) return false; //Not usable in Ed, Nuclear Autumn, You, Robot, or WereProfessor
 
 	//Check to make sure we can use the workshed item and that it isn't already in the campground. If already in campground, return false also
 	//These first 2 ifs are only used if something valid other than auto is specified. Otherwise we go to the auto 

--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1109,7 +1109,7 @@ boolean LX_NemesisQuest()
 void houseUpgrade()
 {
 	//function for upgrading your dwelling.
-	if(isActuallyEd() || in_darkGyffte() || in_nuclear())
+	if(isActuallyEd() || in_darkGyffte() || in_nuclear() || in_wereprof())
 	{
 		return;		//paths where dwelling is locked
 	}


### PR DESCRIPTION
# Description

This PR implements WereProfessor support. ~It is still very much in ALPHA territory so use with caution. Everfull Dart Holster is a must. Expect breakage if you decide to try it out/manually needing to do parts of the run. But comments are welcome~

~Will auto buy skills, but I'm not happy with the implementation~

- [x] Buy skills
- [x] Gets smashed scientific materials as Werewolf
- [x] Buys smashed scientific materials equipment
- [x] Add Werewolf skills to combat
- [x] Prioritize equipment to ensure survival as Professor
- [X] ~Figure out routing for this~ I'm not sure this will ever be optimized but it works pretty well now

## How Has This Been Tested?

~1.5 days of a run of WereProfessor as of 4/23. 10 full Normal WereProf runs as of 5/23~ 25 full Normal WereProf runs and 1 HC WereProf run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
