### PR TITLE
Avatar Paths Can't Use Emotion Chip

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -762,8 +762,8 @@ void initializeDay(int day)
 		use_skill(1, $skill[Iron Palm Technique]);
 	}
 
-	// Get emotionally chipped if you have the item.  boris\zombie slayer\ed cannot use this skill so excluding.
-	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte()))
+	// Get emotionally chipped if you have the item.  boris\jarlsberg\sneaky pete\zombie slayer\ed cannot use this skill so excluding.
+	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || is_jarlsberg() || is_pete() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte()))
 	{
 		use(1, $item[spinal-fluid-covered emotion chip]);
 	}


### PR DESCRIPTION
Adding Jarlsberg and Sneaky Pete to Emotion Chip Prevention

Comments out that request

## How Has This Been Tested?

Running it right now, ya dig

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
