### PR TITLE
Add support for Mayam calendar

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27897;	// additional monster parts
+since r27930;	// mayam
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -1809,6 +1809,7 @@ boolean doTasks()
 	auto_checkTrainSet();
 	prioritizeGoose();
 	auto_useWardrobe();
+	auto_MayamClaimAll();
 	
 	ocrs_postCombatResolve();
 	beatenUpResolution();

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -618,6 +618,28 @@ boolean LX_doVacation()
 	return autoAdv(1, $location[The Shore\, Inc. Travel Agency]);
 }
 
+boolean auto_doTempleSummit()
+{
+	if(!hidden_temple_unlocked() || internalQuestStatus("questL11Worship") < 3)
+	{
+		return false;
+	}
+	if(available_amount($item[stone wool])==0)
+	{
+		return false;
+	}
+	if (get_property("lastTempleAdventures").to_int()>=my_ascensions())
+	{
+		return false;
+	}
+	buffMaintain($effect[Stone-Faced]);
+	if(have_effect($effect[Stone-Faced]) == 0)
+	{
+		return false;
+	}
+	return autoAdv($location[The Hidden Temple]);
+}
+
 void initializeDay(int day)
 {
 	if(inAftercore())
@@ -1888,6 +1910,8 @@ boolean doTasks()
 	if(auto_smallCampgroundGear())		return true;
 	auto_lostStomach(false);
 	if(auto_doPhoneQuest())				return true;
+	
+	if(auto_doTempleSummit())		return true;
 	
 	if (process_tasks()) return true;
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r27930;	// mayam
+since r27955;	// consider free rests from mayam chair
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -762,8 +762,8 @@ void initializeDay(int day)
 		use_skill(1, $skill[Iron Palm Technique]);
 	}
 
-	// Get emotionally chipped if you have the item.  boris\zombie slayer\ed cannot use this skill so excluding.
-	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte()))
+	// Get emotionally chipped if you have the item.  boris\jarlsberg\sneaky pete\zombie slayer\ed cannot use this skill so excluding.
+	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || is_jarlsberg() || is_pete() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte()))
 	{
 		use(1, $item[spinal-fluid-covered emotion chip]);
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -556,6 +556,13 @@ void dartChoiceHandler(int choice, string[int] options);
 int dartBullseyeChance();
 int dartELRcd();
 skill dartSkill();
+boolean auto_haveMayamCalendar();
+boolean auto_MayamClaimStinkBomb();
+boolean auto_MayamIsUsed(string glyph);
+boolean auto_MayamClaimStinkBomb();
+boolean auto_MayamClaimBelt();
+boolean auto_MayamClaimWhatever();
+boolean auto_MayamClaimAll();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -25,6 +25,7 @@ boolean LX_burnDelay();
 boolean LX_calculateTheUniverse(boolean speculative);
 boolean tophatMaker();
 boolean LX_doVacation();
+boolean auto_doTempleSummit();
 void initializeDay(int day);
 boolean dailyEvents();
 boolean Lsc_flyerSeals();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -558,7 +558,6 @@ int dartBullseyeChance();
 int dartELRcd();
 skill dartSkill();
 boolean auto_haveMayamCalendar();
-boolean auto_MayamClaimStinkBomb();
 boolean auto_MayamIsUsed(string glyph);
 boolean auto_MayamClaimStinkBomb();
 boolean auto_MayamClaimBelt();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -559,6 +559,7 @@ int dartELRcd();
 skill dartSkill();
 boolean auto_haveMayamCalendar();
 boolean auto_MayamIsUsed(string glyph);
+boolean auto_MayamAllUsed();
 boolean auto_MayamClaimStinkBomb();
 boolean auto_MayamClaimBelt();
 boolean auto_MayamClaimWhatever();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -638,6 +638,11 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Feel Hatred];
 	}
 	
+	if((item_amount($item[stuffed yam stinkbomb]) > 0) && (!(used contains "stuffed yam stinkbomb")) && auto_is_valid($item[stuffed yam stinkbomb]))
+	{
+		return "item " + $item[stuffed yam stinkbomb];
+	}
+
 	if(auto_have_skill($skill[[28021]Punt]) && (my_mp() > mp_cost($skill[[28021]Punt])) && !(used contains "Punt"))
 	{
 		return "skill " + $skill[[28021]Punt];

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -243,7 +243,7 @@ boolean auto_MayamIsUsed(string glyph)
 boolean auto_MayamAllUsed()
 {
 	// mayam is currently fully used if all 3 ring1 symbols have been used
-	return auto_MayamIsUsed("yam1") && auto_MayamIsUsed("eye") && auto_MayamIsUsed("vessel");
+	return auto_MayamIsUsed("yam4") && auto_MayamIsUsed("clock") && auto_MayamIsUsed("explosion");
 }
 
 boolean auto_MayamClaimStinkBomb()
@@ -292,13 +292,14 @@ boolean auto_MayamClaimWhatever()
 	string ring4 = "BAD_VALUE";
 	boolean failure = false;
 	
-	if      (!auto_MayamIsUsed("yam1"))   { ring1 = "yam"; }
+	if      (!auto_MayamIsUsed("chair") && auto_haveCincho())   { ring1 = "chair"; }
+	// todo: add support for giving appropriate fam 100xp with fur option
 	else if (!auto_MayamIsUsed("eye"))    { ring1 = "eye"; }
 	else if (!auto_MayamIsUsed("vessel")) { ring1 = "vessel"; }
 	else { failure = true; }
 	
-	if      (!auto_MayamIsUsed("yam2"))   { ring2 = "yam"; }
-	else if (!auto_MayamIsUsed("wood"))   { ring2 = "wood"; }
+	if      (!auto_MayamIsUsed("wood") && (lumberCount() < 30 || fastenerCount() < 30))   { ring2 = "wood"; }
+	else if (!auto_MayamIsUsed("lightning"))   { ring2 = "lightning"; }
 	else if (!auto_MayamIsUsed("meat"))   { ring2 = "meat"; }
 	else { failure = true; }
 	

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -167,3 +167,114 @@ skill dartSkill()
 	}
 	return to_skill(7513); // If there aren't any darts available return the Darts: Throw at %PART1
 }
+
+boolean auto_haveMayamCalendar()
+{
+	if(auto_is_valid($item[Mayam Calendar]) && available_amount($item[Mayam Calendar]) > 0 )
+	{
+		return true;
+	}
+	return false;
+}
+
+boolean auto_MayamIsUsed(string glyph)
+{
+	string[int] used = split_string(get_property("_mayamSymbolsUsed"),",");
+	foreach idx,str in used
+	{
+		if (glyph==str)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+boolean auto_MayamClaimStinkBomb()
+{
+	if(!auto_haveMayamCalendar())
+	{
+		return false;
+	}
+	if(auto_MayamIsUsed("vessel") ||
+	   auto_MayamIsUsed("yam2")   ||
+	   auto_MayamIsUsed("cheese") ||
+	   auto_MayamIsUsed("explosion") )
+	{
+		return false;
+	}
+	cli_execute("mayam rings vessel yam cheese explosion");
+	return true;
+}
+
+boolean auto_MayamClaimBelt()
+{
+	if(!auto_haveMayamCalendar())
+	{
+		return false;
+	}
+	if(auto_MayamIsUsed("yam1") ||
+	   auto_MayamIsUsed("meat")   ||
+	   auto_MayamIsUsed("eyepatch") ||
+	   auto_MayamIsUsed("yam4") )
+	{
+		return false;
+	}
+	cli_execute("mayam rings yam meat eyepatch yam");
+	return true;
+}
+
+boolean auto_MayamClaimWhatever()
+{
+	if(!auto_haveMayamCalendar())
+	{
+		return false;
+	}
+	string ring1 = "BAD_VALUE";
+	string ring2 = "BAD_VALUE";
+	string ring3 = "BAD_VALUE";
+	string ring4 = "BAD_VALUE";
+	boolean failure = false;
+	
+	if      (!auto_MayamIsUsed("yam1"))   { ring1 = "yam"; }
+	else if (!auto_MayamIsUsed("eye"))    { ring1 = "eye"; }
+	else if (!auto_MayamIsUsed("vessel")) { ring1 = "vessel"; }
+	else { failure = true; }
+	
+	if      (!auto_MayamIsUsed("yam2"))   { ring2 = "yam"; }
+	else if (!auto_MayamIsUsed("wood"))   { ring2 = "wood"; }
+	else if (!auto_MayamIsUsed("meat"))   { ring2 = "meat"; }
+	else { failure = true; }
+	
+	if      (!auto_MayamIsUsed("yam3"))   { ring3 = "yam"; }
+	else if (!auto_MayamIsUsed("cheese")) { ring3 = "cheese"; }
+	else if (!auto_MayamIsUsed("wall"))   { ring3 = "wall"; }
+	else { failure = true; }
+	
+	if      (!auto_MayamIsUsed("yam4"))      { ring4 = "yam"; }
+	else if (!auto_MayamIsUsed("clock"))     { ring4 = "clock"; }
+	else if (!auto_MayamIsUsed("explosion")) { ring4 = "explosion"; }
+	else { failure = true; }
+	if (failure)
+	{
+		return false;
+	}
+	
+	cli_execute("mayam rings "+ring1+" "+ring2+" "+ring3+" "+ring4);
+	return true;
+}
+
+boolean auto_MayamClaimAll()
+{
+	auto_log_info("Claiming mayam calendar items");
+	if(!auto_haveMayamCalendar())
+	{
+		return false;
+	}
+	auto_MayamClaimStinkBomb();
+	auto_MayamClaimBelt();
+	auto_MayamClaimWhatever();
+	auto_MayamClaimWhatever();
+	auto_MayamClaimWhatever();
+	return true;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -190,6 +190,12 @@ boolean auto_MayamIsUsed(string glyph)
 	return false;
 }
 
+boolean auto_MayamAllUsed()
+{
+	// mayam is currently fully used if all 3 ring1 symbols have been used
+	return auto_MayamIsUsed("yam1") && auto_MayamIsUsed("eye") && auto_MayamIsUsed("vessel");
+}
+
 boolean auto_MayamClaimStinkBomb()
 {
 	if(!auto_haveMayamCalendar())
@@ -267,6 +273,10 @@ boolean auto_MayamClaimWhatever()
 boolean auto_MayamClaimAll()
 {
 	if(!auto_haveMayamCalendar())
+	{
+		return false;
+	}
+	if(auto_MayamAllUsed())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -266,11 +266,11 @@ boolean auto_MayamClaimWhatever()
 
 boolean auto_MayamClaimAll()
 {
-	auto_log_info("Claiming mayam calendar items");
 	if(!auto_haveMayamCalendar())
 	{
 		return false;
 	}
+	auto_log_info("Claiming mayam calendar items");
 	auto_MayamClaimStinkBomb();
 	auto_MayamClaimBelt();
 	auto_MayamClaimWhatever();


### PR DESCRIPTION
# Description

This summons items from the Mayam calendar. It prioritises the stinkbomb and yamtility belt items, then yams, item drops, cheese, wood etc.

It adds the use of the Such Great Heights adventure for +adventures if you have the spare stone wool. I added it because it recharges the calendar, but it will do it even if you don't have a calendar.

Mayam stinkbomb is implemented as a banish, but isn't always used because of the much higher priority of Spring Kick. This may need to be changed.

## How Has This Been Tested?

Couple of days of HC unrestricted runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
