### PR TITLE
Only use candycane sword to skip war start if we have war outfit

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -104,7 +104,7 @@ boolean auto_run_choice(int choice, string page)
 			hiddenTempleChoiceHandler(choice, page);
 			break;
 		case 139: // Bait and Switch (The Hippy Camp (Verge of War))
-			if(options contains 4 && possessOutfit("Frat Warrior Fatigues"))
+			if(options contains 4 && haveWarOutfit())
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}
@@ -114,7 +114,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 140: // The Thin Tie-Dyed Line (The Hippy Camp (Verge of War))
-			if(options contains 4 && possessOutfit("Frat Warrior Fatigues"))
+			if(options contains 4 && haveWarOutfit())
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}
@@ -130,7 +130,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(3); // starts the war. skips adventure if already started.
 			break;
 		case 143: // Catching Some Zetas (Orcish Frat House (Verge of War))
-			if(options contains 4 && possessOutfit("War Hippy Fatigues"))
+			if(options contains 4 && haveWarOutfit())
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}
@@ -140,7 +140,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 144: // One Less Room Than In That Movie (Orcish Frat House (Verge of War))
-			if(options contains 4 && possessOutfit("War Hippy Fatigues"))
+			if(options contains 4 && haveWarOutfit())
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -104,7 +104,7 @@ boolean auto_run_choice(int choice, string page)
 			hiddenTempleChoiceHandler(choice, page);
 			break;
 		case 139: // Bait and Switch (The Hippy Camp (Verge of War))
-			if(options contains 4)
+			if(options contains 4 && possessOutfit("Frat Warrior Fatigues"))
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}
@@ -114,7 +114,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 140: // The Thin Tie-Dyed Line (The Hippy Camp (Verge of War))
-			if(options contains 4)
+			if(options contains 4 && possessOutfit("Frat Warrior Fatigues"))
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}
@@ -130,7 +130,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(3); // starts the war. skips adventure if already started.
 			break;
 		case 143: // Catching Some Zetas (Orcish Frat House (Verge of War))
-			if(options contains 4)
+			if(options contains 4 && possessOutfit("War Hippy Fatigues"))
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}
@@ -140,7 +140,7 @@ boolean auto_run_choice(int choice, string page)
 			}
 			break;
 		case 144: // One Less Room Than In That Movie (Orcish Frat House (Verge of War))
-			if(options contains 4)
+			if(options contains 4 && possessOutfit("War Hippy Fatigues"))
 			{
 				run_choice(4); // use your candy cane sword cane to skip to the war start
 			}


### PR DESCRIPTION
# Description

Currently we don't force candy cane sword being equipped if we don't have the war outfit. However there is nothing stopping maximizer. 

This change will prevent the choice adv script from starting the war until we have a war outfit.

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
