### PR TITLE
Burn MP Properly For Free Resting

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1963,6 +1963,7 @@ void auto_begin()
 	backupSetting("logPreferenceChange", "true");
 	backupSetting("logPreferenceChangeFilter", "maximizerMRUList,testudinalTeachings,auto_maximize_current");
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
+	backupSetting("allowNonMoodBurning", true); // required to be true for burn cli cmd to work properly
 
 	string charpane = visit_url("charpane.php");
 	if(contains_text(charpane, "<hr width=50%><table"))

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2165,7 +2165,7 @@ int auto_potentialMaxFreeRests()
 	// we can get the count of "intrinsic" free rests e.g perm'd skills & rests you get just from having something available in run
 	int potential = numeric_modifier("Free Rests");
 
-	if (auto_canUseJuneCleaver() && !possessEquipment($item[mother's necklace]))
+	if (auto_canUseJuneCleaver() && !possessEquipment($item[mother\'s necklace]))
 	{
 		potential += 5;
 	}
@@ -2208,7 +2208,11 @@ boolean doFreeRest(){
 
 		if (mpToBurn > 0)
 		{
+			// allowNonMoodBurning must be true for burn command to work properly
+			string originalValue = get_property("allowNonMoodBurning");
+			set_property("allowNonMoodBurning", true);
 			cli_execute("burn " + mpToBurn);
+			set_property("allowNonMoodBurning", originalValue);
 		}
 
 		// resting and success check

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2208,11 +2208,7 @@ boolean doFreeRest(){
 
 		if (mpToBurn > 0)
 		{
-			// allowNonMoodBurning must be true for burn command to work properly
-			string originalValue = get_property("allowNonMoodBurning");
-			set_property("allowNonMoodBurning", true);
 			cli_execute("burn " + mpToBurn);
-			set_property("allowNonMoodBurning", originalValue);
 		}
 
 		// resting and success check


### PR DESCRIPTION
# Description

Reported in discord a few times. Fixed issue and fixed one spot for VS code formatting

`keep getting "failed to rest to charge cincho" message, then autoscend aborts. `

## How Has This Been Tested?

Ran in CLI. Pref changes as expected and burns mp as expected. Confirmed when this pref is false, burn command does not work as well.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
