### PR TITLE
Update auto_choice_adv.ash for 11TIHAU non-combats

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -759,6 +759,9 @@ boolean auto_run_choice(int choice, string page)
 		case 1525:
 			dartChoiceHandler(choice, options);
 			break;
+		case 1528: // Eye-Eye-Eye!
+			run_choice(1); // one button, click it
+			break;
 		default:
 			break;
 	}


### PR DESCRIPTION
# Description

Fixes "11 Things I Hate About U" constantly stopping due to unrecognised non-combat.

## How Has This Been Tested?

Ran day one, did not stop for this.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
