### PR TITLE
Black and White Apron Support

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -4,3 +4,4 @@ github Ezandora/Far-Future
 github Ezandora/Voting-Booth
 github loathers/excavator release
 github loathers/combo release
+github C2Talon/c2t_apron master

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -756,14 +756,6 @@ boolean auto_run_choice(int choice, string page)
 		case 1500: // Like a Loded Stone
 			run_choice(2); // only come here to get shadow waters buff
 			break;
-		case 1518: // Prepare your Meal (Black and White Apron Kit)
-			run_choice(1);
-			//string page = visit_url("choice.php?pwd=&whichchoice=1518&option=1",true);
-			boolean works = contains_text(page,"too");
-			print("did it in choice adv");
-			print(works);
-			//print(page);
-			break;
 		case 1525:
 			dartChoiceHandler(choice, options);
 			break;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -756,6 +756,14 @@ boolean auto_run_choice(int choice, string page)
 		case 1500: // Like a Loded Stone
 			run_choice(2); // only come here to get shadow waters buff
 			break;
+		case 1518: // Prepare your Meal (Black and White Apron Kit)
+			run_choice(1);
+			//string page = visit_url("choice.php?pwd=&whichchoice=1518&option=1",true);
+			boolean works = contains_text(page,"too");
+			print("did it in choice adv");
+			print(works);
+			//print(page);
+			break;
 		case 1525:
 			dartChoiceHandler(choice, options);
 			break;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1234,11 +1234,12 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 
 	// Add black and white apron if we are looking to eat
 	item apronKit = $item[Black and White Apron Meal Kit];
-	if(type == AUTO_ORGAN_STOMACH && item_amount(apronKit) > 0 && auto_is_valid(apronKit))
+	if(type == AUTO_ORGAN_STOMACH && (item_amount(apronKit) > 0 || canPull(apronKit)) && auto_is_valid(apronKit))
 	{
 		int size = 3;
 		float adv = 12.0;
-		actions[count(actions)] = new ConsumeAction(apronKit, 0, size, adv, adv, AUTO_ORGAN_STOMACH, AUTO_OBTAIN_NULL);
+		int obtainMethod = item_amount(apronKit) > 0 AUTO_OBTAIN_NULL: AUTO_OBTAIN_PULL;
+		actions[count(actions)] = new ConsumeAction(apronKit, 0, size, adv, adv, AUTO_ORGAN_STOMACH, obtainMethod);
 	}
 
 	// Now, to load cafe consumables. This has some TCRS-specific code.

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -325,6 +325,17 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 	{
 		return false;
 	}
+	if(toEat == $item[Black and White Apron Meal Kit])
+	{
+		if(consumeBlackAndWhiteApronKit())
+		{
+			return true;
+		}
+		else
+		{
+			abort("Attempted to eat food from Black and White Apron Kit, but failed.");
+		}
+	}
 	if(item_amount(toEat) < howMany)
 	{
 		return false;
@@ -1219,6 +1230,15 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 		int size = 1;
 		float adv = auto_expectedStillsuitAdvs().to_float();
 		actions[count(actions)] = new ConsumeAction($item[tiny stillsuit], 0, size, adv, adv, AUTO_ORGAN_LIVER, AUTO_OBTAIN_NULL);
+	}
+
+	// Add black and white apron if we are looking to eat
+	item apronKit = $item[Black and White Apron Meal Kit];
+	if(type == AUTO_ORGAN_STOMACH && item_amount(apronKit) > 0 && auto_is_valid(apronKit))
+	{
+		int size = 3;
+		float adv = 12.0;
+		actions[count(actions)] = new ConsumeAction(apronKit, 0, size, adv, adv, AUTO_ORGAN_STOMACH, AUTO_OBTAIN_NULL);
 	}
 
 	// Now, to load cafe consumables. This has some TCRS-specific code.

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -329,6 +329,7 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 	{
 		if(consumeBlackAndWhiteApronKit())
 		{
+			handleTracker("Black and White Apron Kit", "auto_eaten");
 			return true;
 		}
 		else

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1238,7 +1238,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	{
 		int size = 3;
 		float adv = 12.0;
-		int obtainMethod = item_amount(apronKit) > 0 AUTO_OBTAIN_NULL: AUTO_OBTAIN_PULL;
+		int obtainMethod = item_amount(apronKit) > 0 ? AUTO_OBTAIN_NULL : AUTO_OBTAIN_PULL;
 		actions[count(actions)] = new ConsumeAction(apronKit, 0, size, adv, adv, AUTO_ORGAN_STOMACH, obtainMethod);
 	}
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -541,6 +541,7 @@ void auto_useWardrobe();
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2024.ash
+boolean consumeBlackAndWhiteApronKit();
 boolean auto_haveSpringShoes();
 boolean auto_haveAprilingBandHelmet();
 boolean auto_getAprilingBandItems();

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -5,11 +5,11 @@ import <c2t_apron.ash>// used in consumeBlackAndWhiteApronKit()
 boolean consumeBlackAndWhiteApronKit()
 {
 	item apronKit = $item[Black and White Apron Meal Kit];
-	if(item_amount(apronKit) < 1)
+	if(fullness_left() < 3)
 	{
 		return false;
 	}
-	if(fullness_left() < 3)
+	if(item_amount(apronKit) < 1)
 	{
 		return false;
 	}
@@ -19,8 +19,29 @@ boolean consumeBlackAndWhiteApronKit()
 		abort("script c2t_apron didn't install properly. Fix and run autoscend again.");
 	}
 	
-	// configure so no extra ingredients are used
-	set_property("c2t_apron_allowlist","");
+	// default ingredient allow list. Allow all but:
+	// Potentially quest relevant: Blackberry, Bubblin' crude, enchanted bean
+	// Extra cold damage: grapefruit
+	// 20ml: dill
+	string allowList = "3489,1356,1560,2525,3490,748,1562,1557,1561,3491,\
+	1122,1559,2094,183,182,2338,237,787,1004,238,328,1005,2583,1006,589,672,2524,304,6724,\
+	1462,161,158,358,2589,55,302,332,170,2532,187,357,245,242,4956,830,165,1003,8,786,1558,\
+	246,4,159,209";
+
+	// allow quest items if no longer needed
+	if(possessEquipment($item[Blackberry Galoshes]) || item_amount($item[Blackberry]) > 3)
+	{
+		allowList += ",2063";
+	}
+	if(((oilProgress & 4) == 1) || item_amount($item[Jar Of Oil]) > 0 || item_amount($item[Bubblin\' Crude]) > 12)
+	{
+		allowList += ",5789";
+	}
+	if(item_amount($item[Enchanted Bean]) > 1 || internalQuestStatus("questL10Garbage") >= 1)
+	{
+		allowList += ",186";
+	}
+	set_property("c2t_apron_allowlist",allowList);
 	
 	// consume the apron kit using c2t's script
 	// this will default to consuming food for our current mainstat

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -33,6 +33,7 @@ boolean consumeBlackAndWhiteApronKit()
 	{
 		allowList += ",2063";
 	}
+	int oilProgress = get_property("twinPeakProgress").to_int();
 	if(((oilProgress & 4) == 1) || item_amount($item[Jar Of Oil]) > 0 || item_amount($item[Bubblin\' Crude]) > 12)
 	{
 		allowList += ",5789";

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -1,5 +1,24 @@
 # This is meant for items that have a date of 2024
 
+boolean consumeBlackAndWhiteApronKit()
+{
+	item apronKit = $item[Black and White Apron Meal Kit];
+	if(item_amount(apronKit) < 1)
+	{
+		return false;
+	}
+	if(fullness_left() < 3)
+	{
+		//return false;
+	}
+	use(apronKit);
+	//run_choice(1);s
+	//visit_url("inv_use.php?whichitem=11472&pwd");
+	//href="inv_use.php?whichitem=11472&pwd"
+	//visit_url("choice.php?pwd=&whichchoice=1518&option=2",true);
+	return true;
+}
+
 boolean auto_haveSpringShoes()
 {
 	if(auto_is_valid($item[spring shoes]) && available_amount($item[spring shoes]) > 0 )

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -1,5 +1,7 @@
 # This is meant for items that have a date of 2024
 
+import <c2t_apron.ash>// used in consumeBlackAndWhiteApronKit()
+
 boolean consumeBlackAndWhiteApronKit()
 {
 	item apronKit = $item[Black and White Apron Meal Kit];
@@ -9,14 +11,21 @@ boolean consumeBlackAndWhiteApronKit()
 	}
 	if(fullness_left() < 3)
 	{
-		//return false;
+		return false;
 	}
-	use(apronKit);
-	//run_choice(1);s
-	//visit_url("inv_use.php?whichitem=11472&pwd");
-	//href="inv_use.php?whichitem=11472&pwd"
-	//visit_url("choice.php?pwd=&whichchoice=1518&option=2",true);
-	return true;
+
+	if(!git_exists("C2Talon-c2t_apron-master"))
+	{
+		abort("script c2t_apron didn't install properly. Fix and run autoscend again.");
+	}
+	
+	// configure so no extra ingredients are used
+	set_property("c2t_apron_allowlist","");
+	
+	// consume the apron kit using c2t's script
+	// this will default to consuming food for our current mainstat
+	// https://github.com/C2Talon/c2t_apron
+	return c2t_apron();
 }
 
 boolean auto_haveSpringShoes()


### PR DESCRIPTION
# Description

Add apron kit to foods we consider eating. Will pull if none on hand.

Core of this implementation is C2T's script to actually consume the kit:
https://github.com/C2Talon/c2t_apron

Use any ingredients we have on hand that aren't still needed for quests or potentially harmful. Does not pull or otherwise acquire ingredients, only considers whats already on hand.

## How Has This Been Tested?

Ascended alt into a normal standard run. This account does not have the IOTY, so expect it to pull the kit
Ran consume command
Confirmed apron kit was pulled and consumed

![image](https://github.com/loathers/autoscend/assets/4781473/26d88b93-9898-4997-8f38-4d99bfb283dc)

ignore the mat.group lines, from debugging/understanding c2t's script

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
