### PR TITLE
Burn MP Better

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1969,6 +1969,7 @@ void auto_begin()
 	backupSetting("logPreferenceChangeFilter", "maximizerMRUList,testudinalTeachings,auto_maximize_current");
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
 	backupSetting("allowNonMoodBurning", true); // required to be true for burn cli cmd to work properly
+	backupSetting("lastChanceThreshold", 1); // burn command will always use last chance skill, if we have no active buffs
 
 	string charpane = visit_url("charpane.php");
 	if(contains_text(charpane, "<hr width=50%><table"))

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -424,7 +424,7 @@ void equipStatgainIncreasers(boolean[stat] increaseThisStat, boolean alwaysEquip
 	}
 	else if(alwaysEquip)
 	{
-		catch cli_execute("burn " + (targetedMP - my_maxmp()));
+		auto_burnMP(targetedMP - my_maxmp());
 		doEquips = true;
 	}
 	

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -952,7 +952,7 @@ boolean auto_pre_adventure()
 		if(wasted_mp > 0 && my_mp() > 400)
 		{
 			auto_log_info("Burning " + wasted_mp + " MP...");
-			cli_execute("burn " + wasted_mp);
+			auto_burnMP(wasted_mp);
 		}
 	}
 	borisWastedMP();

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1812,7 +1812,7 @@ boolean acquireMP(int goal, int meat_reserve, boolean useFreeRests)
 				}
 				if(my_mp() > 0)
 				{
-					catch cli_execute("burn " + min(excessMP,my_mp()));
+					auto_burnMP(min(excessMP,my_mp()));
 				}
 			}
 			use_skill(casts, $skill[Soul Food]);
@@ -1837,7 +1837,7 @@ boolean acquireMP(int goal, int meat_reserve, boolean useFreeRests)
 				}
 				if(my_mp() > 0)
 				{
-					catch cli_execute("burn " + min(excessMP,my_mp()));
+					auto_burnMP(min(excessMP,my_mp()));
 				}
 			}
 			use_skill(casts, $skill[Sip Some Sweat]);
@@ -2208,7 +2208,7 @@ boolean doFreeRest(){
 
 		if (mpToBurn > 0)
 		{
-			cli_execute("burn " + mpToBurn);
+			auto_burnMP(mpToBurn);
 		}
 
 		// resting and success check

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4470,9 +4470,6 @@ boolean auto_burnMP(int mpToBurn)
 	}
 	set_property("lastChanceBurn","cast # " + defaultSkill);
 
-	// want to use last chance burn always
-	set_property("lastChanceThreshold",1);
-
 	// record starting MP
 	int startingMP = my_mp();
 	cli_execute("burn " + mpToBurn);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4468,12 +4468,12 @@ boolean auto_burnMP(int mpToBurn)
 			break;
 		}
 	}
-	if(defaultSkill == $skill[none])
+
+	if(defaultSkill != $skill[none])
 	{
-		// don't have any avaiable default skill. Perhaps in an avatar path
-		return false;
+		// only set a default skill if we have one
+		set_property("lastChanceBurn","cast # " + defaultSkill);
 	}
-	set_property("lastChanceBurn","cast # " + defaultSkill);
 
 	// record starting MP
 	int startingMP = my_mp();

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4453,3 +4453,29 @@ item wrap_item(item it) // convert an item into another item, used for replicas 
 	}
 	return it;
 }
+
+boolean auto_burnMP(int mpToBurn)
+{
+	// burn command only extends existing buffs
+	// set default skill to cast so MP is burned if we don't have any active buffs
+	// only consider the default stating buffs for the 6 standard classes
+	skill defaultSkill;
+	foreach sk in $skills[Sauce Contemplation, Seal Clubbing Frenzy, Patience of the Tortoise, Manicotti Meditation, Disco Aerobics, Moxie of the Mariachi]
+	{
+		if(have_skill(sk))
+		{
+			defaultSkill = sk;
+			break;
+		}
+	}
+	set_property("lastChanceBurn","cast # " + defaultSkill);
+
+	// want to use last chance burn always
+	set_property("lastChanceThreshold",1);
+
+	// record starting MP
+	int startingMP = my_mp();
+	cli_execute("burn " + mpToBurn);
+	return startingMP != my_mp();
+}
+

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4459,7 +4459,7 @@ boolean auto_burnMP(int mpToBurn)
 	// burn command only extends existing buffs
 	// set default skill to cast so MP is burned if we don't have any active buffs
 	// only consider the default stating buffs for the 6 standard classes
-	skill defaultSkill;
+	skill defaultSkill = $skill[none];
 	foreach sk in $skills[Sauce Contemplation, Seal Clubbing Frenzy, Patience of the Tortoise, Manicotti Meditation, Disco Aerobics, Moxie of the Mariachi]
 	{
 		if(have_skill(sk))
@@ -4467,6 +4467,11 @@ boolean auto_burnMP(int mpToBurn)
 			defaultSkill = sk;
 			break;
 		}
+	}
+	if(defaultSkill == $skill[none])
+	{
+		// don't have any avaiable default skill. Perhaps in an avatar path
+		return false;
 	}
 	set_property("lastChanceBurn","cast # " + defaultSkill);
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1821,3 +1821,4 @@ boolean hasUsefulShirt();
 int meatReserve();
 boolean auto_wishForEffect(effect wish);
 item wrap_item(item it);
+boolean auto_burnMP(int mpToBurn);

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -236,7 +236,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 			int desiredMp = max(my_maxmp() - 999, 0);
 			int mpToBurn = max(my_mp() - desiredMp, 0);
 			if(mpToBurn > 0)
-				cli_execute("burn " + mpToBurn);
+				auto_burnMP(mpToBurn);
 		}
 
 		if(!eat(1, $item[magical sausage]))
@@ -253,7 +253,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	{
 		int mpToBurn = max(my_mp() - originalMp, 0);
 		if(mpToBurn > 0)
-			cli_execute("burn " + mpToBurn);
+			auto_burnMP(mpToBurn);
 		cli_execute("outfit checkpoint");
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -338,7 +338,8 @@ boolean auto_getCinch(int goal)
 	{
 		if(!doFreeRest())
 		{
-			abort("Failed to rest to charge cincho");
+			auto_log_debug("Failed to rest to charge cincho. Will try again later.");
+			return false;
 		}
 	}
 


### PR DESCRIPTION
# Description

1. (Primary) Removes abort in mr2023.ash when failing to restore cinch. Instead log that we will try again later and continue

2. (Secondary) Created auto_burnMP() to more reliably burn MP. Didn't know that burn only extends existing buffs. Function adds a default skill for the burn command to cast if there are no active buffs to extend

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
