### PR TITLE
reset default mana burn skill

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1970,6 +1970,7 @@ void auto_begin()
 	backupSetting("maximizerMRUSize", 0); // shuts the maximizer spam up!
 	backupSetting("allowNonMoodBurning", true); // required to be true for burn cli cmd to work properly
 	backupSetting("lastChanceThreshold", 1); // burn command will always use last chance skill, if we have no active buffs
+	backupSetting("lastChanceBurn",""); // clear default mana burn skill so mafia doesn't attempt to cast a skill we don't currently have
 
 	string charpane = visit_url("charpane.php");
 	if(contains_text(charpane, "<hr width=50%><table"))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4460,6 +4460,9 @@ boolean auto_burnMP(int mpToBurn)
 	// set default skill to cast so MP is burned if we don't have any active buffs
 	// only consider the default stating buffs for the 6 standard classes
 	skill defaultSkill = $skill[none];
+	// mafia will attempt to cast the last chance burn skill even if we no longer have it, like in avatar paths
+	// clear pref to avoid abbort due to not having the skill
+	set_property("lastChanceBurn","");
 	foreach sk in $skills[Sauce Contemplation, Seal Clubbing Frenzy, Patience of the Tortoise, Manicotti Meditation, Disco Aerobics, Moxie of the Mariachi]
 	{
 		if(have_skill(sk))

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4460,9 +4460,6 @@ boolean auto_burnMP(int mpToBurn)
 	// set default skill to cast so MP is burned if we don't have any active buffs
 	// only consider the default stating buffs for the 6 standard classes
 	skill defaultSkill = $skill[none];
-	// mafia will attempt to cast the last chance burn skill even if we no longer have it, like in avatar paths
-	// clear pref to avoid abbort due to not having the skill
-	set_property("lastChanceBurn","");
 	foreach sk in $skills[Sauce Contemplation, Seal Clubbing Frenzy, Patience of the Tortoise, Manicotti Meditation, Disco Aerobics, Moxie of the Mariachi]
 	{
 		if(have_skill(sk))


### PR DESCRIPTION
# Description

User in discord reported:
Could not find a known, usable skill of yours uniquely matching "29 Sauce Contemplation"
[ERROR] Error running auto_pre_adv.ash, setting auto_interrupt=true

Asked user to set lastChanceBurn to be blank and resolved issue. Must be mafia doesn't check if we have the default skill before trying to cast it

## How Has This Been Tested?

code validates. Pref change was tested by user manually and it solved their issue

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
