### PR TITLE
don't do pre adv when getting shadow waters buff

### DIFF
--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -680,17 +680,9 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 				return true;
 			}
 			// lodestene will be consumed for a free NC to get this buff
-			// visit url directly to not run pre adv script
-			switch(auto_availableBrickRift())
-			{
-			case $location[Shadow Rift (The Ancient Buried Pyramid)]:	visit_url("place.php?whichplace=pyramid&action=pyramid_shadowrift");	break;
-			case $location[Shadow Rift (The Hidden City)]:				visit_url("place.php?whichplace=hiddencity&action=hc_shadowrift");		break;
-			case $location[Shadow Rift (The Misspelled Cemetary)]:		visit_url("place.php?whichplace=cemetery&action=cem_shadowrift");		break;
-			}
-			if(have_effect($effect[Shadow Waters]) == startingShadwWatersAdvs)
-			{
-				abort("Failed to get Shadow Waters buff");
-			}
+		set_property("auto_disableAdventureHandling", true);
+		autoAdv(auto_availableBrickRift());
+		set_property("auto_disableAdventureHandling", false);
 		}
 		break;
 	case $effect[Shells of the Damned]:			useItem = $item[cyan seashell];					break;

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -680,7 +680,13 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 				return true;
 			}
 			// lodestene will be consumed for a free NC to get this buff
-			autoAdv(auto_availableBrickRift());
+			// visit url directly to not run pre adv script
+			switch(auto_availableBrickRift())
+			{
+			case $location[Shadow Rift (The Ancient Buried Pyramid)]:		visit_url("place.php?whichplace=pyramid&action=pyramid_shadowrift");	break;
+			case $location[Shadow Rift (The Hidden City)]:				visit_url("place.php?whichplace=hiddencity&action=hc_shadowrift");		break;
+			case $location[Shadow Rift (The Misspelled Cemetary)]:		visit_url("place.php?whichplace=cemetery&action=cem_shadowrift");		break;
+			}
 		}
 		break;
 	case $effect[Shells of the Damned]:			useItem = $item[cyan seashell];					break;

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -679,13 +679,18 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 			{
 				return true;
 			}
+			int startingShadwWatersAdvs = have_effect($effect[Shadow Waters]);
 			// lodestene will be consumed for a free NC to get this buff
 			// visit url directly to not run pre adv script
 			switch(auto_availableBrickRift())
 			{
-			case $location[Shadow Rift (The Ancient Buried Pyramid)]:		visit_url("place.php?whichplace=pyramid&action=pyramid_shadowrift");	break;
+			case $location[Shadow Rift (The Ancient Buried Pyramid)]:	visit_url("place.php?whichplace=pyramid&action=pyramid_shadowrift");	break;
 			case $location[Shadow Rift (The Hidden City)]:				visit_url("place.php?whichplace=hiddencity&action=hc_shadowrift");		break;
 			case $location[Shadow Rift (The Misspelled Cemetary)]:		visit_url("place.php?whichplace=cemetery&action=cem_shadowrift");		break;
+			}
+			if(have_effect($effect[Shadow Waters]) == startingShadwWatersAdvs)
+			{
+				abort("Failed to get Shadow Waters buff");
 			}
 		}
 		break;

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -679,7 +679,6 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 			{
 				return true;
 			}
-			int startingShadwWatersAdvs = have_effect($effect[Shadow Waters]);
 			// lodestene will be consumed for a free NC to get this buff
 			// visit url directly to not run pre adv script
 			switch(auto_availableBrickRift())


### PR DESCRIPTION
# Description

Reported in discord. Log analysis showed user didn't have enough elemental damage according to ghost check in pre adv to go to a shadow rift. This happened when we were trying to get the shadows water buff though... so there is no combat.

This change should make it so pre adv is not called, meaning no check for sufficient elemental damage.

## How Has This Been Tested?

CLI. Was able to get shadow waters buff while in aftercore with `buffMaintain($effect[shadow waters])`

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
