### PR TITLE
Allow transfunctioner to be worn in g-lover runs.

### DIFF
--- a/RELEASE/scripts/autoscend/paths/g_lover.ash
+++ b/RELEASE/scripts/autoscend/paths/g_lover.ash
@@ -55,7 +55,7 @@ boolean glover_usable(string it)
 	eXtreme scarf, snowboarder pants, eXtreme mittens, linoleum ore, chrome ore, asbestos ore,
 	loadstone, amulet of extreme plot significance, titanium assault umbrella, antique machete,
 	half-size scalpel, head mirror, wet stew, UV-resistant compass, Talisman o' Namsilat, Unstable Fulminate,
-	Orcish baseball cap, Orcish frat-paddle, filthy knitted dread sack, filthy corduroys,
+	Orcish baseball cap, Orcish frat-paddle, filthy knitted dread sack, filthy corduroys, continuum transfunctioner,
 	beer helmet, distressed denim pants, reinforced beaded headband, bullet-proof corduroys] contains checkItem)
 	{
 		// these are all used for quest furthering porpoises so they still "work" even though they don't contain G's


### PR DESCRIPTION
G-lover runs currently crash out when trying to get the 8BitColor property, as the auto equip functions don't allow the transfunctioner to be equipped to get the initial propery.  But also the transfunctioner is now allowed and required to get the digital key since this file was last looked at.   Simplest way to fix should be allow the transfunctioner to be worn.

Error was:
Stack trace:

  at EightBitRealmHandler (level_13.ash:97)
  at LX_getDigitalKey (level_13.ash:179)
  at LX_attemptPowerLevel (auto_powerlevel.ash:90)
  at process_tasks (autoscend.ash:1689)
  at doTasks (autoscend.ash:1921)
  at auto_begin (autoscend.ash:2036)
  at safe_preference_reset_wrapper (autoscend.ash:2066)
  at safe_preference_reset_wrapper (autoscend.ash:2073)
  at safe_preference_reset_wrapper (autoscend.ash:2073)


Fixes # (issue)

## How Has This Been Tested?

I haven't tested this in run, but when error occurred I manually equipped the transfunctioner and then autoascend continued correctly, and change is adding a single item to a list.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
