### PR TITLE
Bedtime reminder for unused August Scepter casts 

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1366,6 +1366,11 @@ boolean doBedtime()
 			auto_log_info("You have a tea tree to shake!", "blue");
 		}
 
+		if((item_amount($item[August Scepter]) > 0) && (get_property("_augSkillsCast").to_int() < 5))
+		{
+			auto_log_info("You still have " + (5 - get_property("_augSkillsCast").to_int()) + " August Scepter casts remaining! Perhaps consider casting Aug 13th/30th for more rollover adventures, and/or 7th for a buff for tomorrow?", "blue");
+		}
+
 		if (get_property("spadingData") != "")
 		{
 			cli_execute("spade autoconfirm");

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1366,7 +1366,7 @@ boolean doBedtime()
 			auto_log_info("You have a tea tree to shake!", "blue");
 		}
 
-		if((item_amount($item[August Scepter]) > 0) && (get_property("_augSkillsCast").to_int() < 5))
+		if (auto_haveAugustScepter() && get_property("_augSkillsCast").to_int() < 5)
 		{
 			auto_log_info("You still have " + (5 - get_property("_augSkillsCast").to_int()) + " August Scepter casts remaining! Perhaps consider casting Aug 13th/30th for more rollover adventures, and/or 7th for a buff for tomorrow?", "blue");
 		}


### PR DESCRIPTION
Not sure what the thoughts are toward the bedtime "resources are still available!" messages in this file; most are for stuff from back in 2015. But in that context, I've been running non-Standard runs and seeing reminders for Deck and Chateau use, I was considering the daily resources that are available that might be worth reminding users are available for manual intervention. 

A lot of these resources, even though they seem a bit wasted are also a bit trickier and maybe-not-advisable to tell a user to make use of (Carto mapping, making decisions about a random monster to reminisce about/fax, forcing NCs, clover uses), but I feel like August Scepter casts are a pretty fair one to remind users of?

# Description

Addition was made to auto_bedtime.ash to tell the user the amount of August Scepter casts remaining, and give a couple recommendations for how the user could manually use them.


## How Has This Been Tested?

Just a bedtime output--ran it on my account with August Scepter casts still available.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [(nothing to comment?)] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
