### PR TITLE
WereProf Advanced Research Fix

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -31,7 +31,7 @@ string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 
 	foreach str in split_string(get_property("wereProfessorAdvancedResearch").to_string(),",")
 	{
-		if(contains_text(str, enemy.id))
+		if(str == enemy.id)
 		{
 			return "";
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_wereprofessor.ash
@@ -29,10 +29,12 @@ string auto_combatWereProfessorStage4(int round, monster enemy, string text)
 		return "";
 	}
 
-	string advresearch = get_property("wereProfessorAdvancedResearch");
-	if(contains_text(advresearch, enemy.id))
+	foreach str in split_string(get_property("wereProfessorAdvancedResearch").to_string(),",")
 	{
-		return "";
+		if(contains_text(str, enemy.id))
+		{
+			return "";
+		}
 	}
 
 	if(is_professor() && wereprof_oculus() && !haveUsed(to_skill(7512)))


### PR DESCRIPTION
# Description

Bug found by Rinn on Discord. Would exit early out of trying Advanced Research if an enemy id matched an existing substring. This should now look at each individual id already researched


## How Has This Been Tested?

Untested after most recent commit

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
