### PR TITLE
Collect sweat-ade as fallback for designer sweatpants when PVPing

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -41,7 +41,7 @@ auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. S
 auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
 auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+auto_pvpEnable	boolean	Break the hippy stone to unlock PvP? This may also let autoscend collect low-effort PVP items.
 auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
 auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -52,7 +52,7 @@ any	39	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = d
 any	40	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
 any	41	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
 any	42	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	43	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP?
+any	43	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP? This may also let autoscend collect low-effort PVP items.
 any	44	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
 any	45	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
 any	46	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
@@ -69,4 +69,3 @@ post	6	auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this as
 pre	0	auto_getSteelOrgan_initialize	boolean	When we initialize an ascension this will be copied to auto_getSteelOrgan
 
 sharing	0	auto_disableExcavator	boolean	When set to true will disable automatically sending spading data via the Extractor script
-

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -404,9 +404,15 @@ void sweatpantsPreAdventure() {
 		}
 	}
 
-	// This is just opportunistic use of sweat. This skill should be used in auto_restore.ash.
-	if (sweat >= 95 && my_mp() < my_maxmp()) {
-		use_skill($skill[Sip Some Sweat]);
+	if (sweat >= 95) {
+		if(get_property("auto_pvpEnable").to_boolean() && spleen_left() >= 4 * (1 + item_amount($item[sweat-ade]))) {
+			// Our player participates in PVP, let's give them a low-effort spleen item to end the day with, if there's still room.
+			use_skill($skill[Make Sweat-Ade]);
+		}
+		else if(my_mp() < my_maxmp()) {
+			// This is just opportunistic use of sweat. This skill should be used in auto_restore.ash.
+			use_skill($skill[Sip Some Sweat]);
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

When designer sweatpants are full of sweat, add a fallback to make sweat-ade during the run, so that the player can optionally consume those at the end of the day when they have spleen capacity left. This only happens when:

- Sweat collected is at >95% AND
- liver is fully cleaned (or nothing drunk yet) AND
- Not in sensitive zones for sleaze/drunkenness AND
- autoscend is configured to break the hippy stone at the start of the run (auto_pvpEnable) AND
- there is enough spleen capacity remaining today for an additional sweat-ade

## How Has This Been Tested?

Completed a 2-day HC 11TIHU run with this, ending up with 3 sweat-ades on day 1, and 1 on day 2 (after the day 1 consumables were used)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
