### PR TITLE
Added handling of red blue green and yellow candle

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -845,6 +845,22 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 			}
 		}
 
+		if(auto_haveRoman() && auto_is_valid($skill[Blow the Green Candle\!]))
+		{
+			if(!inCombat)
+			{
+				autoEquip($item[Roman Candelabra]);
+				return "skill " + $skill[Blow the Green Candle\!];
+			}
+			else
+			{
+				if(canUse($skill[Blow the Green Candle\!]))
+				{
+					return "skill " + $skill[Blow the Green Candle\!];
+				}
+			}
+		}
+
 		foreach it in $items[green smoke bomb, tattered scrap of paper, GOTO]
 		{
 			if (canUse(it) && item_amount(it) > 0)

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -566,6 +566,7 @@ boolean auto_MayamClaimStinkBomb();
 boolean auto_MayamClaimBelt();
 boolean auto_MayamClaimWhatever();
 boolean auto_MayamClaimAll();
+boolean auto_haveRoman();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -173,6 +173,13 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		return useSkill($skill[Stuffed Mortar Shell]);
 	}
 
+	
+	//Roman Candelabra red candle
+	if(have_equipped($item[Roman Candelabra]) && have_effect($effect[Everything Looks Red]) == 0)
+	{
+		return useSkill($skill[Blow the Red Candle\!]);
+	}
+
 	//general killing code
 	switch(my_class())
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -175,7 +175,7 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 
 	
 	//Roman Candelabra red candle
-	if(have_equipped($item[Roman Candelabra]) && have_effect($effect[Everything Looks Red]) == 0)
+	if(have_equipped($item[Roman Candelabra]) && have_effect($effect[Everything Looks Red]) == 0 && !auto_haveDarts())
 	{
 		return useSkill($skill[Blow the Red Candle\!]);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -302,6 +302,10 @@ skill getSniffer(monster enemy)
 
 skill getStunner(monster enemy)
 {
+	if(canUse($skill[Blow the Blue Candle\!]) && have_effect($effect[Everything Looks Blue]) == 0)
+	{
+		return $skill[Blow the Blue Candle\!]; //20 Turns
+	}
 	// Class specific
 	switch(my_class())
 	{
@@ -803,6 +807,10 @@ string yellowRayCombatString(monster target, boolean inCombat, boolean noForceDr
 		if((item_amount($item[yellow rocket]) > 0) && auto_is_valid($item[yellow rocket]))
 		{
 			return "item " + $item[yellow rocket]; // 75 turns & 250 meat
+		}
+		if(inCombat ? have_skill($skill[Blow the Yellow Candle\!]) : auto_haveRoman() && auto_is_valid($skill[Blow the Yellow Candle\!]))
+		{
+			return "skill " + $skill[Blow the Yellow Candle\!]; //75 Turns
 		}
 		if(inCombat ? have_skill($skill[Unleash the Devil\'s Kiss]) : auto_hasRetrocape() && auto_is_valid($skill[Unleash the Devil\'s Kiss]))
 		{

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -349,3 +349,12 @@ boolean auto_MayamClaimAll()
 	auto_MayamClaimWhatever();
 	return true;
 }
+
+boolean auto_haveRoman()
+{
+	if(auto_is_valid($item[Roman Candelabra]) && possessEquipment($item[Roman Candelabra]))
+	{
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
# Description

- yellow and green are handled as standard  
yellow rays and free runs respectively
- blue is handled as a stunner when available
- red is used at stage 5 whenever available (after
Evert darts, didn't see any reason to save it)
- Not sure how to deal with purple

## How Has This Been Tested?
Ran it a couple days on my account, it uses the candles as needed. 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
