### PR TITLE
Add "gremlins" to JoAT LED candle types

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -730,6 +730,7 @@ void auto_handleJillOfAllTrades()
 		case "regen":
 		case "init":
 		case "gremlin":
+		case "gremlins":
 		case "yellowray":
 			cli_execute("jillcandle item");
 			break;


### PR DESCRIPTION
# Description

Fixes an abort when using the Jill-of-all-trades for the Yossarian quest.
Reported in Discord.

## How Has This Been Tested?

Hasn't. It's a single line change to a switch statement. I'm willing to take the chance.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
