### PR TITLE
Only visit the Cake-Shaped Arena with the Reagnimated Gnome if we don't have all the equipment yet.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -774,7 +774,17 @@ void preAdvUpdateFamiliar(location place)
 	if (my_familiar() == $familiar[Reagnimated Gnome])
 	{
 		// This arena visit to obtain gnome familiar equips is turn free and can be done once a day.
-		if (!get_property("_auto_gnomeArenaVisited").to_boolean())
+		boolean visitArena = false;
+		foreach it in $items[gnomish swimmer's ears, gnomish coal miner's lung, gnomish tennis elbow, gnomish housemaid's kgnee, gnomish athlete's foot]
+		{
+			if (available_amount(it) == 0)
+			{
+				visitArena = true;
+				break;
+			}
+		}
+		// only visit the cake-shaped arena if we need to pickup an equipment.
+		if (!get_property("_auto_gnomeArenaVisited").to_boolean() && visitArena)
 		{
 			visit_url("arena.php");
 			run_choice(-1);


### PR DESCRIPTION
# Description

Reported in discord.
If you own the Reagnimated Gnome (or I guess, are in Quantum Familiars) & get to day 6 the script would abort because you would have all of the Gnome's equips.

Do we even use anything other than the kgnee? Who knows? Not me that's for sure but at least we won't abort on day 6 any more.

## How Has This Been Tested?

Hasn't. I honestly don't have the time to waste getting a test account with the Gnome into day 6 of an Unrestricted run just to test this and neither should you.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
