### PR TITLE
No You, Robot Campground

### DIFF
--- a/RELEASE/scripts/autoscend/quests/optional.ash
+++ b/RELEASE/scripts/autoscend/quests/optional.ash
@@ -1109,7 +1109,7 @@ boolean LX_NemesisQuest()
 void houseUpgrade()
 {
 	//function for upgrading your dwelling.
-	if(isActuallyEd() || in_darkGyffte() || in_nuclear() || in_wereprof())
+	if(isActuallyEd() || in_darkGyffte() || in_nuclear() || in_wereprof() || in_robot())
 	{
 		return;		//paths where dwelling is locked
 	}


### PR DESCRIPTION
No campground access in You, Robot so this prevents repeated attempts to use housing items

# Description

Adds a check for being in You, Robot for houseUpgrade()

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
