### PR TITLE
fix missing else in L11 quest

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1659,8 +1659,8 @@ void hiddenCityChoiceHandler(int choice)
 			if (available_choice_options() contains 4)
 			{
 				run_choice(4); // get free meat via CCSC
-				run_choice(2); // get the stone triangle
 			}
+			run_choice(2); // get the stone triangle
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1644,6 +1644,7 @@ void hiddenCityChoiceHandler(int choice)
 	{
 		run_choice(1); // fight the spirit
 	}
+
 	else if(choice == 785) // Air Apparent (An Overgrown Shrine (Northeast))
 	{
 		
@@ -1651,14 +1652,19 @@ void hiddenCityChoiceHandler(int choice)
 		{
 			run_choice(1); // unlock the Hidden Office Building
 		}
+
+		// either use CCSC + unlock or just unlock based on user sphere presence
 		else if(item_amount($item[crackling stone sphere]) > 0)
 		{
 			if (available_choice_options() contains 4)
 			{
-				run_choice(4); // get free meat
+				run_choice(4); // get free meat via CCSC
 				run_choice(2); // get the stone triangle
 			}
-			run_choice(2); // get the stone triangle
+			else 
+			{
+				run_choice(2); // get the stone triangle
+			}
 		}
 		else
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1661,10 +1661,6 @@ void hiddenCityChoiceHandler(int choice)
 				run_choice(4); // get free meat via CCSC
 				run_choice(2); // get the stone triangle
 			}
-			else 
-			{
-				run_choice(2); // get the stone triangle
-			}
 		}
 		else
 		{


### PR DESCRIPTION
# Description
there was a missing else in L11 and I added it. no logged issue on this i think, replying to an issue reported on discord

## How Has This Been Tested?

have not tested sorry doggs

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
