### PR TITLE
feat: tool gremlins allow magnet on any non-crit hit

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -52,7 +52,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		return "attack with weapon";
 	}
 
-	if(contains_text(text, "It whips out a hammer") || contains_text(text, "He whips out a crescent") || contains_text(text, "It whips out a pair") || contains_text(text, "It whips out a screwdriver"))
+	if(contains_text(text, "<!--moly1-->") || contains_text(text, "<!--moly2-->") || contains_text(text, "<!--moly3-->") || contains_text(text, "<!--moly4-->"))
 	{
 		return useItem($item[Molybdenum Magnet]);
 	}


### PR DESCRIPTION
# Description

After a recent KoL update, the tool gremlins allow using the magnet against any non-crit hit, which is helpfully made clear by a comment in the HTML.

## How Has This Been Tested?

A run completed the gremlin quest successfully.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
