### PR TITLE
Buy antique accordion from Cosmic Ray in KoE

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -886,6 +886,12 @@ void initializeDay(int day)
 					{
 						auto_buyUpTo(1, $item[Toy Accordion]);
 					}
+					
+					if((in_koe()) && (item_amount($item[Antique Accordion]) == 0) && (koe_rmi_count() >= 10))
+					{
+						koe_acquire_rmi(10);
+						buy($coinmaster[Cosmic Ray\'s Bazaar], 1, $item[Antique Accordion]);
+					}
 				}
 				acquireTotem();
 				if(!possessEquipment($item[Saucepan]))


### PR DESCRIPTION
# Description

Autoscend was getting stuck trying to cast ode to booze as a seal clubber, but it didn't have an accordion. Not sure why, it hadn't previously gotten stuck. Autoscend will now buy an antique accordion if you have enough meat or isotopes. 

## How Has This Been Tested?

Untested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
