### PR TITLE
Rare Meat Isotope count now accounts for discount

### DIFF
--- a/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
+++ b/RELEASE/scripts/autoscend/paths/kingdom_of_exploathing.ash
@@ -21,7 +21,7 @@ boolean koe_initializeSettings()
 int koe_rmi_count()
 {
 	//counts how much [rare meat isotopes] you effectively have. since you can convert meat to rmi with no limit at a 1000 to 1 ratio
-	return item_amount($item[rare Meat Isotope]) + (my_meat()/1000);
+	return item_amount($item[rare Meat Isotope]) + (my_meat()/(1000 * npcStoreDiscountMulti()));
 }
 
 boolean koe_acquire_rmi(int target)


### PR DESCRIPTION
# Description

Autoscend was previously counting your effective amount of rare meat isotopes by dividing your meat total by 1,000, without accounting for NPC shop discounts. Now it will.

Sidenote: the method that calculates the discount checks for having Travoltan trousers, but as far as I can tell nothing equips them? Does mafia automatically equip them and designer sweatpants when possible?

