### PR TITLE
use Implode Universe / Silent Treatment against difficult enemies

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -79,6 +79,10 @@ string auto_combatHandler(int round, monster enemy, string text)
 {
 	if(round > 25 && !($monsters[The Man, The Big Wisniewski] contains enemy))	//war bosses can go to round 50
 	{
+		if (canUse($skill[Implode Universe]))
+		{
+			return useSkill($skill[Implode Universe], true);
+		}
 		abort("Some sort of problem occurred, it is past round 25 but we are still in non-gremlin combat...");
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -202,8 +202,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 	{
 		doWeaksauce = true;
 	}
-	// if(enemy == $monster[invader bullet]) // TODO: on version bump
-	if(enemy.to_string().to_lower_case() == "invader bullet")
+	if(enemy == $monster[invader bullet])
 	{
 		doWeaksauce = false;
 	}
@@ -218,8 +217,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		enemy_la = 151;
 	}
 
-	// if(enemy == $monster[invader bullet]) // TODO: on version bump
-	if(enemy.to_string().to_lower_case() == "invader bullet")
+	if(enemy == $monster[invader bullet])
 	{
 		enemy_la = 151;
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_disguises_delimit.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_disguises_delimit.ash
@@ -84,12 +84,20 @@ string auto_combatDisguisesStage5(int round, monster enemy, string text)
 			{
 				return useSkill($skill[Saucestorm], false);
 			}
+			if (canUse($skill[Implode Universe]))
+			{
+				return useSkill($skill[Implode Universe], true);
+			}
 			//TODO check if our physical attack can deal elemental damage.
-			else abort("Not sure how to handle a physically resistent enemy wearing a welding mask.");
+			abort("Not sure how to handle a physically resistent enemy wearing a welding mask.");
 		}
 		if(canSurvive(1.5) && round < 10)
 		{
 			return "attack with weapon";
+		}
+		if (canUse($skill[Implode Universe]))
+		{
+			return useSkill($skill[Implode Universe], true);
 		}
 		abort("Not sure how to handle welding mask.");
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_fall_of_the_dinosaurs.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_fall_of_the_dinosaurs.ash
@@ -112,7 +112,8 @@ string auto_combatFallOfTheDinosaursStage5(int round, monster enemy, string text
 	}
 	if(dino == "ghostasaurus")	// physically immune, ml-scaling elemental resistance
 	{
-		if (monster_level_adjustment() >= 75 && canUse($skill[Silent Treatment]))
+		int dino_difficulty = enemy.attributes.contains_text("Scale:") ? 0 : enemy.base_attack / 1.8;
+		if (dino_difficulty >= 75 && canUse($skill[Silent Treatment]))
 		{
 			return useSkill($skill[Silent Treatment], true);
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_fall_of_the_dinosaurs.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_fall_of_the_dinosaurs.ash
@@ -64,11 +64,19 @@ string auto_combatFallOfTheDinosaursStage5(int round, monster enemy, string text
 		// reflects damage from spells back to player. 
 		if(enemy.physical_resistance >= 80)
 		{
+			if (canUse($skill[Implode Universe]))
+			{
+				return useSkill($skill[Implode Universe], true);
+			}
 			abort("Not sure how to handle a physically resistent enemy eaten by a glass-shelled archelon."); // TODO - work something out here?
 		}
 		if(canSurvive(1.5) && round < 25)
 		{
 			return "attack with weapon";
+		}
+		if (canUse($skill[Implode Universe]))
+		{
+			return useSkill($skill[Implode Universe], true);
 		}
 		abort("Not sure how to handle monster eaten by a glass-shelled archelon.");
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_fall_of_the_dinosaurs.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_fall_of_the_dinosaurs.ash
@@ -62,11 +62,15 @@ string auto_combatFallOfTheDinosaursStage5(int round, monster enemy, string text
 	if(dino == "archelon")
 	{
 		// reflects damage from spells back to player. 
-		if(enemy.physical_resistance >= 80)
+		if(enemy.physical_resistance >= 80 && !haveUsed($skill[Silent Treatment]))
 		{
 			if (canUse($skill[Implode Universe]))
 			{
 				return useSkill($skill[Implode Universe], true);
+			}
+			if (canUse($skill[Silent Treatment]))
+			{
+				return useSkill($skill[Silent Treatment], true);
 			}
 			abort("Not sure how to handle a physically resistent enemy eaten by a glass-shelled archelon."); // TODO - work something out here?
 		}
@@ -108,6 +112,10 @@ string auto_combatFallOfTheDinosaursStage5(int round, monster enemy, string text
 	}
 	if(dino == "ghostasaurus")	// physically immune, ml-scaling elemental resistance
 	{
+		if (monster_level_adjustment() >= 75 && canUse($skill[Silent Treatment]))
+		{
+			return useSkill($skill[Silent Treatment], true);
+		}
 		if(canUse($skill[Saucestorm], false))
 		{
 			return useSkill($skill[Saucestorm], false);


### PR DESCRIPTION
# Description

Fall of the Dinosaurs / Disguises Delimit struggles with doing the Shadow Rifts. Add some more options for this.

Implode Universe is an auto kill. It fails on some special monsters, which is the reason I mark it as used. I don't know if any exist that can be eaten by dinos and have over 80% physical resistance, but some may be added in the future.

Silent Treatment removes physical resistance from shadow trees and elemental resistance from ghostasaurus. This enables killing straightforwardly.

Also try using Implode Universe when past round 25 instead of aborting. I've hit this with a spikolodon hermetic seal; there are probably other cases.

## How Has This Been Tested?

Ran Fall of the Dinosaurs a bunch.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
