### PR TITLE
Support Trendy

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3030,6 +3030,10 @@ boolean auto_is_valid(item it)
 	{
 		return iluh_foodConsumable(it.to_string());
 	}
+	if(my_path() == $path[Trendy])
+	{
+		return is_trendy(it);
+	}
 	
 	return is_unrestricted(it);
 }
@@ -3040,11 +3044,17 @@ boolean auto_is_valid(familiar fam)
 	{
 		return to_familiar(get_property("auto_100familiar")) == fam;
 	}
+	if(my_path() == $path[Trendy])
+	{
+		return is_trendy(fam);
+	}
 	return bhy_usable(fam.to_string()) && glover_usable(fam.to_string()) && zombieSlayer_usable(fam) && wereprof_usable(fam.to_string()) && iluh_famAllowed(fam.to_string()) && is_unrestricted(fam);
 }
 
 boolean auto_is_valid(skill sk)
 {
+	// trendy restricts which skills are valid
+	if(my_path() == $path[Trendy]) return is_trendy(sk);
 	// Hack for Legacy of Loathing as is_unrestricted returns false for Source Terminal skills
 	if (in_lol() && $skills[Extract, Turbo, Digitize, Duplicate, Portscan, Compress] contains sk) return true;
 	// No skills for the Professor except Advanced Research in WereProf


### PR DESCRIPTION
# Description

Discord user had error where they were adventuring in 8-bit realm forever. Turns out we were trying to place a sausage goblin there to burn delay. Kramco isn't valid anymore in trendy

## How Has This Been Tested?

Validates

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
