### PR TITLE
KoE: Prevent getting stuck in NC loop in castle

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -290,6 +290,10 @@ void castleTopFloorChoiceHandler(int choice)
 		{
 			run_choice(2); // if quest not done and have the record, complete the quest
 		}
+		else if(in_koe() && item_amount($item[Model airship]) == 0)
+		{
+			run_choice(1); // if we're in koe we only want to go to Copper Feel if we can complete the quest, so fight a goth giant otherwise
+		}
 		else
 		{
 			run_choice(4); // moves to Copper Feel (#677) in all other scenarios


### PR DESCRIPTION
# Description

It was possible to get stuck in a loop of NCs in the Castle in Kingdom of Exploathing. This fixes it by choosing to fight a goth giant instead of Copper Feel if you're in KoE and don't have the airship to immediately complete the quest.
