### PR TITLE
feat: better calcs for whether we can survive shoot ghost

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -102,8 +102,8 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		int shots_takens = usedCount($skill[Shoot Ghost]);
 		if(canUse($skill[Shoot Ghost], false) && shots_takens < 3)
 		{
-			float survive_needed = 3.05 - shots_takens.to_float();
-			if(canSurvive(survive_needed))
+			int shotsLeft = 3 - shots_takens;
+			if(canSurviveShootGhost(enemy, shotsLeft))
 			{
 				markAsUsed($skill[Shoot Ghost]);		//needs to be manually done for skills with a use limit that is not 1
 				return useSkill($skill[Shoot Ghost], false);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -50,6 +50,7 @@ float turns_to_kill(float dmg);
 boolean combat_status_check(string mark);
 void combat_status_add(string mark);
 boolean wantToForceDrop(monster enemy);
+boolean canSurviveShootGhost(monster enemy, int shots);
 
 #####################################################
 //defined in /autoscend/combat/auto_combat_awol.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -1009,3 +1009,51 @@ boolean wantToForceDrop(monster enemy)
 	return forceDrop;
 }
 
+boolean canSurviveShootGhost(monster enemy, int shots) {
+	int damage;
+	switch(enemy)
+	{
+		case $monster[the ghost of Oily McBindle]:
+			damage = my_maxhp() * 0.4 * elemental_resistance($element[sleaze]) / 100;
+			break;
+		case $monster[boneless blobghost]:
+			damage = my_maxhp() * 0.45 * elemental_resistance($element[spooky]) / 100;
+			break;
+		case $monster[the ghost of Monsieur Baguelle]:
+			damage = my_maxhp() * 0.5 * elemental_resistance($element[hot]) / 100;
+			break;
+		case $monster[The Headless Horseman]:
+			damage = my_maxhp() * 0.55 * elemental_resistance($element[spooky]) / 100;
+			break;
+		case $monster[The Icewoman]:
+			damage = my_maxhp() * 0.6 * elemental_resistance($element[cold]) / 100;
+			break;
+		case $monster[The ghost of Ebenoozer Screege]:
+			damage = my_maxhp() * 0.65 * elemental_resistance($element[spooky]) / 100;
+			break;
+		case $monster[The ghost of Lord Montague Spookyraven]:
+			damage = my_maxhp() * 0.7 * elemental_resistance($element[stench]) / 100;
+			break;
+		case $monster[The ghost of Vanillica "Trashblossom" Gorton]:
+			damage = my_maxhp() * 0.75 * elemental_resistance($element[stench]) / 100;
+			break;
+		case $monster[The ghost of Sam McGee]:
+			damage = my_maxhp() * 0.8 * elemental_resistance($element[hot]) / 100;
+			break;
+		case $monster[The ghost of Richard Cockingham]:
+			damage = my_maxhp() * 0.85 * elemental_resistance($element[spooky]) / 100;
+			break;
+		case $monster[The ghost of Waldo the Carpathian]:
+			damage = my_maxhp() * 0.9 * elemental_resistance($element[hot]) / 100;
+			break;
+		case $monster[Emily Koops, a spooky lime]:
+			damage = my_maxhp() * 0.95 * elemental_resistance($element[spooky]) / 100;
+			break;
+		case $monster[The ghost of Jim Unfortunato]:
+			damage = my_maxhp() * elemental_resistance($element[sleaze]) / 100;
+			break;
+		default:
+			damage = my_maxhp() * 0.3;
+	}
+	return my_hp() > damage * shots;
+}


### PR DESCRIPTION
# Description

Protonic ghosts do damage based on max HP. If we are an muscle class with high max HP and low elemental resistance, the previous calculation lead to unexpected death.

## How Has This Been Tested?

Ran with it, successfully skipped and killed ghosts as expected.

Might be a bit cautious but I think it's better than dying.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
