### PR TITLE
More meat autoselling, esp spring shoes and secret door drops

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1545,7 +1545,7 @@ boolean autosellCrap()
 		return false;
 	}
 
-	foreach it in $items[Anticheese, Awful Poetry Journal, Beach Glass Bead, Beer Bomb, Clay Peace-Sign Bead, Decorative Fountain, Dense Meat Stack, Empty Cloaca-Cola Bottle, Enchanted Barbell, Fancy Bath Salts, Frigid Ninja Stars, Feng Shui For Big Dumb Idiots, Giant Moxie Weed, Half of a Gold Tooth, Headless Sparrow, Imp Ale, Keel-Haulin\' Knife, Kokomo Resort Pass, Leftovers Of Indeterminate Origin, Mad Train Wine, Mangled Squirrel, Margarita, Meat Paste, Mineapple, Moxie Weed, Patchouli Incense Stick, Phat Turquoise Bead, Photoprotoneutron Torpedo, Plot Hole, Procrastination Potion, Rat Carcass, Smelted Roe, Spicy Jumping Bean Burrito, Spicy Bean Burrito, Strongness Elixir, Sunken Chest, Tambourine Bells, Tequila Sunrise, Uncle Jick\'s Brownie Mix, Windchimes]
+	foreach it in $items[Anticheese, Awful Poetry Journal, Azurite, Beach Glass Bead, Beer Bomb, Bit-o-Cactus, Clay Peace-Sign Bead, Cocoa Eggshell Fragment, Decorative Fountain, Dense Meat Stack, Empty Cloaca-Cola Bottle, Enchanted Barbell, Eye Agate, Fancy Bath Salts, Frigid Ninja Stars, Feng Shui For Big Dumb Idiots, Giant Moxie Weed, Half of a Gold Tooth, Headless Sparrow, Imp Ale, Keel-Haulin\' Knife, Kokomo Resort Pass, Lapis Lazuli, Leftovers Of Indeterminate Origin, Mad Train Wine, Mangled Squirrel, Margarita, Meat Paste, Mineapple, Moxie Weed, Patchouli Incense Stick, Phat Turquoise Bead, Photoprotoneutron Torpedo, Plot Hole, Procrastination Potion, Rat Carcass, Sea Honeydew, Sea Lychee, Sea Tangelo, Smelted Roe, Spicy Jumping Bean Burrito, Spicy Bean Burrito, Strongness Elixir, Sunken Chest, Tambourine Bells, Tequila Sunrise, Uncle Jick\'s Brownie Mix, Windchimes]
 	{
 		if(item_amount(it) > 0)
 		{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -797,6 +797,10 @@ void finalizeMaximize(boolean speculative)
 		{
 			addBonusToMaximize($item[spring shoes], 200);
 		}
+		else if(my_meat() < meatReserve()) // those fruit drops can autosell for a lot
+		{
+			addBonusToMaximize($item[spring shoes], 200);
+		}
 		else if(my_hp() < 0.5*my_maxhp() && my_hp() > 0)
 		{
 			addBonusToMaximize($item[spring shoes], 200); // bonus to heal in wereprof as the werewolf after transition from Professor

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -916,11 +916,16 @@ boolean auto_post_adventure()
 		// items which give stats
 		buffMaintain($effect[Scorched Earth]);
 		buffMaintain($effect[Wisdom of Others]);
-		foreach it in $items[azurite, eye agate, lapis lazuli]
+		// Only use these if we've got plenty of meat and aren't max level
+		// Otherwise we'll autosell them
+		if(my_meat() > meatReserve()+1000 && my_level()<13)
 		{
-			if(item_amount(it) > 0 && auto_is_valid(it))
+			foreach it in $items[azurite, eye agate, lapis lazuli]
 			{
-				use(it, item_amount(it));
+				if(item_amount(it) > 0 && auto_is_valid(it))
+				{
+					use(it, item_amount(it));
+				}
 			}
 		}
 		


### PR DESCRIPTION
Some paths still take a bit of time to get meat together, especially those that have no trainset and need to buy torso.

This adds using the spring shoes and secret door detection high autosell items as a meat source.

# Description

Some paths still take a bit of time to get meat together, especially those that have no trainset and need to buy torso.

This adds using the spring shoes and secret door detection high autosell items as a meat source.

Additionally, if we're broke (meat<reserve) then prefer the spring shoes until we're not any more.

## How Has This Been Tested?

Invoked altered functions with gCLI. 

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
