### PR TITLE
User prop to abort when no weapon equipped

### DIFF
--- a/BUILD/settings_extra/any.dat
+++ b/BUILD/settings_extra/any.dat
@@ -4,3 +4,4 @@ auto_clanstuff	string	What was the last day we did 'end of day' clan stuff.
 auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (default 2500)
 _auto_ignoreRestoreFailureToday	boolean	if true we will for today only ignore failure to restore MP or HP and just continue playing
 auto_aosol_dontUnCurse	boolean	Avatar of Shadows Over Loathing: if true will keep all cursed items.
+auto_debug_maximizer	boolean	Help debug maximizer issue where it is not equipping a weapon

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -13,6 +13,7 @@ any	2	auto_clanstuff	string	What was the last day we did 'end of day' clan stuff
 any	3	auto_maxCandyPrice	integer	Max allowable price per candy for Rethinking Candy (default 2500)
 any	4	_auto_ignoreRestoreFailureToday	boolean	if true we will for today only ignore failure to restore MP or HP and just continue playing
 any	5	auto_aosol_dontUnCurse	boolean	Avatar of Shadows Over Loathing: if true will keep all cursed items.
+any	6	auto_debug_maximizer	boolean	Help debug maximizer issue where it is not equipping a weapon
 
 post	0	auto_chasmBusted	boolean	Has the orc chasm bridge been 'trolled yet? Ed only.
 post	1	auto_day1_dna	string	'finished' if we have hybridized ourselves at the start of Ascension.

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -998,6 +998,10 @@ void equipMaximizedGear()
 			addToMaximize("2 dump"); // maximizer will dump a bunch of stuff to the session log with this
 			maximize(get_property("auto_maximize_current"), 2500, 0, false);
 			removeFromMaximize("2 dump");
+			if(get_property("auto_debug_maximizer").to_boolean())
+			{
+				abort("NO WEAPON WAS EQUIPPED BY THE MAXIMIZER. REPORT THIS IN DISCORD AND INCLUDE YOUR SESSION LOG! YOU CAN RE-RUN AUTOSCEND AND IT SHOULD RUN OK (possibly).");
+			}
 			if (equipped_item($slot[weapon]) == $item[none]) {
 				// workaround. equip a weapon & re-running maximizer appears to fix the issue.
 				equip(equippableWeapon);


### PR DESCRIPTION
# Description

Supports
https://kolmafia.us/threads/maximizer-didnt-equip-a-weapon.29577/page-4#post-175257

Adds prop to let user abort when getting maximizer bug. Prop by default doesn't exist, meaning false. 

Can set prop to true via extra settings in the relay browser or `ash set_property("auto_debug_maximizer", true);`

## How Has This Been Tested?

Validates

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
