### PR TITLE
Add Meat Provider

### DIFF
--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -802,6 +802,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		{
 			useSkill = $skill[Tenacity of the Snapper];
 		}																						break;
+	case $effect[The Grass... Is Blue...]:		useItem = $item[Blue Grass];					break;
 	case $effect[There is a Spoon]:				useItem = $item[Dented Spoon];					break;
 	case $effect[They\'ve Got Fleas]:			useItem = $item[Out-of-work circus flea];		break;
 	case $effect[This is Where You\'re a Viking]:useItem = $item[VYKEA woadpaint];				break;

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -716,7 +716,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		useSkill = $skill[Snarl of the Timberwolf];
 		break;
 	case $effect[Snow Shoes]:					useItem = $item[Snow Cleats];					break;
-	case $effect[So You Can Work More...];		useItem = $item[Baggie of powdered sugar];		break;
+	case $effect[So You Can Work More...]:		useItem = $item[Baggie of powdered sugar];		break;
 	case $effect[Soles of Glass]:
 		if(auto_have_familiar($familiar[Grim Brother]))
 		{

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -858,6 +858,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Wisdom of Thoth]:				useSkill = $skill[Wisdom of Thoth];				break;
 	case $effect[Wit Tea]:						useItem = $item[cuppa Wit tea];					break;
 	case $effect[Woad Warrior]:					useItem = $item[Pygmy Pygment];					break;
+	case $effect[Worth Your Salt]:				useItem = $item[Salt wages];					break;
 	case $effect[Wry Smile]:					useSkill = $skill[Wry Smile];					break;
 	case $effect[Yoloswagyoloswag]:				useItem = $item[Yolo&trade; Chocolates];		break;
 	case $effect[You Read the Manual]:			useItem = $item[O\'Rly Manual];					break;

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -716,6 +716,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		useSkill = $skill[Snarl of the Timberwolf];
 		break;
 	case $effect[Snow Shoes]:					useItem = $item[Snow Cleats];					break;
+	case $effect[So You Can Work More...];		useItem = $item[Baggie of powdered sugar];		break;
 	case $effect[Soles of Glass]:
 		if(auto_have_familiar($familiar[Grim Brother]))
 		{

--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -802,7 +802,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		{
 			useSkill = $skill[Tenacity of the Snapper];
 		}																						break;
-	case $effect[The Grass... Is Blue...]:		useItem = $item[Blue Grass];					break;
+	case $effect[The Grass... \ Is Blue...]:		useItem = $item[Blue Grass];					break;
 	case $effect[There is a Spoon]:				useItem = $item[Dented Spoon];					break;
 	case $effect[They\'ve Got Fleas]:			useItem = $item[Out-of-work circus flea];		break;
 	case $effect[This is Where You\'re a Viking]:useItem = $item[VYKEA woadpaint];				break;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -262,7 +262,7 @@ boolean auto_pre_adventure()
 	}
 	if(place == $location[The Fungus Plains])
 	{
-		buffMaintain($effect[Polka of Plenty], 30, 1, 1);
+		provideMeat(450, $location[The Fungus Plains], true);
 		addToMaximize("200meat drop 550max");
 	}
 	if(place == $location[Megalo-City])

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1451,10 +1451,14 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 				return result();
 		if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])) & auto_is_valid($effect[Meet the Meat]))
 		{
-			zataraSeaside("meat"); //100% meat, 50% gear drops
+			if(!speculative)
+			{
+				zataraSeaside("meat");
+			}
+			handleEffect($effect[Meat the meat]); //100% meat, 50% gear drops
+			if(pass())
+				return result();			
 		}
-		if(pass())
-			return result();
 		if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
 		{
 			if(is_professor())
@@ -1468,7 +1472,13 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			{
 				outfit("Frat Warrior Fatigues");
 			}
-			cli_execute("concert 2"); //40% meat
+			if(!speculative)
+			{
+				cli_execute("concert 2"); //40% meat
+			}
+			handleEffect($effect[Winklered]); //40% meat
+			if(pass())
+				return result();
 		}
 		if(pass())
 			return result();
@@ -1493,14 +1503,14 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			{
 				if(have_effect(eff) == 0)
 				{
-					auto_wishForEffect(eff);
+					if(!speculative)
+						auto_wishForEffect(eff);
+					handleEffect(eff);
 					if(pass())
 						return result();
 				}
 			}
 		}
-		if(pass())
-			return result();
 		delta = simValue("Meat Drop") - numeric_modifier("Meat Drop");
 		auto_log_debug("With limited buffs we can get to " + result());
 		if(pass())

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1363,6 +1363,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		Patent Avarice, //50% meat
 		Earning Interest, //50% meat
 		Bet Your Autumn Dollar, //50% meat
+		The Grass... Is Blue..., //40% meat, 20% item
 		Greedy Resolve, //30% meat
 		Human-Fish Hybrid, //10 fam
 		Human-Humanoid Hybrid, //20% meat, 10% all stats

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1494,7 +1494,6 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 				Let's Go Shopping!,  //150% meat, 75% item, -300% myst
 				Always Be Collecting, //100% meat, 50% item
 				Incredibly Well Lit, //100% meat, 50% item
-				Friendly Chops, //100% meat, +5 Sleaze Res
 				A View to Some Meat, //100% meat
 				Cravin' for a Ravin', //100% meat
 				Low on the Hog, //100% meat

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1257,7 +1257,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			return result();
 	}
 	//see how much familiar will help
-	if(doEverything && pathHasFamiliar() && pathAllowsChangingFamiliar())
+	if(doEverything && canChangeFamiliar())
 	{
 		if(!speculative)
 		{
@@ -1298,30 +1298,16 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		}
 		return false;
 	}
-	if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
-	{
-		if(is_professor())
-		{
-			//Need to manually equip because professor
-			if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
-			if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
-			if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
-		}
-		else
-		{
-			outfit("Frat Warrior Fatigues");
-		}
-		cli_execute("concert 2");
-	}
-	handleBjornify($familiar[Hobo Monkey]);
 	// unlimited skills
 	if(tryEffects($effects[
-		Polka of Plenty,
-		Disco Leer
+		Polka of Plenty, //50% meat
+		Disco Leer //10% meat
 	]))
-		return result();
+		if(pass())
+			return result();
 	if(canAsdonBuff($effect[Driving Observantly]))
 	{
+		//50% meat, 50% item, 50% booze drops
 		if(!speculative)
 			asdonBuff($effect[Driving Observantly]);
 		handleEffect($effect[Driving Observantly]);
@@ -1330,22 +1316,28 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		return result();
 	if(bat_formWolf(speculative))
 	{
+		//150% meat, 150% muscle
 		handleEffect($effect[Wolf Form]);
 	}
 	if(pass())
 		return result();
 	if(auto_birdModifier("Meat Drop") > 0)
 	{
+		//Can be 20/40/60/80/100% meat drop
 		if(tryEffects($effects[Blessing of the Bird]))
-			return result();
+			if(pass())
+				return result();
 	}
 	if(auto_favoriteBirdModifier("Meat Drop") > 0)
 	{
+		//Can be 20/40/60/80/100% meat drop
 		if(tryEffects($effects[Blessing of Your Favorite Bird]))
-			return result();
+			if(pass())
+				return result();
 	}
 	if(isActuallyEd())
 	{
+		//50% meat drop
 		if(!have_skill($skill[Gift of the Maid]) && ($servant[Maid].experience >= 441))
 		{
 			visit_url("charsheet.php");
@@ -1355,81 +1347,103 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			}
 		}
 		if(tryEffects($effects[
-		Purr of the Feline
+		Purr of the Feline //makes the maid 5 levels higher
 		]))
-		return result();
+		if(pass())
+			return result();
 	}
-	songboomSetting("meat");
+	songboomSetting("meat"); //30% meat
 	// items
 	if(tryEffects($effects[
-		Greedy Resolve,
-		Kindly Resolve,
-		Heightened Senses,
-		Big Meat Big Prizes,
-		Human-Machine Hybrid,
-		Human-Constellation Hybrid,
-		Human-Humanoid Hybrid,
-		Human-Fish Hybrid,
-		Cranberry Cordiality,
-		Patent Avarice,
-		Car-Charged,
-		Heart of Pink,
-		Sweet Heart,
-		Earning Interest,
-		Bet Your Autumn Dollar,
-		Flapper Dancin\',
-		shadow waters
+		Car-Charged, //100% meat, 100% item, 5-10MP, 50% init, 50% spell dmg, +3 stats per fight
+		Flapper Dancin\', //100% meat
+		Heightened Senses, //50% meat, 25% item drop
+		Big Meat Big Prizes, //50% meat
+		Human-Constellation Hybrid, //50% meat
+		Patent Avarice, //50% meat
+		Earning Interest, //50% meat
+		Bet Your Autumn Dollar, //50% meat
+		Greedy Resolve, //30% meat
+		Human-Fish Hybrid, //10 fam
+		Human-Humanoid Hybrid, //20% meat, 10% all stats
+		Heart of Pink, //20% meat, +3 all stats
+		Kindly Resolve, //5 fam weight
+		Human-Machine Hybrid, //5 fam weight, DA +50, DR 5
+		Sweet Heart, // Muscle +X, +2X% meat
+		Cranberry Cordiality, //10% meat
 	]))
-		return result();
-	
-	if(!in_wereprof())
-	{
-		//wereprof doesn't like +ML effects outside of Werewolf
-		if(tryEffects($effects[Frosty]))
-			return result();
-	}
-	if(item_amount($item[body spradium]) > 0 && !in_tcrs() && have_effect($effect[Boxing Day Glow]) == 0)
-	{
-		autoChew(1, $item[body spradium]);
 		if(pass())
 			return result();
-	}
-	if(auto_sourceTerminalEnhanceLeft() > 0 && have_effect($effect[meat.enh]) == 0 && auto_is_valid($effect[meat.enh]))
-	{
-		if(!speculative)
-			auto_sourceTerminalEnhance("meat");
-		handleEffect($effect[meat.enh]);
-		if(pass())
-			return result();
-	}
+
 	if(have_effect($effect[Synthesis: Greed]) == 0)
 	{
-		rethinkingCandy($effect[Synthesis: Greed]);
+		rethinkingCandy($effect[Synthesis: Greed]); //300% meat
 		if(pass())
 			return result();
 	}
 	if(available_amount($item[Li\'l Pirate Costume]) > 0 && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (!in_heavyrains()))
 	{
 		use_familiar($familiar[Trick-or-Treating Tot]);
-		autoEquip($item[Li\'l Pirate Costume]);
+		autoEquip($item[Li\'l Pirate Costume]); //300% meat
 		handleFamiliar($familiar[Trick-or-Treating Tot]);
+		if(pass())
+			return result();
+	}
+	if(!in_wereprof())
+	{
+		//wereprof doesn't like +ML effects outside of Werewolf
+		if(tryEffects($effects[Frosty])) //200% meat, 100% item, 100% init, 25 ML
+			if(pass())
+				return result();
+	}
+	if(auto_sourceTerminalEnhanceLeft() > 0 && have_effect($effect[meat.enh]) == 0 && auto_is_valid($effect[meat.enh]))
+	{
+		if(!speculative)
+			auto_sourceTerminalEnhance("meat");
+		handleEffect($effect[meat.enh]); //60% meat
+		if(pass())
+			return result();
+	}
+	if(item_amount($item[body spradium]) > 0 && !in_tcrs() && have_effect($effect[Boxing Day Glow]) == 0)
+	{
+		autoChew(1, $item[body spradium]); //50% meat, 5 fam weight
+		if(pass())
+			return result();
 	}
 
 	// craft equipment, even limited use, here. also use limited resources like Inhaler
 	if(doEverything)
 	{
+		handleBjornify($familiar[Hobo Monkey]); //25% meat, hot damage, delevels
 		//craft IOTM derivative that gives high item bonus
 		if((equipped_item($slot[off-hand]) != $item[Half a Purse]) && !possessEquipment($item[Half a Purse]) && (item_amount($item[Lump of Brituminous Coal]) > 0))
 		{
+			//+X% meat based on smithness (10% if only half a purse is equipped)
 			auto_buyUpTo(1, $item[Loose Purse Strings]);
 			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Loose purse strings]);
 		}
 		if(tryEffects($effects[
-		Sinuses For Miles
+		shadow waters, //200% meat, 100% item, 100% init, -10% combat
+		Sinuses For Miles //200% meat
 		]))
 		if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])) & auto_is_valid($effect[Meet the Meat]))
 		{
-			zataraSeaside("meat");
+			zataraSeaside("meat"); //100% meat, 50% gear drops
+		}
+		if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
+		{
+			if(is_professor())
+			{
+				//Need to manually equip because professor
+				if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
+				if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
+				if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
+			}
+			else
+			{
+				outfit("Frat Warrior Fatigues");
+			}
+			cli_execute("concert 2"); //40% meat
 		}
 		string max = "500meat " + (amt + 100) + "max";
 		if(speculative)

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1487,42 +1487,40 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		{
 			boolean success = true;
 			int specwishes = 0;
-			while(auto_monkeyPawWishesLeft() + auto_wishesAvailable() > 0 && success)
+			foreach eff in $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
+			Braaaaaains, //200% meat, -50% item
+			Let's Go Shopping!,  //150% meat, 75% item, -300% myst
+			Always Be Collecting, //100% meat, 50% item
+			Incredibly Well Lit, //100% meat, 50% item
+			A View to Some Meat, //100% meat
+			Cravin' for a Ravin', //100% meat
+			Low on the Hog, //100% meat
+			Leisurely Amblin', //100% meat
+			Trufflin', //100% meat
+			Here's Some More Mud in Your Eye, //100% meat
+			Eau d' Clochard, //100% meat
+			Flapper Dancin', //100% meat
+			Fishing for Meat, //100% meat
+			Preternatural Greed] //100% meat
 			{
-				foreach eff in $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
-				Braaaaaains, //200% meat, -50% item
-				Let's Go Shopping!,  //150% meat, 75% item, -300% myst
-				Always Be Collecting, //100% meat, 50% item
-				Incredibly Well Lit, //100% meat, 50% item
-				A View to Some Meat, //100% meat
-				Cravin' for a Ravin', //100% meat
-				Low on the Hog, //100% meat
-				Leisurely Amblin', //100% meat
-				Trufflin', //100% meat
-				Here's Some More Mud in Your Eye, //100% meat
-				Eau d' Clochard, //100% meat
-				Flapper Dancin', //100% meat
-				Fishing for Meat, //100% meat
-				Preternatural Greed] //100% meat
+				if(eff == $effect[Frosty] && in_wereprof()) continue; //skip frosty in wereprof
+				if(have_effect(eff) == 0)
 				{
-					if(have_effect(eff) == 0)
+					if(!speculative)
+						success = auto_wishForEffect(eff);
+					specwishes +=1;
+					if(specwishes <= auto_monkeyPawWishesLeft() + auto_wishesAvailable())
 					{
-						if(!speculative)
-							success = auto_wishForEffect(eff);
-						specwishes +=1;
-						if(specwishes <= auto_monkeyPawWishesLeft() + auto_wishesAvailable())
-						{
-							handleEffect(eff);
-							if(pass())
-								return result();
-						}
-						else
-						{
-							success = false;
-						}
+						handleEffect(eff);
+						if(pass())
+							return result();
 					}
-					if(!success) break;
+					else
+					{
+						success = false;
+					}
 				}
+				if(!success) break;
 			}
 		}
 		auto_log_debug("With limited buffs we can get to " + result());

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1212,3 +1212,252 @@ boolean provideMoxie(int amt, boolean doEquips)
 	return provideMoxie(amt, my_location(), doEquips);
 }
 
+float provideMeat(int amt, location loc, boolean doEverything, boolean speculative)
+{
+	auto_log_info((speculative ? "Checking if we can" : "Trying to") + " provide " + amt + " meat, " + (doEverything ? "with" : "without") + " equipment, familiar, and limited buffs", "blue");
+	float alreadyHave = numeric_modifier("Meat Drop");
+	float need = amt - alreadyHave;
+	if(need > 0)
+	{
+		auto_log_debug("We currently have " + alreadyHave + ", so we need an extra " + need);
+	}
+	else
+	{
+		auto_log_debug("We already have enough +meat!");
+		return alreadyHave;
+	}
+	float delta = 0;
+	float result()
+	{
+		return numeric_modifier("Meat Drop") + delta;
+	}
+	boolean pass()
+	{
+		return result() >= amt;
+	}
+	if(pass())
+		return result();
+	
+	// don't craft equipment here. See how much +item we can get with gear on hand
+	if(doEverything)
+	{
+		string max = "500meat " + (amt + 100) + "max";
+		if(speculative)
+		{
+			simMaximizeWith(loc, max);
+		}
+		else
+		{
+			addToMaximize(max);
+			simMaximize(loc);
+		}
+		delta = simValue("Meat Drop") - numeric_modifier("Meat Drop");
+		auto_log_debug("With existing gear we can get to " + result());
+		if(pass())
+			return result();
+	}
+	//see how much familiar will help
+	if(doEverything && pathHasFamiliar() && pathAllowsChangingFamiliar())
+	{
+		if(!speculative)
+		{
+			handleFamiliar("meat");
+		}
+		// fam isn't equipped immediatly even if we aren't speculating
+		// so add bonus from fam regardless of speculation
+		familiar target = lookupFamiliarDatafile("meat");
+		if(target != $familiar[none] && target != my_familiar())
+		{
+			int famWeight = familiar_weight(target) + weight_adjustment();
+			delta += numeric_modifier(target, "Meat Drop",famWeight,$item[none]);
+			auto_log_debug("With using familiar: " + target + " we can get to " + result());
+		}
+		else
+		{
+			auto_log_debug("Already have desired familar, " + target + ", active.");
+		}
+		if(pass())
+			return result();
+	}
+	void handleEffect(effect eff)
+	{
+		if(speculative)
+		{
+			delta += numeric_modifier(eff, "Meat Drop");
+		}
+		auto_log_debug("We " + (speculative ? "can gain" : "just gained") + " " + eff.to_string() + ", now we have " + result());
+	}
+	boolean tryEffects(boolean [effect] effects)
+	{
+		foreach eff in effects
+		{
+			if(buffMaintain(eff, 0, 1, 1, speculative))
+				handleEffect(eff);
+			if(pass())
+				return true;
+		}
+		return false;
+	}
+	if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
+	{
+		if(is_professor())
+		{
+			//Need to manually equip because professor
+			if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
+			if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
+			if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
+		}
+		else
+		{
+			outfit("Frat Warrior Fatigues");
+		}
+		cli_execute("concert 2");
+	}
+	handleBjornify($familiar[Hobo Monkey]);
+	// unlimited skills
+	if(tryEffects($effects[
+		Polka of Plenty,
+		Disco Leer
+	]))
+		return result();
+	if(canAsdonBuff($effect[Driving Observantly]))
+	{
+		if(!speculative)
+			asdonBuff($effect[Driving Observantly]);
+		handleEffect($effect[Driving Observantly]);
+	}
+	if(pass())
+		return result();
+	if(bat_formWolf(speculative))
+	{
+		handleEffect($effect[Wolf Form]);
+	}
+	if(pass())
+		return result();
+	if(auto_birdModifier("Meat Drop") > 0)
+	{
+		if(tryEffects($effects[Blessing of the Bird]))
+			return result();
+	}
+	if(auto_favoriteBirdModifier("Meat Drop") > 0)
+	{
+		if(tryEffects($effects[Blessing of Your Favorite Bird]))
+			return result();
+	}
+	if(isActuallyEd())
+	{
+		if(!have_skill($skill[Gift of the Maid]) && ($servant[Maid].experience >= 441))
+		{
+			visit_url("charsheet.php");
+			if(have_skill($skill[Gift of the Maid]))
+			{
+				auto_log_warning("Gift of the Maid not properly detected until charsheet refresh.", "red");
+			}
+		}
+		if(tryEffects($effects[
+		Purr of the Feline
+		]))
+		return result();
+	}
+	songboomSetting("meat");
+	// items
+	if(tryEffects($effects[
+		Greedy Resolve,
+		Kindly Resolve,
+		Heightened Senses,
+		Big Meat Big Prizes,
+		Human-Machine Hybrid,
+		Human-Constellation Hybrid,
+		Human-Humanoid Hybrid,
+		Human-Fish Hybrid,
+		Cranberry Cordiality,
+		Patent Avarice,
+		Car-Charged,
+		Heart of Pink,
+		Sweet Heart,
+		Earning Interest,
+		Bet Your Autumn Dollar,
+		Flapper Dancin\',
+		shadow waters
+	]))
+		return result();
+	
+	if(!in_wereprof())
+	{
+		//wereprof doesn't like +ML effects outside of Werewolf
+		if(tryEffects($effects[Frosty]))
+			return result();
+	}
+	if(item_amount($item[body spradium]) > 0 && !in_tcrs() && have_effect($effect[Boxing Day Glow]) == 0)
+	{
+		autoChew(1, $item[body spradium]);
+		if(pass())
+			return result();
+	}
+	if(auto_sourceTerminalEnhanceLeft() > 0 && have_effect($effect[meat.enh]) == 0 && auto_is_valid($effect[meat.enh]))
+	{
+		if(!speculative)
+			auto_sourceTerminalEnhance("meat");
+		handleEffect($effect[meat.enh]);
+		if(pass())
+			return result();
+	}
+	if(have_effect($effect[Synthesis: Greed]) == 0)
+	{
+		rethinkingCandy($effect[Synthesis: Greed]);
+		if(pass())
+			return result();
+	}
+	if(available_amount($item[Li\'l Pirate Costume]) > 0 && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (!in_heavyrains()))
+	{
+		use_familiar($familiar[Trick-or-Treating Tot]);
+		autoEquip($item[Li\'l Pirate Costume]);
+		handleFamiliar($familiar[Trick-or-Treating Tot]);
+	}
+
+	// craft equipment, even limited use, here. also use limited resources like Inhaler
+	if(doEverything)
+	{
+		//craft IOTM derivative that gives high item bonus
+		if((equipped_item($slot[off-hand]) != $item[Half a Purse]) && !possessEquipment($item[Half a Purse]) && (item_amount($item[Lump of Brituminous Coal]) > 0))
+		{
+			auto_buyUpTo(1, $item[Loose Purse Strings]);
+			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Loose purse strings]);
+		}
+		if(tryEffects($effects[
+		Sinuses For Miles
+		]))
+		if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])) & auto_is_valid($effect[Meet the Meat]))
+		{
+			zataraSeaside("meat");
+		}
+		string max = "500meat " + (amt + 100) + "max";
+		if(speculative)
+		{
+			simMaximizeWith(loc, max);
+		}
+		else
+		{
+			addToMaximize(max);
+			simMaximize(loc);
+		}
+		delta = simValue("Meat Drop") - numeric_modifier("Meat Drop");
+		auto_log_debug("With existing and crafted gear we can get to " + result());
+		if(pass())
+			return result();
+	}
+	return result();
+}
+
+float provideMeat(int amt, boolean doEverything, boolean speculative)
+{
+	return provideMeat(amt, my_location(), doEverything, speculative);
+}
+boolean provideMeat(int amt, location loc, boolean doEverything)
+{
+	return provideMeat(amt, loc, doEverything, false) >= amt;
+}
+boolean provideMeat(int amt, boolean doEverything)
+{
+	return provideMeat(amt, my_location(), doEverything);
+}

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1363,7 +1363,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		Patent Avarice, //50% meat
 		Earning Interest, //50% meat
 		Bet Your Autumn Dollar, //50% meat
-		The Grass... Is Blue..., //40% meat, 20% item
+		The Grass... \ Is Blue..., //40% meat, 20% item
 		Greedy Resolve, //30% meat
 		Human-Fish Hybrid, //10 fam
 		Human-Humanoid Hybrid, //20% meat, 10% all stats

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1472,6 +1472,35 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		}
 		if(pass())
 			return result();
+		if(auto_monkeyPawWishesLeft() + auto_wishesAvailable() > 0)
+		{
+			foreach eff in $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
+			Braaaaaains, //200% meat, -50% item
+			Let's Go Shopping!,  //150% meat, 75% item, -300% myst
+			Always Be Collecting, //100% meat, 50% item
+			Incredibly Well Lit, //100% meat, 50% item
+			Friendly Chops, //100% meat, +5 Sleaze Res
+			A View to Some Meat, //100% meat
+			Cravin' for a Ravin', //100% meat
+			Low on the Hog, //100% meat
+			Leisurely Amblin', //100% meat
+			Trufflin', //100% meat
+			Here's Some More Mud in Your Eye, //100% meat
+			Eau d' Clochard, //100% meat
+			Flapper Dancin', //100% meat
+			Fishing for Meat, //100% meat
+			Preternatural Greed] //100% meat
+			{
+				if(have_effect(eff) == 0)
+				{
+					auto_wishForEffect(eff);
+					if(pass())
+						return result();
+				}
+			}
+		}
+		if(pass())
+			return result();
 		delta = simValue("Meat Drop") - numeric_modifier("Meat Drop");
 		auto_log_debug("With limited buffs we can get to " + result());
 		if(pass())

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1355,7 +1355,6 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 	songboomSetting("meat"); //30% meat
 	// items
 	if(tryEffects($effects[
-		Car-Charged, //100% meat, 100% item, 5-10MP, 50% init, 50% spell dmg, +3 stats per fight
 		Flapper Dancin\', //100% meat
 		Heightened Senses, //50% meat, 25% item drop
 		Big Meat Big Prizes, //50% meat
@@ -1413,7 +1412,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			return result();
 	}
 
-	// craft equipment, even limited use, here. also use limited resources like Inhaler
+	// craft equipment, even limited use, here
 	if(doEverything)
 	{
 		handleBjornify($familiar[Hobo Monkey]); //25% meat, hot damage, delevels
@@ -1423,30 +1422,6 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			//+X% meat based on smithness (10% if only half a purse is equipped)
 			auto_buyUpTo(1, $item[Loose Purse Strings]);
 			autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Loose purse strings]);
-		}
-		if(tryEffects($effects[
-		shadow waters, //200% meat, 100% item, 100% init, -10% combat
-		Sinuses For Miles, //200% meat
-		Incredibly Well Lit //100% meat, 50% item
-		]))
-		if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])) & auto_is_valid($effect[Meet the Meat]))
-		{
-			zataraSeaside("meat"); //100% meat, 50% gear drops
-		}
-		if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
-		{
-			if(is_professor())
-			{
-				//Need to manually equip because professor
-				if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
-				if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
-				if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
-			}
-			else
-			{
-				outfit("Frat Warrior Fatigues");
-			}
-			cli_execute("concert 2"); //40% meat
 		}
 		string max = "500meat " + (amt + 100) + "max";
 		if(speculative)
@@ -1463,6 +1438,46 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		if(pass())
 			return result();
 	}
+	// Use limited resources like Inhaler
+	if(doEverything)
+	{
+		if(tryEffects($effects[
+		shadow waters, //200% meat, 100% item, 100% init, -10% combat
+		Sinuses For Miles, //200% meat
+		Car-Charged, //100% meat, 100% item, 5-10MP, 50% init, 50% spell dmg, +3 stats per fight
+		Incredibly Well Lit //100% meat, 50% item
+		]))
+			if(pass())
+				return result();
+		if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])) & auto_is_valid($effect[Meet the Meat]))
+		{
+			zataraSeaside("meat"); //100% meat, 50% gear drops
+		}
+		if(pass())
+			return result();
+		if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
+		{
+			if(is_professor())
+			{
+				//Need to manually equip because professor
+				if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
+				if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
+				if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
+			}
+			else
+			{
+				outfit("Frat Warrior Fatigues");
+			}
+			cli_execute("concert 2"); //40% meat
+		}
+		if(pass())
+			return result();
+		delta = simValue("Meat Drop") - numeric_modifier("Meat Drop");
+		auto_log_debug("With limited buffs we can get to " + result());
+		if(pass())
+			return result();
+	}
+
 	return result();
 }
 

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1364,6 +1364,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		Bet Your Autumn Dollar, //50% meat
 		The Grass... \ Is Blue..., //40% meat, 20% item
 		Greedy Resolve, //30% meat
+		Worth Your Salt, //25% meat, max hp +25
 		Human-Fish Hybrid, //10 fam
 		Human-Humanoid Hybrid, //20% meat, 10% all stats
 		Heart of Pink, //20% meat, +3 all stats

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1485,6 +1485,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		if(auto_monkeyPawWishesLeft() + auto_wishesAvailable() > 0)
 		{
 			boolean success = true;
+			int specwishes = 0;
 			while(auto_monkeyPawWishesLeft() + auto_wishesAvailable() > 0 && success)
 			{
 				foreach eff in $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
@@ -1508,15 +1509,22 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 					{
 						if(!speculative)
 							success = auto_wishForEffect(eff);
-						handleEffect(eff);
-						if(pass())
-							return result();
+						specwishes +=1;
+						if(specwishes <= auto_monkeyPawWishesLeft() + auto_wishesAvailable())
+						{
+							handleEffect(eff);
+							if(pass())
+								return result();
+						}
+						else
+						{
+							success = false;
+						}
 					}
 					if(!success) break;
 				}
 			}
 		}
-		delta = simValue("Meat Drop") - numeric_modifier("Meat Drop");
 		auto_log_debug("With limited buffs we can get to " + result());
 		if(pass())
 			return result();

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1484,30 +1484,35 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			return result();
 		if(auto_monkeyPawWishesLeft() + auto_wishesAvailable() > 0)
 		{
-			foreach eff in $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
-			Braaaaaains, //200% meat, -50% item
-			Let's Go Shopping!,  //150% meat, 75% item, -300% myst
-			Always Be Collecting, //100% meat, 50% item
-			Incredibly Well Lit, //100% meat, 50% item
-			Friendly Chops, //100% meat, +5 Sleaze Res
-			A View to Some Meat, //100% meat
-			Cravin' for a Ravin', //100% meat
-			Low on the Hog, //100% meat
-			Leisurely Amblin', //100% meat
-			Trufflin', //100% meat
-			Here's Some More Mud in Your Eye, //100% meat
-			Eau d' Clochard, //100% meat
-			Flapper Dancin', //100% meat
-			Fishing for Meat, //100% meat
-			Preternatural Greed] //100% meat
+			boolean success = true;
+			while(auto_monkeyPawWishesLeft() + auto_wishesAvailable() > 0 && success)
 			{
-				if(have_effect(eff) == 0)
+				foreach eff in $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
+				Braaaaaains, //200% meat, -50% item
+				Let's Go Shopping!,  //150% meat, 75% item, -300% myst
+				Always Be Collecting, //100% meat, 50% item
+				Incredibly Well Lit, //100% meat, 50% item
+				Friendly Chops, //100% meat, +5 Sleaze Res
+				A View to Some Meat, //100% meat
+				Cravin' for a Ravin', //100% meat
+				Low on the Hog, //100% meat
+				Leisurely Amblin', //100% meat
+				Trufflin', //100% meat
+				Here's Some More Mud in Your Eye, //100% meat
+				Eau d' Clochard, //100% meat
+				Flapper Dancin', //100% meat
+				Fishing for Meat, //100% meat
+				Preternatural Greed] //100% meat
 				{
-					if(!speculative)
-						auto_wishForEffect(eff);
-					handleEffect(eff);
-					if(pass())
-						return result();
+					if(have_effect(eff) == 0)
+					{
+						if(!speculative)
+							success = auto_wishForEffect(eff);
+						handleEffect(eff);
+						if(pass())
+							return result();
+					}
+					if(!success) break;
 				}
 			}
 		}

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1455,7 +1455,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 			{
 				zataraSeaside("meat");
 			}
-			handleEffect($effect[Meat the meat]); //100% meat, 50% gear drops
+			handleEffect($effect[Meet the meat]); //100% meat, 50% gear drops
 			if(pass())
 				return result();			
 		}

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1371,6 +1371,7 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		Human-Machine Hybrid, //5 fam weight, DA +50, DR 5
 		Sweet Heart, // Muscle +X, +2X% meat
 		Cranberry Cordiality, //10% meat
+		So You Can Work More... //10% meat
 	]))
 		if(pass())
 			return result();
@@ -1424,7 +1425,8 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		}
 		if(tryEffects($effects[
 		shadow waters, //200% meat, 100% item, 100% init, -10% combat
-		Sinuses For Miles //200% meat
+		Sinuses For Miles, //200% meat
+		Incredibly Well Lit //100% meat, 50% item
 		]))
 		if(zataraAvailable() && (0 == have_effect($effect[Meet the Meat])) & auto_is_valid($effect[Meet the Meat]))
 		{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1592,6 +1592,10 @@ float provideMoxie(int amt, location loc, boolean doEquips, boolean speculative)
 float provideMoxie(int amt, boolean doEquips, boolean speculative);
 boolean provideMoxie(int amt, location loc, boolean doEquips);
 boolean provideMoxie(int amt, boolean doEquips);
+float provideMeat(int amt, location loc, boolean doEverything, boolean speculative);
+float provideMeat(int amt, boolean doEverything, boolean speculative);
+boolean provideMeat(int amt, location loc, boolean doEverything);
+boolean provideMeat(int amt, boolean doEverything);
 
 ########################################################################################################
 //Defined in autoscend/auto_restore.ash

--- a/RELEASE/scripts/autoscend/quests/level_04.ash
+++ b/RELEASE/scripts/autoscend/quests/level_04.ash
@@ -65,7 +65,7 @@ boolean L4_batCave()
 			return false;
 		}
 
-		provideMeat(1000, $location[The Boss Bat\'s Lair], false);
+		provideMeat(50, $location[The Boss Bat\'s Lair], false);
 		//AoSOL buffs
 		if(in_aosol())
 		{

--- a/RELEASE/scripts/autoscend/quests/level_04.ash
+++ b/RELEASE/scripts/autoscend/quests/level_04.ash
@@ -65,7 +65,7 @@ boolean L4_batCave()
 			return false;
 		}
 
-		buffMaintain($effect[Polka of Plenty], 15, 1, 1);
+		provideMeat(1000, $location[The Boss Bat\'s Lair], false);
 		//AoSOL buffs
 		if(in_aosol())
 		{
@@ -75,8 +75,6 @@ boolean L4_batCave()
 				handleFamiliar($familiar[Grey Goose]);
 			}
 		}
-		bat_formWolf();
-		addToMaximize("10meat");
 		int batskinBelt = item_amount($item[Batskin Belt]);
 		auto_change_mcd(4); // get the pants from the Boss Bat.
 		autoAdv($location[The Boss Bat\'s Lair]);

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1759,7 +1759,7 @@ boolean L12_themtharHills()
 		use_familiar(to_familiar(get_property("auto_familiarChoice")));
 	}
 	equipMaximizedGear();
-	float meatDropHave = provideMeat(400, false, true);
+	float meatDropHave = provideMeat(1800, true, true);
 
 	if(isActuallyEd() && have_skill($skill[Curse of Fortune]) && item_amount($item[Ka Coin]) > 0)
 	{

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1737,106 +1737,6 @@ boolean L12_themtharHills()
 		auto_log_info("Themthar Nuns!", "blue");
 	}
 
-	if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
-	{
-		if(is_professor())
-		{
-			//Need to manually equip because professor
-			if(!have_equipped($item[beer helmet])) equip($item[beer helmet]);
-			if(!have_equipped($item[distressed denim pants])) equip($item[distressed denim pants]);
-			if(!have_equipped($item[bejeweled pledge pin])) equip($item[bejeweled pledge pin]);
-		}
-		else
-		{
-			outfit("Frat Warrior Fatigues");
-		}
-		cli_execute("concert 2");
-	}
-
-	handleBjornify($familiar[Hobo Monkey]);
-	if((equipped_item($slot[off-hand]) != $item[Half a Purse]) && !possessEquipment($item[Half a Purse]) && (item_amount($item[Lump of Brituminous Coal]) > 0))
-	{
-		auto_buyUpTo(1, $item[Loose Purse Strings]);
-		autoCraft("smith", 1, $item[Lump of Brituminous Coal], $item[Loose purse strings]);
-	}
-
-	autoEquip($item[Half a Purse]);
-	if(in_heavyrains())
-	{
-		autoEquip($item[Thor\'s Pliers]);
-	}
-	autoEquip($item[Miracle Whip]);
-
-	shrugAT($effect[Polka of Plenty]);
-	if(isActuallyEd())
-	{
-		if(!have_skill($skill[Gift of the Maid]) && ($servant[Maid].experience >= 441))
-		{
-			visit_url("charsheet.php");
-			if(have_skill($skill[Gift of the Maid]))
-			{
-				auto_log_warning("Gift of the Maid not properly detected until charsheet refresh.", "red");
-			}
-		}
-	}
-	buffMaintain($effect[Purr of the Feline], 10, 1, 1);
-	songboomSetting("meat");
-	handleFamiliar("meat");
-	addToMaximize("200meat drop");
-
-	if(have_effect($effect[Frosty])==0 && !in_wereprof())
-	{
-		auto_wishForEffect($effect[Frosty]);
-	}
-	buffMaintain($effect[Greedy Resolve]);
-	buffMaintain($effect[Disco Leer], 10, 1, 1);
-	buffMaintain($effect[Polka of Plenty], 8, 1, 1);
-	#Handle for familiar weight change.
-	buffMaintain($effect[Kindly Resolve]);
-	buffMaintain($effect[Heightened Senses]);
-	buffMaintain($effect[Big Meat Big Prizes]);
-	buffMaintain($effect[Human-Machine Hybrid]);
-	buffMaintain($effect[Human-Constellation Hybrid]);
-	buffMaintain($effect[Human-Humanoid Hybrid]);
-	buffMaintain($effect[Human-Fish Hybrid]);
-	buffMaintain($effect[Cranberry Cordiality]);
-	buffMaintain($effect[Patent Avarice]);
-	buffMaintain($effect[Car-Charged]);
-	buffMaintain($effect[Heart of Pink]);
-	buffMaintain($effect[Sweet Heart], 0, 1, 20);
-	buffMaintain($effect[Earning Interest]);
-	buffMaintain($effect[Bet Your Autumn Dollar]);
-	buffMaintain($effect[Flapper Dancin\']);
-	buffMaintain($effect[shadow waters]);
-		
-	if(item_amount($item[body spradium]) > 0 && !in_tcrs() && have_effect($effect[Boxing Day Glow]) == 0)
-	{
-		autoChew(1, $item[body spradium]);
-	}
-	if(have_effect($effect[meat.enh]) == 0 && auto_is_valid($effect[meat.enh]))
-	{
-		if(auto_sourceTerminalEnhanceLeft() > 0)
-		{
-			auto_sourceTerminalEnhance("meat");
-		}
-	}
-	if(have_effect($effect[Synthesis: Greed]) == 0)
-	{
-		rethinkingCandy($effect[Synthesis: Greed]);
-	}
-	asdonBuff($effect[Driving Observantly]);
-
-	if(available_amount($item[Li\'l Pirate Costume]) > 0 && canChangeToFamiliar($familiar[Trick-or-Treating Tot]) && (!in_heavyrains()))
-	{
-		use_familiar($familiar[Trick-or-Treating Tot]);
-		autoEquip($item[Li\'l Pirate Costume]);
-		handleFamiliar($familiar[Trick-or-Treating Tot]);
-	}
-
-	if(in_heavyrains())
-	{
-		buffMaintain($effect[Sinuses For Miles]);
-	}
 	// Target 1000 + 400% = 5000 meat per brigand. Of course we want more, but don\'t bother unless we can get this.
 	float meat_need = 400.00;
 	//count inhaler if we have one or if we have a clover to obtain one and can use one
@@ -1859,7 +1759,7 @@ boolean L12_themtharHills()
 		use_familiar(to_familiar(get_property("auto_familiarChoice")));
 	}
 	equipMaximizedGear();
-	float meatDropHave = meat_drop_modifier();
+	float meatDropHave = provideMeat(400, false, true);
 
 	if(isActuallyEd() && have_skill($skill[Curse of Fortune]) && item_amount($item[Ka Coin]) > 0)
 	{
@@ -1909,29 +1809,7 @@ boolean L12_themtharHills()
 		return autoLuckyAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
 	}
 
-	buffMaintain($effect[Disco Leer], 10, 1, 1);
-	buffMaintain($effect[Polka of Plenty], 8, 1, 1);
-	buffMaintain($effect[Sinuses For Miles]);
-	buffMaintain($effect[Greedy Resolve]);
-	buffMaintain($effect[Kindly Resolve]);
-	buffMaintain($effect[Heightened Senses]);
-	buffMaintain($effect[Big Meat Big Prizes]);
-	buffMaintain($effect[Fortunate Resolve]);
-	buffMaintain($effect[Human-Machine Hybrid]);
-	buffMaintain($effect[Human-Constellation Hybrid]);
-	buffMaintain($effect[Human-Humanoid Hybrid]);
-	buffMaintain($effect[Human-Fish Hybrid]);
-	buffMaintain($effect[Cranberry Cordiality]);
-	buffMaintain($effect[Car-Charged]);
-	buffMaintain($effect[Heart of Pink]);
-	buffMaintain($effect[Sweet Heart], 0, 1, 20);
-	buffMaintain($effect[Good Things Are Coming, You Can Smell It]);
-	buffMaintain($effect[Incredibly Well Lit]);
-	bat_formWolf();
-	if(auto_is_valid($effect[Meet the Meat]))
-	{
-		zataraSeaside("meat");
-	}
+	provideMeat(1800, true, false); // Do as much as possible to get meat drops
 
 	{
 		equipWarOutfit();

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1454,7 +1454,7 @@ boolean L13_towerNSTower()
 			abort("auto_towerBreak set to abort here.");
 		}
 		equipBaseline();
-		provideMeat(526, true, false);
+		provideMeat(626, true, false);
 
 		acquireHP();
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_06_monster2", $location[Noob Cave]);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1454,35 +1454,7 @@ boolean L13_towerNSTower()
 			abort("auto_towerBreak set to abort here.");
 		}
 		equipBaseline();
-		shrugAT($effect[Polka of Plenty]);
-		buffMaintain($effect[Disco Leer]);
-		buffMaintain($effect[Polka of Plenty]);
-		buffMaintain($effect[Cranberry Cordiality]);
-		buffMaintain($effect[Big Meat Big Prizes]);
-		buffMaintain($effect[Patent Avarice]);
-		buffMaintain($effect[Flapper Dancin\']);
-		buffMaintain($effect[Incredibly Well Lit]);
-		bat_formWolf();
-		if(auto_birdModifier("Meat Drop") > 0)
-		{
-			buffMaintain($effect[Blessing of the Bird]);
-		}
-		if(auto_favoriteBirdModifier("Meat Drop") > 0)
-		{
-			buffMaintain($effect[Blessing of Your Favorite Bird]);
-		}
-		if((get_property("sidequestArenaCompleted") == "fratboy") && !get_property("concertVisited").to_boolean() && (have_effect($effect[Winklered]) == 0))
-		{
-			cli_execute("concert 2");
-		}
-		
-		handleFamiliar("meat");
-		addToMaximize("200meat drop");
-		
-		if(my_class() == $class[Seal Clubber])
-		{
-			autoEquip($item[Meat Tenderizer is Murder]);
-		}
+		provideMeat(525.625, true, false);
 
 		acquireHP();
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_06_monster2", $location[Noob Cave]);

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1454,7 +1454,7 @@ boolean L13_towerNSTower()
 			abort("auto_towerBreak set to abort here.");
 		}
 		equipBaseline();
-		provideMeat(525.625, true, false);
+		provideMeat(526, true, false);
 
 		acquireHP();
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_06_monster2", $location[Noob Cave]);


### PR DESCRIPTION
# Description

Standing on Alium's Add Item Provider #1331 Shoulders, but for Meat. Values are either to achieve specific targets (wall of meat in 1 turn, Fungal Plains max points) or estimates I'm not particularly beholden to.

## How Has This Been Tested?

Tested in a separate local branch merged with the ag-improvements branch in a HC Avant Guard run. At The Fungus Plains, saw it try to provide 450% meat drop as expected per PR

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
