### PR TITLE
fix: improve 2002 purchases for avatar paths

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -790,7 +790,7 @@ void initializeDay(int day)
 	}
 
 	// Get emotionally chipped if you have the item.  boris\jarlsberg\sneaky pete\zombie slayer\ed cannot use this skill so excluding.
-	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && !(is_boris() || is_jarlsberg() || is_pete() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte() || in_wereprof()))
+	if (!have_skill($skill[Emotionally Chipped]) && item_amount($item[spinal-fluid-covered emotion chip]) > 0 && can_read_skillbook($item[spinal-fluid-covered emotion chip]))
 	{
 		use(1, $item[spinal-fluid-covered emotion chip]);
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4527,3 +4527,12 @@ boolean auto_burnMP(int mpToBurn)
 	return startingMP != my_mp();
 }
 
+boolean can_read_skillbook(item it) {
+  if (it == $item[spinal-fluid-covered emotion chip] && in_robot()) {
+    return true;
+  }
+  if (is_boris() || is_jarlsberg() || is_pete() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte() || in_robot() || in_wereprof()) {
+    return false;
+  }
+  return true;
+}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4528,13 +4528,14 @@ boolean auto_burnMP(int mpToBurn)
 }
 
 boolean can_read_skillbook(item it) {
+  // all the normal classes and AoSOL classes are literate
+  if ($classes[Seal Clubber, Turtle Tamer, Sauceror, Pastamancer, Disco Bandit, Accordion Thief, Pig Skinner, Cheese Wizard, Jazz Agent] contains my_class()) {
+    return true;
+  }
   if (it == $item[spinal-fluid-covered emotion chip] && in_robot()) {
     return true;
   }
-  if (is_boris() || is_jarlsberg() || is_pete() || in_zombieSlayer() || isActuallyEd() || in_awol() || in_gnoob() || in_darkGyffte() || in_robot() || in_wereprof()) {
-    return false;
-  }
-  return true;
+  return false;
 }
 
 boolean have_campground() {

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4528,26 +4528,26 @@ boolean auto_burnMP(int mpToBurn)
 }
 
 boolean can_read_skillbook(item it) {
-  // all the normal classes and AoSOL classes are literate
-  if ($classes[Seal Clubber, Turtle Tamer, Sauceror, Pastamancer, Disco Bandit, Accordion Thief, Pig Skinner, Cheese Wizard, Jazz Agent] contains my_class()) {
-    return true;
-  }
-  if (it == $item[spinal-fluid-covered emotion chip] && in_robot()) {
-    return true;
-  }
-  return false;
+	// all the normal classes and AoSOL classes are literate
+	if ($classes[Seal Clubber, Turtle Tamer, Sauceror, Pastamancer, Disco Bandit, Accordion Thief, Pig Skinner, Cheese Wizard, Jazz Agent] contains my_class()) {
+		return true;
+	}
+	if (it == $item[spinal-fluid-covered emotion chip] && in_robot()) {
+		return true;
+	}
+	return false;
 }
 
 boolean have_campground() {
-  if (isActuallyEd() || in_robot() || in_nuclear() || in_small() || in_wereprof()) {
-    return false;
-  }
-  return true;
+	if (isActuallyEd() || in_robot() || in_nuclear() || in_small() || in_wereprof()) {
+		return false;
+	}
+	return true;
 }
 
 boolean have_workshed() {
-  if (isActuallyEd() || in_robot() || in_nuclear() || in_wereprof()) {
-    return false;
-  }
-  return true;
+	if (isActuallyEd() || in_robot() || in_nuclear() || in_wereprof()) {
+		return false;
+	}
+	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4536,3 +4536,17 @@ boolean can_read_skillbook(item it) {
   }
   return true;
 }
+
+boolean have_campground() {
+  if (isActuallyEd() || in_robot() || in_nuclear() || in_small() || in_wereprof()) {
+    return false;
+  }
+  return true;
+}
+
+boolean have_workshed() {
+  if (isActuallyEd() || in_robot() || in_nuclear() || in_wereprof()) {
+    return false;
+  }
+  return true;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1864,3 +1864,4 @@ int meatReserve();
 boolean auto_wishForEffect(effect wish);
 item wrap_item(item it);
 boolean auto_burnMP(int mpToBurn);
+boolean can_read_skillbook(item it);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1865,3 +1865,5 @@ boolean auto_wishForEffect(effect wish);
 item wrap_item(item it);
 boolean auto_burnMP(int mpToBurn);
 boolean can_read_skillbook(item it);
+boolean have_campground();
+boolean have_workshed();

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -445,7 +445,7 @@ void auto_buyFrom2002MrStore()
 	auto_log_debug("Have " + remainingCatalogCredits() + " credit(s) to buy from Mr. Store 2002. Let's spend them!");
 	// meat butler on day 1 of run
 	item itemConsidering = $item[meat butler];
-	if(remainingCatalogCredits() > 0 && my_daycount() == 1 && !haveCampgroundMaid() && auto_is_valid(itemConsidering))
+	if(have_campground() && remainingCatalogCredits() > 0 && my_daycount() == 1 && !haveCampgroundMaid() && auto_is_valid(itemConsidering))
 	{
 		buy($coinmaster[Mr. Store 2002], 1, itemConsidering);
 		use(itemConsidering);

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -452,7 +452,7 @@ void auto_buyFrom2002MrStore()
 	}
 	// manual of secret door detection. skill: Secret door awareness
 	itemConsidering = $item[manual of secret door detection];
-	if(remainingCatalogCredits() > 0 && !auto_have_skill($skill[Secret door awareness]) && auto_is_valid(itemConsidering))
+	if(can_read_skillbook(itemConsidering) && remainingCatalogCredits() > 0 && !auto_have_skill($skill[Secret door awareness]) && auto_is_valid(itemConsidering))
 	{
 		buy($coinmaster[Mr. Store 2002], 1, itemConsidering);
 		use(itemConsidering);

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -856,7 +856,7 @@ boolean LX_setWorkshed(){
 	boolean workshedChanged = get_property("_workshedItemUsed").to_boolean();
 
 	if (workshedChanged) return false; //Don't even try if the workshed has already been changed once
-	if (isActuallyEd() || in_robot() || in_nuclear() || in_wereprof()) return false; //Not usable in Ed, Nuclear Autumn, You, Robot, or WereProfessor
+	if (!have_workshed()) return false; //Not usable in certain paths
 
 	//Check to make sure we can use the workshed item and that it isn't already in the campground. If already in campground, return false also
 	//These first 2 ifs are only used if something valid other than auto is specified. Otherwise we go to the auto 


### PR DESCRIPTION
# Description

Autoscend should not buy and try to read the Manual of Secret Door Detection if it's going to fail.

It also shouldn't buy the meat butler if there's no campground.

## How Has This Been Tested?

Ran WereProfessor.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
