### PR TITLE
fix: wereprof skill buying

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1808,6 +1808,10 @@ boolean doTasks()
 	{
 		cli_execute("refresh inv");
 	}
+	if (in_wereprof()) {
+		// wereprof doesn't update wereProfessorTransformTurns unless you hit the charpane
+		visit_url("charpane.php", false);
+	}
 
 	// actually doing stuff should start from here onwards.
 	resetState();

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -150,7 +150,7 @@ void wereprof_buySkills()
 			{
 				if(contains_text(get_property("beastSkillsAvailable").to_string(), sk))
 				{
-					if(rpcost[sk] >= rp)
+					if(rpcost[sk] > rp)
 					{
 						cantbuy += 1;
 						if(cantbuy==count(split_string(get_property("beastSkillsAvailable").to_string(),",")))


### PR DESCRIPTION
# Description

WereProfessor only buys skills if
* it's the beginning of the ascension
* organs are full and it has very few adventures left
* it is about to transform into a wolf

It calculates the latter using "wereProfessorTransformTurns", which is only updated when you view the charpane. Autoscend almost never views the charpane, so this preference is almost never updated, so autoscend generally doesn't buy skills during the run. This can really hinder daycount if it doesn't buy stomach / liver.

Also fix a separate issue where it only bought skills if it had 1 more RP than required.

## How Has This Been Tested?

Running WereProf.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
