### PR TITLE
Apriling Band Providers

### DIFF
--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -89,7 +89,14 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 	}
 	
 	// Do the April band
-	auto_setAprilBandCombat();
+	if(auto_haveAprilingBandHelmet())
+	{
+		if(!speculative)
+			auto_setAprilBandCombat();
+		handleEffect($effect[Apriling Band Battle Cadence]);
+		if(pass())
+			return result();
+	}
 
 	// Now handle buffs that cost MP, items or other resources
 
@@ -261,7 +268,14 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 	}
 	
 	// Do the April band
-	auto_setAprilBandNonCombat();
+	if(auto_haveAprilingBandHelmet())
+	{
+		if(!speculative)
+			auto_setAprilBandNonCombat();
+		handleEffect($effect[Apriling Band Patrol Beat]);
+		if(pass())
+			return result();
+	}
 
 	// Now handle buffs that cost MP, items or other resources
 


### PR DESCRIPTION
# Description

We weren't properly speculating Apriling Band Combat/Non-Combat skills causing them to be used erroneously when trying to see how much +/- combat we can get. This fixes that.


## How Has This Been Tested?

It hasn't but it follows the same pattern as other working code.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
