### PR TITLE
Ed modernisation, free run expansion and other small fixes

### DIFF
--- a/BUILD/monsters/freerun.dat
+++ b/BUILD/monsters/freerun.dat
@@ -31,3 +31,14 @@ animated rustic nightstand
 Wardröb nightstand
 drunken rat
 bunch of drunken rats
+tapdancing skeleton
+floating platter of hors d\'oeuvres
+boaraffe
+pygmy assault squad
+pygmy blowgunner
+Copperhead Club bartender
+fan dancer
+Mob Penguin Capo
+ninja snowman (chopsticks)
+ninja snowman janitor
+ninja snowman weaponmaster

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -89,6 +89,17 @@ freerun	29	animated rustic nightstand
 freerun	30	Wardröb nightstand
 freerun	31	drunken rat
 freerun	32	bunch of drunken rats
+freerun	33	tapdancing skeleton
+freerun	34	floating platter of hors d'oeuvres
+freerun	35	boaraffe
+freerun	36	pygmy assault squad
+freerun	37	pygmy blowgunner
+freerun	38	Copperhead Club bartender
+freerun	39	fan dancer
+freerun	40	Mob Penguin Capo
+freerun	41	ninja snowman (chopsticks)
+freerun	42	ninja snowman janitor
+freerun	43	ninja snowman weaponmaster
 
 replace	0	Banshee Librarian	item:Killing Jar>0
 replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber;!pathid:41;!path:Wildfire;!path:Fall of the Dinosaurs;!path:Avatar of Shadows Over Loathing;!path:Legacy of Loathing;!path:WereProfessor

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -950,6 +950,13 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	{
 		return "skill " + $skill[Peel Out];
 	}
+	
+	// Bowling ball is a banish as well, but is available enough that we want to use it as a free run source too
+	// bowling ball is only in inventory if it is available to use in combat. While on cooldown, it is not in inventory
+	if((inCombat ? auto_have_skill($skill[Bowl a Curveball]) : item_amount($item[Cosmic Bowling Ball]) > 0) && auto_is_valid($skill[Bowl a Curveball]))
+	{
+		return "skill " + $skill[Bowl a Curveball];
+	}
 
 	//Non-standard free-runs
 	if(!inAftercore())

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -906,25 +906,25 @@ generic_t zone_delay(location loc)
 		}
 		break;
 	case $location[Vanya\'s Castle]:
-		if (possessEquipment($item[Continuum Transfunctioner]) && (get_property("8BitColor") == "black" || get_property("8BitColor") == ""))
+		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && (get_property("8BitColor") == "black" || get_property("8BitColor") == ""))
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}
 		break;
 	case $location[The Fungus Plains]:
-		if (possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "red")
+		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "red")
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}
 		break;
 	case $location[Megalo-City]:
-		if (possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "blue")
+		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "blue")
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}
 		break;
 	case $location[Hero\'s Field]:
-		if (possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "green")
+		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "green")
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -906,25 +906,25 @@ generic_t zone_delay(location loc)
 		}
 		break;
 	case $location[Vanya\'s Castle]:
-		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && (get_property("8BitColor") == "black" || get_property("8BitColor") == ""))
+		if (need8BitPoints() && possessEquipment($item[Continuum Transfunctioner]) && (get_property("8BitColor") == "black" || get_property("8BitColor") == ""))
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}
 		break;
 	case $location[The Fungus Plains]:
-		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "red")
+		if (need8BitPoints() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "red")
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}
 		break;
 	case $location[Megalo-City]:
-		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "blue")
+		if (need8BitPoints() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "blue")
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}
 		break;
 	case $location[Hero\'s Field]:
-		if (needDigitalKey() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "green")
+		if (need8BitPoints() && possessEquipment($item[Continuum Transfunctioner]) && get_property("8BitColor") == "green")
 		{
 			value = 5 - get_property("8BitBonusTurns").to_int();
 		}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1199,6 +1199,7 @@ boolean L12_islandWar();
 //Defined in autoscend/quests/level_13.ash
 boolean needStarKey();
 boolean needDigitalKey();
+boolean need8BitPoints();
 int towerKeyCount();
 int towerKeyCount(boolean effective);
 int EightBitScore();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -485,6 +485,7 @@ boolean auto_sendAutumnaton(location loc);
 boolean auto_autumnatonQuest();
 boolean auto_hasSpeakEasy();
 int auto_remainingSpeakeasyFreeFights();
+boolean speakeasyCombat();
 
 
 boolean auto_haveTrainSet();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -824,20 +824,24 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		return useSkill(dartSkill(), false);
 	}
 	
-	if(wantToForceDrop(enemy))
+	// Don't risk drop forcing if we've already been beaten up twice
+	if (get_property("_edDefeats").to_int()<2)
 	{
-		boolean polarVortexAvailable = canUse($skill[Fire Extinguisher: Polar Vortex], false) && auto_fireExtinguisherCharges() > 10;
-		boolean mildEvilAvailable = canUse($skill[Perpetrate Mild Evil],false) && get_property("_mildEvilPerpetrated").to_int() < 3;
-		// mild evil only can pick pocket. Use it before fire extinguisher
-		if(mildEvilAvailable)
+		if(wantToForceDrop(enemy))
 		{
-			handleTracker(enemy, $skill[Perpetrate Mild Evil], "auto_otherstuff");
-			return useSkill($skill[Perpetrate Mild Evil]);	
-		}
-		if(polarVortexAvailable)
-		{
-			handleTracker(enemy, $skill[Fire Extinguisher: Polar Vortex], "auto_otherstuff");
-			return useSkill($skill[Fire Extinguisher: Polar Vortex]);	
+			boolean polarVortexAvailable = canUse($skill[Fire Extinguisher: Polar Vortex], false) && auto_fireExtinguisherCharges() > 10;
+			boolean mildEvilAvailable = canUse($skill[Perpetrate Mild Evil],false) && get_property("_mildEvilPerpetrated").to_int() < 3;
+			// mild evil only can pick pocket. Use it before fire extinguisher
+			if(mildEvilAvailable)
+			{
+				handleTracker(enemy, $skill[Perpetrate Mild Evil], "auto_otherstuff");
+				return useSkill($skill[Perpetrate Mild Evil]);	
+			}
+			if(polarVortexAvailable)
+			{
+				handleTracker(enemy, $skill[Fire Extinguisher: Polar Vortex], "auto_otherstuff");
+				return useSkill($skill[Fire Extinguisher: Polar Vortex]);	
+			}
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -492,7 +492,10 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 	if (!get_property("edUsedLash").to_boolean() && canUse($skill[Lash of the Cobra]) && get_property("_edLashCount").to_int() < 30)
 	{
 		boolean doLash = false;
-
+		if(enemy == $monster[Shadow Slab])
+		{
+			doLash = true;
+		}
 		if((enemy == $monster[Big Wheelin\' Twins]) && !possessEquipment($item[Badge Of Authority]))
 		{
 			doLash = true;
@@ -770,6 +773,13 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 			}
 		}
 
+		if(canUse($item[shadow brick]) && (get_property("_shadowBricksUsed").to_int() < 13))
+		{
+			handleTracker(enemy, $item[shadow brick], "auto_instakill");
+			loopHandlerDelayAll();
+			return useItems($item[shadow brick], $item[none]);
+		}
+
 		if(!combat_status_check("jokesterGun") && (equipped_item($slot[Weapon]) == $item[The Jokester\'s Gun]) && !get_property("_firedJokestersGun").to_boolean() && auto_have_skill($skill[Fire the Jokester\'s Gun]))
 		{
 			combat_status_add("jokesterGun");
@@ -812,6 +822,23 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 	if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0)
 	{
 		return useSkill(dartSkill(), false);
+	}
+	
+	if(wantToForceDrop(enemy))
+	{
+		boolean polarVortexAvailable = canUse($skill[Fire Extinguisher: Polar Vortex], false) && auto_fireExtinguisherCharges() > 10;
+		boolean mildEvilAvailable = canUse($skill[Perpetrate Mild Evil],false) && get_property("_mildEvilPerpetrated").to_int() < 3;
+		// mild evil only can pick pocket. Use it before fire extinguisher
+		if(mildEvilAvailable)
+		{
+			handleTracker(enemy, $skill[Perpetrate Mild Evil], "auto_otherstuff");
+			return useSkill($skill[Perpetrate Mild Evil]);	
+		}
+		if(polarVortexAvailable)
+		{
+			handleTracker(enemy, $skill[Fire Extinguisher: Polar Vortex], "auto_otherstuff");
+			return useSkill($skill[Fire Extinguisher: Polar Vortex]);	
+		}
 	}
 
 	// Actually killing stuff starts here

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -322,6 +322,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		}
 	}
 
+	//yellowray instantly kills the enemy and makes them drop all items they can drop.
 	if(!combat_status_check("yellowray") && auto_wantToYellowRay(enemy, my_location()))
 	{
 		string combatAction = yellowRayCombatString(enemy, true, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains enemy);
@@ -354,25 +355,78 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 
 	if(!combat_status_check("banishercheck") && auto_wantToBanish(enemy, my_location()))
 	{
-		string combatAction = banisherCombatString(enemy, my_location(), true);
-		if(combatAction != "")
+		string banishAction = banisherCombatString(enemy, my_location(), true);
+		if(banishAction != "")
 		{
+			auto_log_info("Looking at banishAction: " + banishAction, "green");
 			combat_status_add("banisher");
-			if(index_of(combatAction, "skill") == 0)
+			if(index_of(banishAction, "skill") == 0)
 			{
-				handleTracker(enemy, to_skill(substring(combatAction, 6)), "auto_banishes");
+				handleTracker(enemy, to_skill(substring(banishAction, 6)), "auto_banishes");
 			}
-			else if(index_of(combatAction, "item") == 0)
+			else if(index_of(banishAction, "item") == 0)
 			{
-				handleTracker(enemy, to_item(substring(combatAction, 5)), "auto_banishes");
+				if(contains_text(banishAction, ", none"))
+				{
+					int commapos = index_of(banishAction, ", none");
+					handleTracker(enemy, to_item(substring(banishAction, 5, commapos)), "auto_banishes");
+				}
+				else
+				{
+					handleTracker(enemy, to_item(substring(banishAction, 5)), "auto_banishes");
+				}
 			}
 			else
 			{
-				auto_log_warning("Unable to track banisher behavior: " + combatAction, "red");
+				auto_log_warning("Unable to track banisher behavior: " + banishAction, "red");
 			}
-			return combatAction;
+			return banishAction;
 		}
+		//we wanted to banish an enemy and failed. set a property so we do not bother trying in subsequent rounds
 		combat_status_add("banishercheck");
+	}
+
+	// Free run from monsters we want to banish but are unable to, or monsters on the free run list
+	if(!combat_status_check("freeruncheck") && (auto_wantToFreeRun(enemy, my_location()) || auto_wantToBanish(enemy, my_location())))
+	{
+		string freeRunAction = freeRunCombatString(enemy, my_location(), true);
+		if(freeRunAction != "")
+		{
+			if (index_of(freeRunAction, "runaway familiar") == 0)
+			{
+				handleTracker(enemy, to_familiar(substring(freeRunAction, 17)), "auto_freeruns");
+				freeRunAction = "runaway";
+			}
+			else if (index_of(freeRunAction, "runaway item") == 0)
+			{
+				handleTracker(enemy, to_item(substring(freeRunAction, 13)), "auto_freeruns");
+				freeRunAction = "runaway";
+			}
+			else if(index_of(freeRunAction, "skill") == 0)
+			{
+				handleTracker(enemy, to_skill(substring(freeRunAction, 6)), "auto_freeruns");
+			}
+			else if(index_of(freeRunAction, "item") == 0)
+			{
+				if(contains_text(freeRunAction, ", none"))
+				{
+					int commapos = index_of(freeRunAction, ", none");
+					handleTracker(enemy, to_item(substring(freeRunAction, 5, commapos)), "auto_freeruns");
+				}
+				else
+				{
+					handleTracker(enemy, to_item(substring(freeRunAction, 5)), "auto_freeruns");
+				}
+			}
+			else
+			{
+				auto_log_warning("Unable to track runaway behavior: " + freeRunAction, "red");
+			}
+			return freeRunAction;
+		}
+
+		//we wanted to free run an enemy and failed. set a property so we do not bother trying in subsequent rounds
+		combat_status_add("freeruncheck");
 	}
 
 	if (!combat_status_check("replacercheck") && auto_wantToReplace(enemy, my_location()))
@@ -584,14 +638,6 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		}
 	}
 
-	if (canUse($item[Tattered Scrap of Paper], false) && have_effect($effect[Everything Looks Green]) == 0)
-	{
-		if($monsters[Bubblemint Twins, Bunch of Drunken Rats, Coaltergeist, Creepy Ginger Twin, Demoninja, Drunk Goat, Drunken Rat, Fallen Archfiend, Hellion, Knob Goblin Elite Guard, L imp, Mismatched Twins, Sabre-Toothed Goat, W imp] contains enemy)
-		{
-			return useItem($item[Tattered Scrap Of Paper]);
-		}
-	}
-
 	if (!combat_status_check("talismanofrenenutet") && canUse($item[Talisman of Renenutet]))
 	{
 		boolean doRenenutet = false;
@@ -682,11 +728,27 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 	{
 		return useItem($item[Short Writ of Habeas Corpus]);
 	}
+	
+	if(canUse($skill[Darts: Aim for the Bullseye]) && have_effect($effect[Everything Looks Red]) == 0 && dartELRcd() <= 40)
+	{
+		set_property("auto_instakillSource", "darts bullseye");
+		set_property("auto_instakillSuccess", true);
+		loopHandlerDelayAll();
+		return useSkill($skill[Darts: Aim for the Bullseye]);
+	}
 
 	// use cosmic bowling ball iotm
 	if(auto_bowlingBallCombatString(my_location(), true) != "")
 	{
 		return 	auto_bowlingBallCombatString(my_location(), false);
+	}
+	
+	// prep parka NC forcing if requested
+	if(canUse($skill[Launch spikolodon spikes]) && get_property("auto_forceNonCombatSource") == "jurassic parka"
+		&& !get_property("auto_parkaSpikesDeployed").to_boolean())
+	{
+		set_property("auto_parkaSpikesDeployed", true);
+		return useSkill($skill[Launch spikolodon spikes]);
 	}
 	
 	if(instakillable(enemy) && !isFreeMonster(enemy,my_location()) && doInstaKill)
@@ -744,6 +806,12 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		}
 
 		return "skill Mild Curse; repeat; ";
+	}
+	
+	//Everfull Dart Holder
+	if(have_equipped($item[Everfull Dart Holster]) && get_property("_dartsLeft").to_int() > 0)
+	{
+		return useSkill(dartSkill(), false);
 	}
 
 	// Actually killing stuff starts here

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -1005,6 +1005,29 @@ boolean wantToForceDrop(monster enemy)
 			forceDrop = true;
 		}
 	}
+	
+	if(isActuallyEd() && my_location() == $location[The Secret Council Warehouse])
+	{
+		int progress = get_property("warehouseProgress").to_int();
+		if(enemy == $monster[Warehouse Guard])
+		{
+			int n_pages = item_amount($item[warehouse map page]);
+			int progress_with_pages = progress+n_pages*8;
+			if (progress_with_pages<39) // need 40 to "win", will get +1 for this combat
+			{
+				forceDrop = true;
+			}
+		}
+		else if(enemy == $monster[Warehouse Clerk])
+		{
+			int n_pages = item_amount($item[warehouse inventory page]);
+			int progress_with_pages = progress+n_pages*8;
+			if (progress_with_pages<39) // need 40 to "win", will get +1 for this combat
+			{
+				forceDrop = true;
+			}
+		}
+	} // ed warehouse
 
 	return forceDrop;
 }

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -754,6 +754,20 @@ int auto_remainingSpeakeasyFreeFights()
 	return max(3 - get_property("_speakeasyFreeFights").to_int(), 0);
 }
 
+boolean speakeasyCombat()
+{
+	if(!auto_hasSpeakEasy())
+	{
+		return false;
+	}
+	
+	if(auto_remainingSpeakeasyFreeFights()>0)
+	{
+		return autoAdv($location[An Unusually Quiet Barroom Brawl]);
+	}
+	return false;
+}
+
 boolean auto_haveTrainSet()
 {
 	return auto_get_campground() contains $item[model train set] && auto_is_valid($item[model train set]); //check if the model train set is in the campground

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -578,9 +578,9 @@ skill ed_nextUpgrade()
 	{
 		return $skill[Another Extra Spleen]; // 10 Ka
 	}
-	else if (!have_skill($skill[Replacement Stomach]))
+	else if (!have_skill($skill[Replacement Liver]))
 	{
-		return $skill[Replacement Stomach]; // 30 Ka
+		return $skill[Replacement Liver]; // 30 Ka
 	}
 	else if (!have_skill($skill[Upgraded Legs]))
 	{
@@ -602,9 +602,9 @@ skill ed_nextUpgrade()
 	{
 		return $skill[Just One More Extra Spleen]; // 25 Ka
 	}
-	else if (!have_skill($skill[Replacement Liver]))
+	else if (!have_skill($skill[Replacement Stomach]))
 	{
-		return $skill[Replacement Liver]; // 30 Ka
+		return $skill[Replacement Stomach]; // 30 Ka
 	}
 	else if (!have_skill($skill[Elemental Wards]))
 	{
@@ -1116,7 +1116,10 @@ boolean L1_ed_islandFallback()
 
 	//track that we are farming Ka as Ed
 	set_property("_auto_farmingKaAsEd", true);
-
+	if (auto_remainingSpeakeasyFreeFights() > 0)
+	{
+		return speakeasyCombat();
+	}
 	if (neverendingPartyAvailable())
 	{
 		return neverendingPartyCombat();
@@ -1448,8 +1451,10 @@ boolean LM_edTheUndying()
 
 	// we should open the manor second floor sooner rather than later as starting the level 11 quest
 	// ruins our pool skill and having delay burning zones open is nice.
-	if (LX_unlockManorSecondFloor() || LX_unlockHauntedLibrary() || LX_unlockHauntedBilliardsRoom(true)) {
-		return true;
+	if(my_level()<11) {
+		if (LX_unlockManorSecondFloor() || LX_unlockHauntedLibrary() || LX_unlockHauntedBilliardsRoom(true)) {
+			return true;
+		}
 	}
 	// as we do hippy side, the war is a 2 Ka quest (excluding sidequests but that shouldn't matter)
 	if (L12_islandWar())
@@ -1470,6 +1475,10 @@ boolean LM_edTheUndying()
 	// Castle zones are all 1 Ka so may as well finish it off
 	if (L10_plantThatBean() || L10_airship() || L10_basement() || L10_ground() || L10_topFloor())
 	{
+		return true;
+	}
+	// If we didn't get the Spookyraven unlock done before level 11, do it now since airship is done and we want more delay zones open
+	if (LX_unlockManorSecondFloor() || LX_unlockHauntedLibrary() || LX_unlockHauntedBilliardsRoom(true)) {
 		return true;
 	}
 	// Smut Orcs are 1 Ka so build the bridge.

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -13,6 +13,10 @@ boolean needStarKey()
 
 boolean needDigitalKey()
 {
+	if(isActuallyEd())
+	{
+		return false;
+	}
 	if(contains_text(get_property("nsTowerDoorKeysUsed"),"digital key"))
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -25,8 +25,17 @@ boolean needDigitalKey()
 	{
 		return false;
 	}
-
+	
 	return true;
+}
+
+boolean need8BitPoints()
+{
+	if(get_property("8BitScore").to_int() >= 10000)
+	{
+		return false;
+	}
+	return needDigitalKey();
 }
 
 int towerKeyCount()


### PR DESCRIPTION
# Description

This PR contains several updates. Most of these directly relate to the Actually Ed path, mostly copy/pasting updates that were made to the main combat scripts into the Ed combat script.

Full list of Ed changes:

- Reorder purchase of organs so Liver is before Stomach now we no longer need semirares, but still need to play pool.
- Move spookyraven down the task order list if we've already hit level 11 (and so no longer get the extra pool skill from having the Staff of Ed)
- Add drop forces/pickpockets (eg Polar Vortex)
- Use pickpockets/forces on Warehouse guards
- Add shadow brick use
- Use lash of the cobra to get shadow bricks
- Add darts use
- Add spikolodon use
- Add free run use
- Use Speakeasy free fights while farming ka

Changes that affect other paths:

- Expands the list of monsters we free run away from, and adds the bowling ball as a source of runaways.
- Adds a function to check if we still need Digital Key points for whether or not 8-bit realm is counted as having "delay".

## How Has This Been Tested?

Many HC runs on a shiny character. 5 Ed runs, 8 in other paths (standard, booze, oxy, wildfire).

Seems to be a drastic reduction in Ed turncount on a fully shiny character (approx 50).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
