### PR TITLE
ZS fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1449,10 +1449,6 @@ boolean isGeneralStoreAvailable()
 	{
 		return false;
 	}
-	if(in_zombieSlayer())
-	{
-		return false;
-	}
 	if(is_werewolf())
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2575,9 +2575,12 @@ boolean woods_questStart()
 	}
 	visit_url("place.php?whichplace=woods");
 	visit_url("place.php?whichplace=forestvillage&action=fv_mystic");
-	visit_url("choice.php?pwd=&whichchoice=664&option=1&choiceform1=Sure%2C+old+man.++Tell+me+all+about+it.");
-	visit_url("choice.php?pwd=&whichchoice=664&option=1&choiceform1=Against+my+better+judgment%2C+yes.");
-	visit_url("choice.php?pwd=&whichchoice=664&option=1&choiceform1=Er,+sure,+I+guess+so...");
+	if (!in_zombieSlayer())
+	{
+		visit_url("choice.php?pwd=&whichchoice=664&option=1&choiceform1=Sure%2C+old+man.++Tell+me+all+about+it.");
+		visit_url("choice.php?pwd=&whichchoice=664&option=1&choiceform1=Against+my+better+judgment%2C+yes.");
+		visit_url("choice.php?pwd=&whichchoice=664&option=1&choiceform1=Er,+sure,+I+guess+so...");
+	}
 	if(knoll_available())
 	{
 		visit_url("place.php?whichplace=knoll_friendly&action=dk_innabox");

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -222,5 +222,11 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 	{
 		return useSkill($skill[Toss], false);
 	}
+	
+	if (canUse($skill[Plague Claws]), false)
+	{
+		return useSkill($skill[Plague Claws], false);
+	}
+	
 	return "attack with weapon";
 }

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -223,7 +223,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Toss], false);
 	}
 	
-	if (canUse($skill[Plague Claws]), false))
+	if (canUse($skill[Plague Claws], false))
 	{
 		return useSkill($skill[Plague Claws], false);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -223,7 +223,7 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Toss], false);
 	}
 	
-	if (canUse($skill[Plague Claws]), false)
+	if (canUse($skill[Plague Claws]), false))
 	{
 		return useSkill($skill[Plague Claws], false);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_zombie_slayer.ash
@@ -44,9 +44,14 @@ string auto_combatZombieSlayerStage3(int round, monster enemy, string text)
 		return "";
 	}
 
-	if(canUse($skill[Infectious Bite]) && zombieSlayer_canInfect(enemy) && canSurvive(4.0))
+	if(canUse($skill[Infectious Bite]) && canSurvive(4.0))
 	{
 		return useSkill($skill[Infectious Bite]);
+	}
+	
+	if(canUse($skill[Meat Shields]) && enemy.boss && canSurvive(4.0))
+	{
+		return useSkill($skill[Meat Shields]);
 	}
 
 	// Just always use Bear-ly Legal for the delevel + meat, unless we want to Bear Hug or Kodiak Moment

--- a/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
@@ -186,10 +186,10 @@ boolean zombieSlayer_acquireHP(int goal)
 
 	int missingHP = goal - my_hp();
 
-	// Devour Minions if you need at least 4 casts of Bite Minion
+	// Devour Minions if you need at least 4 casts of Bite Minion or if doing the Hidden Apartment Building
 	if (auto_have_skill($skill[Devour Minions]))
 	{
-		while (missingHP > floor(my_maxhp() * 0.3) && zombieSlayer_acquireMP(mp_cost($skill[Devour Minions])))
+		while ((missingHP > floor(my_maxhp() * 0.3) || ((have_effect($effect[Thrice-Cursed]) > 0 || have_effect($effect[Twice-Cursed]) > 0 || have_effect($effect[Once-Cursed]) > 0) && !(internalQuestStatus("questL11Curses") > 1 || item_amount($item[Moss-Covered Stone Sphere]) > 0))) && zombieSlayer_acquireMP(mp_cost($skill[Devour Minions])))
 		{
 			use_skill(1, $skill[Devour Minions]);
 			if (my_hp() >= goal) break;

--- a/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/paths/zombie_slayer.ash
@@ -165,7 +165,7 @@ boolean zombieSlayer_acquireMP(int goal, int meat_reserve)
 		return false;
 	}
 
-	if (my_hp() >= goal) return true;
+	if (my_mp() >= goal) return true;
 
 	return lureMinions(goal) || summonMinions(goal, meat_reserve);
 }

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -550,7 +550,7 @@ void hauntedBedroomChoiceHandler(int choice, string[int] options)
 	else if(choice == 878) // One Ornate Nightstand (The Haunted Bedroom)
 	{
 		boolean needSpectacles = !possessEquipment($item[Lord Spookyraven\'s Spectacles]) && internalQuestStatus("questL11Manor") < 2;
-		if(is_boris() || in_wotsf() || (in_zombieSlayer() && in_hardcore()) || (in_nuclear() && in_hardcore()))
+		if(is_boris() || in_wotsf() || (in_nuclear() && in_hardcore()))
 		{
 			needSpectacles = false;
 		}
@@ -620,7 +620,7 @@ boolean LX_getLadySpookyravensFinestGown() {
 	// Might not be worth it since we need to fight ornate nightstands for the spectacles and camera
 	boolean needSpectacles = !possessEquipment($item[Lord Spookyraven\'s Spectacles]) && internalQuestStatus("questL11Manor") < 2;
 	boolean needCamera = (item_amount($item[disposable instant camera]) == 0 && internalQuestStatus("questL11Palindome") < 1);
-	if (is_boris() || in_wotsf() || (in_zombieSlayer() && in_hardcore()) || (in_nuclear() && in_hardcore())) {
+	if (is_boris() || in_wotsf() || (in_nuclear() && in_hardcore())) {
 		needSpectacles = false;
 	}
 	else if(needCamera && needSpectacles) {
@@ -2315,7 +2315,7 @@ boolean L11_mauriceSpookyraven()
 		}
 	}
 
-	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || in_zombieSlayer() || in_wotsf() || in_bhy() || in_robot() || (in_nuclear() && !get_property("auto_haveoven").to_boolean()))
+	if(!possessEquipment($item[Lord Spookyraven\'s Spectacles]) || is_boris() || in_wotsf() || in_bhy() || in_robot() || (in_nuclear() && !get_property("auto_haveoven").to_boolean()))
 	{
 		auto_log_warning("Alternate fulminate pathway... how sad :(", "red");
 		# I suppose we can let anyone in without the Spectacles.

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1179,7 +1179,14 @@ boolean L12_gremlins()
 	{
 		return false;
 	}
-	if(in_glover())
+	if (in_zombieSlayer())
+	{
+		if(!auto_have_skill($skill[Plague Claws]) && item_amount($item[Seal Tooth]) == 0)
+		{
+			return false;
+		}
+	}
+	else if(in_glover())
 	{
 		int need = 30 - item_amount($item[Doc Galaktik\'s Pungent Unguent]);
 		if((need > 0) && (item_amount($item[Molybdenum Pliers]) == 0))

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1484,6 +1484,11 @@ boolean L13_towerNSTower()
 			autoEquip($item[Meat Tenderizer is Murder]);
 		}
 
+		if(in_zombieSlayer())
+		{
+			acquireMP(30,0);
+		}
+
 		acquireHP();
 		autoAdvBypass("place.php?whichplace=nstower&action=ns_06_monster2", $location[Noob Cave]);
 		return true;

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -260,7 +260,7 @@ boolean LX_islandAccess()
 		return false;
 	}
 
-	if(in_lowkeysummer() || in_zombieSlayer())
+	if(in_lowkeysummer())
 	{
 		return LX_hippyBoatman();
 	}


### PR DESCRIPTION
# Description
misc Zombie Slayer changes

# Fixes  (issue)
-enable the use of the General Store to avoid having to get the junk junk/mortar-dissolving solution
-don't abort after getting the continuum transfunctioner
-stasis gremlins with Plague Claws
-don't cast Bite Minion if it would remove Thrice-Cursed and we're not done with the quest
-fix typo in zombieSlayer_acquireMP()
-try to handle the Wall of Meat/monsters that can't become zombies

## How Has This Been Tested?
I've done 2 ZS ascensions with the current version of the script, running it after spending the first ~80 turns getting the ZS photo booth prop. The Wall of Meat requires Meat Shields, so that change probably doesn't work at low progression and with no trainset.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
