### PR TITLE
More Bat Wings Support

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -1,7 +1,7 @@
 pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed;prop:hiddenApartmentProgress<7
 Writing Desk	prop:writingDesksDefeated<4
 cabinet of Dr. Limpieza
-Dairy Goat	loc:The Goatlet
+Dairy Goat	loc:The Goatlet;item:goat cheese<3
 Pygmy Bowler
 Pygmy Witch Surgeon
 pygmy witch accountant	loc:The Hidden Office Building

--- a/BUILD/restoration/skill.dat
+++ b/BUILD/restoration/skill.dat
@@ -4,3 +4,4 @@ Shake it Off	ALL	0	0	0	All Negative	none
 Gelatinous Reconstruction	13	0	0	0	Beaten Up	none
 Disco Nap	20	0	0	0	none	none
 Lasagna Bandages	20	0	0	0	none	none
+Rest Upside Down	1000	1000	0	0	none	none

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -131,7 +131,7 @@ replace	34	trendy bugbear chef	path:Bugbear Invasion;loc:Galley
 sniff	0	pygmy shaman	loc:The Hidden Apartment Building;!effect:Thrice-Cursed;prop:hiddenApartmentProgress<7
 sniff	1	Writing Desk	prop:writingDesksDefeated<4
 sniff	2	cabinet of Dr. Limpieza
-sniff	3	Dairy Goat	loc:The Goatlet
+sniff	3	Dairy Goat	loc:The Goatlet;item:goat cheese<3
 sniff	4	Pygmy Bowler
 sniff	5	Pygmy Witch Surgeon
 sniff	6	pygmy witch accountant	loc:The Hidden Office Building

--- a/RELEASE/data/autoscend_restoration.txt
+++ b/RELEASE/data/autoscend_restoration.txt
@@ -117,4 +117,5 @@ skill	2	Shake it Off	ALL	0	0	0	All Negative	none
 skill	3	Gelatinous Reconstruction	13	0	0	0	Beaten Up	none
 skill	4	Disco Nap	20	0	0	0	none	none
 skill	5	Lasagna Bandages	20	0	0	0	none	none
+skill	6	Rest Upside Down	1000	1000	0	0	none	none
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28077;	// feat: various iotm improvements
+since r28084;	// feat: make bat wings rest always available
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -813,7 +813,7 @@ int handlePulls(int day)
 	}
 
 	// do this regardless of day if we still need to complete the bridge.
-	if (canPull($item[smut orc keepsake box]) && lumberCount() < 26 && fastenerCount() < 26)
+	if (canPull($item[smut orc keepsake box]) && (lumberCount() + 5 <= bridgeGoal()) && (fastenerCount() + 5 <= bridgeGoal()))
 	{
 		if (pullXWhenHaveY($item[smut orc keepsake box], 1, 0))
 		{

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -844,10 +844,10 @@ boolean LX_craftAcquireItems()
 			cli_execute("make 1 snow cleats");
 		}
 
-		if((item_amount($item[snow berries]) > 0) && (my_daycount() > 1) && (get_property("chasmBridgeProgress").to_int() >= 30) && (my_level() >= 9))
+		if((item_amount($item[snow berries]) > 0) && (my_daycount() > 1) && (get_property("chasmBridgeProgress").to_int() >= bridgeGoal()) && (my_level() >= 9))
 		{
 			visit_url("place.php?whichplace=orc_chasm");
-			if(get_property("chasmBridgeProgress").to_int() >= 30)
+			if(get_property("chasmBridgeProgress").to_int() >= bridgeGoal())
 			{
 				#if(in_hardcore() && isGuildClass())
 				if(isGuildClass())

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -188,6 +188,10 @@ boolean auto_run_choice(int choice, string page)
 			{
 				run_choice(4); // get the model airship
 			}
+			else if (options contains 6)
+			{
+				run_choice(6); // advance immateria quest
+			}
 			else if (options contains 5)
 			{
 				run_choice(5); // get titanium umbrella, metallic A, SGEEA and a penultimate fantasy chest

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -813,16 +813,7 @@ void finalizeMaximize(boolean speculative)
 
 	if(auto_haveBatWings() && get_property("_batWingsFreeFights").to_int() < 5)
 	{
-		if(!nextMonsterIsFree)
-		{
-			addBonusToMaximize($item[bat wings], 200); // get the 5 free fights
-		}
-		else
-		{
-			// bat wings free fights can get swallowed by some free fights
-			// a doubly free fight doesn't help
-			addToMaximize("-equip " + $item[bat wings].to_string());
-		}
+		addBonusToMaximize($item[bat wings], 200); // get the 5 free fights
 	}
 
 	// We still need pixels in KoE, badly.

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -821,7 +821,7 @@ void finalizeMaximize(boolean speculative)
 		{
 			// bat wings free fights can get swallowed by some free fights
 			// a doubly free fight doesn't help
-			addBonusToMaximize($item[bat wings], -200);
+			addToMaximize("-equip " + $item[bat wings].to_string());
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -810,6 +810,21 @@ void finalizeMaximize(boolean speculative)
 			addBonusToMaximize($item[spring shoes], 50);
 		}
 	}
+
+	if(auto_haveBatWings() && get_property("_batWingsFreeFights").to_int() < 5)
+	{
+		if(!nextMonsterIsFree)
+		{
+			addBonusToMaximize($item[bat wings], 200); // get the 5 free fights
+		}
+		else
+		{
+			// bat wings free fights can get swallowed by some free fights
+			// a doubly free fight doesn't help
+			addBonusToMaximize($item[bat wings], -200);
+		}
+	}
+
 	// We still need pixels in KoE, badly.
 	if(in_koe() && auto_hasPowerfulGlove())
 	{

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -521,7 +521,6 @@ boolean auto_pre_adventure()
 	{
 		// only here to get immateria. Get it faster with bat wings
 		autoEquip($item[Bat Wings]);
-		abort("test airship NC");
 	}
 
 

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -517,6 +517,13 @@ boolean auto_pre_adventure()
 		addBonusToMaximize(exting, 200); // extinguisher prevents per-round hot damage in wildfire path 
 	}
 
+	if(place == $location[The Penultimate Fantasy Airship] && auto_haveBatWings())
+	{
+		// only here to get immateria. Get it faster with bat wings
+		autoEquip($item[Bat Wings]);
+		abort("test airship NC");
+	}
+
 
 	if(in_plumber())
 	{

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -677,7 +677,14 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		}
 		else if(metadata.type == "skill")
 		{
-			available = floor(get_value("mp_starting") / mp_cost(to_skill(metadata.name)));
+			if(to_skill(metadata.name).dailylimit != -1)
+			{
+				available = to_skill(metadata.name).dailylimit;
+			}
+			else
+			{
+				available = floor(get_value("mp_starting") / mp_cost(to_skill(metadata.name)));
+			}
 		}
 		else if(metadata.name == __HOT_TUB)
 		{
@@ -955,6 +962,10 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		if(metadata.type == "skill")
 		{
 			skill s = to_skill(metadata.name);
+			if(s.dailylimit != -1)
+			{
+				return s.dailylimit > 0;
+			}
 			if(my_maxmp() >= mp_cost(s))
 			{
 				return true;

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -677,13 +677,19 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 		}
 		else if(metadata.type == "skill")
 		{
-			if(to_skill(metadata.name).dailylimit != -1)
+			int dailyLimit = to_skill(metadata.name).dailylimit;
+			int mpCost = mp_cost(to_skill(metadata.name));
+			if(dailyLimit != -1 && mpCost > 0)
 			{
-				available = to_skill(metadata.name).dailylimit;
+				available = min(dailyLimit, floor(get_value("mp_starting") / mpCost));
+			}
+			else if(dailyLimit != -1)
+			{
+				available = dailyLimit;
 			}
 			else
 			{
-				available = floor(get_value("mp_starting") / mp_cost(to_skill(metadata.name)));
+				available = floor(get_value("mp_starting") / mpCost);
 			}
 		}
 		else if(metadata.name == __HOT_TUB)

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -173,7 +173,7 @@ generic_t zone_needItem(location loc)
 		value = 20.0;
 		break;
 	case $location[The Smut Orc Logging Camp]:
-		if(get_property("chasmBridgeProgress").to_int() < 30)
+		if(get_property("chasmBridgeProgress").to_int() < bridgeGoal())
 		{
 			value = 10.0;
 		}
@@ -870,7 +870,7 @@ generic_t zone_delay(location loc)
 		}
 		break;
 	case $location[The Smut Orc Logging Camp]:
-		if (shenZones contains loc && get_property("chasmBridgeProgress").to_int() >= 30)
+		if (shenZones contains loc && get_property("chasmBridgeProgress").to_int() >= bridgeGoal())
 		{
 			value = 3 - (loc.turns_spent - shenZones[loc]);
 		}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -568,6 +568,7 @@ boolean auto_MayamClaimBelt();
 boolean auto_MayamClaimWhatever();
 boolean auto_MayamClaimAll();
 boolean auto_haveRoman();
+boolean auto_haveBatWings();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1082,6 +1082,7 @@ boolean L8_trapperQuest();
 boolean LX_loggingHatchet();
 boolean L9_leafletQuest();
 void L9_chasmMaximizeForNoncombat();
+int bridgeGoal();
 int fastenerCount();
 int lumberCount();
 boolean finishBuildingSmutOrcBridge();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -569,7 +569,7 @@ boolean auto_MayamClaimWhatever();
 boolean auto_MayamClaimAll();
 boolean auto_haveRoman();
 boolean auto_haveBatWings();
-boolean canLeapBridge();
+boolean auto_canLeapBridge();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -569,6 +569,7 @@ boolean auto_MayamClaimWhatever();
 boolean auto_MayamClaimAll();
 boolean auto_haveRoman();
 boolean auto_haveBatWings();
+boolean canLeapBridge();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -284,7 +284,7 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 	
 	# Instakill handler
 	boolean couldInstaKill = true;
-	if($monsters[Smut Orc Pipelayer,Smut Orc Jacker,Smut Orc Screwer,Smut Orc Nailer] contains enemy && get_property("chasmBridgeProgress").to_int() < 30)
+	if($monsters[Smut Orc Pipelayer,Smut Orc Jacker,Smut Orc Screwer,Smut Orc Nailer] contains enemy && get_property("chasmBridgeProgress").to_int() < bridgeGoal())
 	{
 		//want to do cold damage in stage3
 		if(my_adventures() > 6)

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -177,7 +177,14 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 	{
 		boolean polarVortexAvailable = canUse($skill[Fire Extinguisher: Polar Vortex], false) && auto_fireExtinguisherCharges() > 10;
 		boolean mildEvilAvailable = canUse($skill[Perpetrate Mild Evil],false) && get_property("_mildEvilPerpetrated").to_int() < 3;
-		// mild evil only can pick pocket. Use it before fire extinguisher
+		boolean swoopAvailable = canUse($skill[Swoop like a Bat], true) && get_property("_batWingsSwoopUsed").to_int() < 11;
+
+		// mild evil and swoop can only pick pocket. Use them before fire extinguisher
+		if(swoopAvailable)
+		{
+			handleTracker(enemy, $skill[Swoop like a Bat], "auto_otherstuff");
+			return useSkill($skill[Swoop like a Bat]);	
+		}
 		if(mildEvilAvailable)
 		{
 			handleTracker(enemy, $skill[Perpetrate Mild Evil], "auto_otherstuff");

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -356,7 +356,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			}
 		}
 
-		if(my_location() == $location[The Smut Orc Logging Camp] && canSurvive(1.0) && get_property("chasmBridgeProgress").to_int() < 30)
+		if(my_location() == $location[The Smut Orc Logging Camp] && canSurvive(1.0) && get_property("chasmBridgeProgress").to_int() < bridgeGoal())
 		{
 			boolean coldMortarShell = canUse($skill[Stuffed Mortar Shell]) && have_effect($effect[Spirit of Peppermint]) != 0;
 			skill coldSkillToUse;

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -956,6 +956,7 @@ boolean wantToForceDrop(monster enemy)
 	//skills that can be used on any combat round, repeatedly until an item is stolen
 	//take into account if a yellow ray has been used. Must have been one that doesn't insta-kill
 	boolean mildEvilAvailable = canUse($skill[Perpetrate Mild Evil],false) && get_property("_mildEvilPerpetrated").to_int() < 3;
+	boolean swoopAvailable = canUse($skill[Swoop like a Bat], true) && get_property("_batWingsSwoopUsed").to_int() < 11;
 
 	boolean forceDrop = false;
 
@@ -979,7 +980,7 @@ boolean wantToForceDrop(monster enemy)
 
 	// polar vortex/mild evil is more likely to pocket an item the higher the drop rate. Unlike XO which has equal chance for all drops
 	// reserve extinguisher 30 charge for filth worms
-	if(auto_fireExtinguisherCharges() > 20 || mildEvilAvailable)
+	if(auto_fireExtinguisherCharges() > 20 || mildEvilAvailable || swoopAvailable)
 	{
 		int dropsFromYR = 0;
 		if(combat_status_check("yellowray"))

--- a/RELEASE/scripts/autoscend/iotms/mr2014.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2014.ash
@@ -69,12 +69,12 @@ boolean considerGrimstoneGolem(boolean bjornCrown)
 		return false;
 	}
 
-	if((get_property("desertExploration").to_int() >= 70) && (get_property("chasmBridgeProgress").to_int() >= 29))
+	if((get_property("desertExploration").to_int() >= 70) && (get_property("chasmBridgeProgress").to_int() >= (bridgeGoal() - 1)))
 	{
 		return false;
 	}
 
-	if(get_property("chasmBridgeProgress").to_int() >= 29)
+	if(get_property("chasmBridgeProgress").to_int() >= (bridgeGoal() - 1))
 	{
 		if(!get_property("auto_grimstoneOrnateDowsingRod").to_boolean())
 		{
@@ -407,7 +407,7 @@ boolean LX_ornateDowsingRod()
 
 boolean fancyOilPainting()
 {
-	if(get_property("chasmBridgeProgress").to_int() >= 30)
+	if(get_property("chasmBridgeProgress").to_int() >= bridgeGoal())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -809,7 +809,7 @@ string auto_FireExtinguisherCombatString(location place)
 		return "skill " + $skill[Fire Extinguisher: Zone Specific];
 	}
 
-	if(place == $location[The Smut Orc Logging Camp] && !get_property("fireExtinguisherChasmUsed").to_boolean() && get_property("chasmBridgeProgress").to_int() < 30 && !auto_hasAutumnaton())
+	if(place == $location[The Smut Orc Logging Camp] && !get_property("fireExtinguisherChasmUsed").to_boolean() && get_property("chasmBridgeProgress").to_int() < bridgeGoal() && !auto_hasAutumnaton())
 	{
 		return "skill " + $skill[Fire Extinguisher: Zone Specific];
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -358,3 +358,12 @@ boolean auto_haveRoman()
 	}
 	return false;
 }
+
+boolean auto_haveBatWings()
+{
+	if(auto_is_valid($item[Bat Wings]) && possessEquipment($item[Bat Wings]))
+	{
+		return true;
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -367,3 +367,21 @@ boolean auto_haveBatWings()
 	}
 	return false;
 }
+
+boolean canLeapBridge()
+{
+	// bat wings allow for us to leap bridge at 5/6 progress (25 of 30)
+	if(!auto_haveBatWings())
+	{
+		return false;
+	}
+	if(fastenerCount() < 25)
+	{
+		return false;
+	}
+	if(lumberCount() < 25)
+	{
+		return false;
+	}
+	return true;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -368,7 +368,7 @@ boolean auto_haveBatWings()
 	return false;
 }
 
-boolean canLeapBridge()
+boolean auto_canLeapBridge()
 {
 	// bat wings allow for us to leap bridge at 5/6 progress (25 of 30)
 	if(!auto_haveBatWings())

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -375,11 +375,7 @@ boolean auto_canLeapBridge()
 	{
 		return false;
 	}
-	if(fastenerCount() < 25)
-	{
-		return false;
-	}
-	if(lumberCount() < 25)
+	if(fastenerCount() < 25 || lumberCount() < 25)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
+++ b/RELEASE/scripts/autoscend/paths/license_to_adventure.ash
@@ -93,7 +93,7 @@ boolean bond_buySkills()
 				points -= 1;
 			}
 		}
-		else if(!get_property("bondBridge").to_boolean() && (get_property("chasmBridgeProgress").to_int() < 28))
+		else if(!get_property("bondBridge").to_boolean() && (get_property("chasmBridgeProgress").to_int() < (bridgeGoal() - 2)))
 		{
 			if(points >= 3)
 			{

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -308,7 +308,7 @@ boolean LX_findHelpfulLowKey()
 	}
 
 	// cold spell damage before orcs. Ice Key needs The Icy Peak access
-	if (internalQuestStatus("questL09Topping") == 0 && get_property("chasmBridgeProgress").to_int() < 30)
+	if (internalQuestStatus("questL09Topping") == 0 && get_property("chasmBridgeProgress").to_int() < bridgeGoal())
 	{
 		if (lowkey_keyAdv($item[Ice Key])) { return true; }
 	}

--- a/RELEASE/scripts/autoscend/paths/you_robot.ash
+++ b/RELEASE/scripts/autoscend/paths/you_robot.ash
@@ -1323,7 +1323,7 @@ void robot_directive()
 	boolean desert_ready = internalQuestStatus("questL11Desert") == 0;
 	boolean desert_done = internalQuestStatus("questL11Desert") > 0;
 	boolean chasm_offhand_slot_needed = possessEquipment($item[Loadstone]) || canPull($item[Loadstone]);
-	boolean chasm_ready = internalQuestStatus("questL09Topping") == 0 && get_property("chasmBridgeProgress").to_int() < 30 && !shenShouldDelayZone($location[The Smut Orc Logging Camp]);
+	boolean chasm_ready = internalQuestStatus("questL09Topping") == 0 && get_property("chasmBridgeProgress").to_int() < bridgeGoal() && !shenShouldDelayZone($location[The Smut Orc Logging Camp]);
 	boolean chasm_done = internalQuestStatus("questL09Topping") > 0;
 	
 	if(directive == "chasm" && chasm_done)

--- a/RELEASE/scripts/autoscend/quests/level_04.ash
+++ b/RELEASE/scripts/autoscend/quests/level_04.ash
@@ -20,7 +20,7 @@ boolean L4_batCave()
 
 	auto_log_info("In the bat hole!", "blue");
 
-	if (possessEquipment($item[bat wings]) && auto_can_equip($item[bat wings]))
+	if (auto_haveBatWings())
 	{
 		if (!get_property("batWingsBatHoleEntrance").to_boolean() && zone_available($location[The Bat Hole Entrance]))
 		{

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -996,7 +996,8 @@ boolean L9_highLandlord()
 	{
 		return false;
 	}
-	if(get_property("chasmBridgeProgress").to_int() < 30)
+	if(get_property("chasmBridgeProgress").to_int() < 30 && !auto_haveBatWings() ||
+		get_property("chasmBridgeProgress").to_int() < 25 && auto_haveBatWings())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -160,7 +160,7 @@ boolean finishBuildingSmutOrcBridge()
 	visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 
 	// finish chasm if we can
-	if(canLeapBridge())
+	if(auto_canLeapBridge())
 	{
 		autoForceEquip($item[bat wings]);
 		visit_url("place.php?whichplace=orc_chasm&action=bridge_jump");

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -120,6 +120,11 @@ void L9_chasmMaximizeForNoncombat()
 	}
 }
 
+int bridgeGoal()
+{
+	return (!auto_haveBatWings() ? 30 : 25);
+}
+
 int fastenerCount()
 {
 	int base = get_property("chasmBridgeProgress").to_int();
@@ -144,7 +149,7 @@ int lumberCount()
 
 boolean finishBuildingSmutOrcBridge()
 {
-	if (internalQuestStatus("questL09Topping") != 0 || get_property("chasmBridgeProgress").to_int() >= 30)
+	if (internalQuestStatus("questL09Topping") != 0 || get_property("chasmBridgeProgress").to_int() >= bridgeGoal())
 	{
 		return false;
 	}
@@ -180,7 +185,7 @@ boolean finishBuildingSmutOrcBridge()
 void prepareForSmutOrcs()
 {
 
-	if(lumberCount() >= 30 && fastenerCount() >= 30)
+	if(lumberCount() >= bridgeGoal() && fastenerCount() >= bridgeGoal())
 	{
 		// must be here for shen snake and quest objective is already done
 		// set blech NC and don't bother prepping for the zone
@@ -277,11 +282,11 @@ void prepareForSmutOrcs()
 			}
 		}
 
-		if(fastenerCount() < 30)
+		if(fastenerCount() < bridgeGoal())
 		{
 			autoEquip($item[Loadstone]);
 		}
-		if(lumberCount() < 30)
+		if(lumberCount() < bridgeGoal())
 		{
 			autoEquip($item[Logging Hatchet]);
 		}
@@ -289,7 +294,7 @@ void prepareForSmutOrcs()
 		return;
 	}
 
-	int need = (30 - get_property("chasmBridgeProgress").to_int()) / 5;
+	int need = (bridgeGoal() - get_property("chasmBridgeProgress").to_int()) / 5;
 	if(need > 0)
 	{
 		while((need > 0) && (item_amount($item[Snow Berries]) >= 2))
@@ -300,13 +305,13 @@ void prepareForSmutOrcs()
 		}
 	}
 
-	if (get_property("chasmBridgeProgress").to_int() < 30)
+	if (get_property("chasmBridgeProgress").to_int() < bridgeGoal())
 	{
-		if(fastenerCount() < 30)
+		if(fastenerCount() < bridgeGoal())
 		{
 			autoEquip($item[Loadstone]);
 		}
-		if(lumberCount() < 30)
+		if(lumberCount() < bridgeGoal())
 		{
 			autoEquip($item[Logging Hatchet]);
 		}
@@ -317,7 +322,7 @@ void prepareForSmutOrcs()
 
 boolean L9_chasmBuild()
 {
-	if (internalQuestStatus("questL09Topping") != 0 || get_property("chasmBridgeProgress").to_int() >= 30)
+	if (internalQuestStatus("questL09Topping") != 0 || get_property("chasmBridgeProgress").to_int() >= bridgeGoal())
 	{
 		return false;
 	}
@@ -337,7 +342,7 @@ boolean L9_chasmBuild()
 		return false;	//delay for You, Robot path
 	}
 	if(auto_hasAutumnaton() && !isAboutToPowerlevel() && $location[The Smut Orc Logging Camp].turns_spent > 0 
-		&& (fastenerCount() < 30 || lumberCount() < 30))
+		&& (fastenerCount() < bridgeGoal() || lumberCount() < bridgeGoal()))
 	{
 		// delay zone to allow autumnaton to grab bridge parts
 		// unless we have ran out of other stuff to do
@@ -902,7 +907,7 @@ boolean L9_oilPeak()
 		{
 			return false;
 		}
-		else if(item_amount($item[Bubblin' Crude]) >= 12)
+		else if(item_amount($item[Bubblin\' Crude]) >= 12)
 		{
 			if(in_glover())
 			{
@@ -923,7 +928,7 @@ boolean L9_oilPeak()
 					}
 				}
 			}
-			else if(auto_is_valid($item[Bubblin' Crude]) && creatable_amount($item[Jar Of Oil]) > 0)
+			else if(auto_is_valid($item[Bubblin\' Crude]) && creatable_amount($item[Jar Of Oil]) > 0)
 			{
 				create(1, $item[Jar Of Oil]);
 			}
@@ -996,8 +1001,7 @@ boolean L9_highLandlord()
 	{
 		return false;
 	}
-	if(get_property("chasmBridgeProgress").to_int() < 30 && !auto_haveBatWings() ||
-		get_property("chasmBridgeProgress").to_int() < 25 && auto_haveBatWings())
+	if(get_property("chasmBridgeProgress").to_int() < bridgeGoal())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -163,6 +163,7 @@ boolean finishBuildingSmutOrcBridge()
 	if(canLeapBridge())
 	{
 		autoForceEquip($item[bat wings]);
+		visit_url("place.php?whichplace=orc_chasm&action=bridge_jump");
 		visit_url("place.php?whichplace=highlands&action=highlands_dude");
 		return true;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_09.ash
+++ b/RELEASE/scripts/autoscend/quests/level_09.ash
@@ -160,6 +160,12 @@ boolean finishBuildingSmutOrcBridge()
 	visit_url("place.php?whichplace=orc_chasm&action=bridge"+(to_int(get_property("chasmBridgeProgress"))));
 
 	// finish chasm if we can
+	if(canLeapBridge())
+	{
+		autoForceEquip($item[bat wings]);
+		visit_url("place.php?whichplace=highlands&action=highlands_dude");
+		return true;
+	}
 	if(get_property("chasmBridgeProgress").to_int() >= 30)
 	{
 		visit_url("place.php?whichplace=highlands&action=highlands_dude");


### PR DESCRIPTION
# Description

1. Bonus to maximizer if have free fights left
2. Equip bat wings at airship
3. Leap the smut bridge
4. Add rest upside down as a restore option
5. Swoop pickpocket
6. Bonus - only sniff dairy goat if we need cheese still

## How Has This Been Tested?

Standard run
Test status:
- [x] free fight maximizer bonus 
- [x] airship
- [x] bridge
- [x] rest
- [x] swoop

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
