### PR TITLE
feat: never stun tool gremlins, and don't stasis them either

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28084;	// feat: make bat wings rest always available
+since r28092;	// feat: add 'avoid attack' modifier
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_quest.ash
@@ -57,34 +57,9 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		return useItem($item[Molybdenum Magnet]);
 	}
 
-	if (canUse($skill[Curse Of Weaksauce]))
-	{
-		return useSkill($skill[Curse Of Weaksauce]);
-	}
-
-	if (canUse($skill[Curse Of The Marshmallow]))
-	{
-		return useSkill($skill[Curse Of The Marshmallow]);
-	}
-
 	if (canUse($skill[Summon Love Scarabs]))
 	{
 		return useSkill($skill[Summon Love Scarabs]);
-	}
-
-	if (canUse($skill[Summon Love Gnats]))
-	{
-		return useSkill($skill[Summon Love Gnats]);
-	}
-	
-	if(canUse($skill[Beanscreen]))
-	{
-		return useSkill($skill[Beanscreen]);
-	}
-
-	if(canUse($skill[Bad Medicine]))
-	{
-		return useSkill($skill[Bad Medicine]);
 	}
 
 	if(canUse($skill[Good Medicine]) && canSurvive(2.1))
@@ -142,20 +117,11 @@ string auto_JunkyardCombatHandler(int round, monster enemy, string text)
 		}
 	}
 	
-	if (get_property("auto_gremlinMoly").to_boolean() && !canSurvive(20) && !stunned && !staggeringFlyer)	//don't flyer tool gremlins if it's dangerous to survive them for long
+	if (get_property("auto_gremlinMoly").to_boolean())	//don't ever stun tool gremlins
 	{
-		if(monster_attack() > ( my_buffedstat($stat[moxie]) + 10) && !canSurvive(10) && haveUsed($skill[Curse Of Weaksauce]))
-		{
-			//if after all deleveling it's still too strong to safely stasis let weaksauce delevel it more in exchange for a few turns
-			//except if stuck with an attack familiar or unforeseen passive damage effects that can kill the gremlin
-			if(!gremlinTakesDamage && round < 10 && stunner != $skill[none])
-			{
-				combat_status_add("stunned");
-				return useSkill(stunner);
-			}
-		}
+		stunner = $skill[none];
 	}
-	else if (canUse(flyer) && get_property("flyeredML").to_int() < 10000 && !get_property("auto_ignoreFlyer").to_boolean())
+	if (canUse(flyer) && get_property("flyeredML").to_int() < 10000 && !get_property("auto_ignoreFlyer").to_boolean())
 	{
 		if(!staggeringFlyer && stunner != $skill[none] && !stunned)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1268,7 +1268,7 @@ boolean L12_gremlins()
 
 	auto_log_info("Doing them gremlins", "blue");
 	// ideally we want to survive a single attack
-	addToMaximize("20dr,1da 1000max,-ml,-100avoid attack");
+	addToMaximize("20dr,1da 1000max,-ml,-1000avoid attack");
 	acquireHP();
 	if(!bat_wantHowl($location[over where the old tires are]))
 	{

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1267,7 +1267,8 @@ boolean L12_gremlins()
 	gremlinsFamiliar();
 
 	auto_log_info("Doing them gremlins", "blue");
-	addToMaximize("20dr,1da 1000max,3hp,-3ml");
+	// ideally we want to survive a single attack
+	addToMaximize("20dr,1da 1000max,-ml,-100avoid attack");
 	acquireHP();
 	if(!bat_wantHowl($location[over where the old tires are]))
 	{


### PR DESCRIPTION
# Description

After the gremlins change, they no longer need to be stasised, so change the code accordingly. Don't buff HP or value -ml too heavily because we only need to survive one hit (unless it's a crit).

Also never stun tool gremlins to try to finish the fight ASAP. It's possible we should only not stun if we have an attacking familiar or passive damage, but given we are minimizing ML the additional flyer bonus is not going to be significant.

## How Has This Been Tested?

Did some runs. Autoscend gets the jump on the gremlins, flyers, then magnets them. Player took 3 damage from flyering, so I'm not concerned about survivability.

At lower skill levels it should either fail to get the jump and magnet immediately, or flyer if survivable then magnet. I'm happy with this.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
