### PR TITLE
fix: clear portscan counter when encountering agent

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat.ash
@@ -41,6 +41,7 @@ void auto_combatInitialize(int round, monster enemy, string text)
 	{
 		case $monster[Government Agent]:
 			set_property("_portscanPending", false);
+			stop_counter("portscan.edu");
 			break;
 		case $monster[possessed wine rack]:
 			set_property("auto_wineracksencountered", get_property("auto_wineracksencountered").to_int() + 1);


### PR DESCRIPTION
# Description

Without this change, after completing an ascension there can be portscan counters left over. I assume this happens when an agent is encountered in a "special" way and this is the right fix, but it might not be.

## How Has This Been Tested?

Many runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
