### PR TITLE
Update auto_consume.ash to blacklist "bag of QWOP"

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -850,7 +850,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 	boolean[item] blacklist;
 	boolean[item] craftable_blacklist;
 
-	foreach it in $items[Cursed Punch, Unidentified Drink, FantasyRealm turkey leg, FantasyRealm mead, waffle]
+	foreach it in $items[Cursed Punch, Unidentified Drink, bag of QWOP, FantasyRealm turkey leg, FantasyRealm mead, waffle]
 	{
 		blacklist[it] = true;
 	}


### PR DESCRIPTION
# Description

Blacklisting bag of QWOP to prevent it from being consumed as it being consumed can cause combat issues/aborts due to abilities like Thrust-Smacks also being fumbling with the buff given by the food.

(No issue filed, just posted in ASS #autoscend channel)

## How Has This Been Tested?

Not formally tested yes?

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
