### PR TITLE
feat: add a couple more item sources

### DIFF
--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1711,7 +1711,6 @@ float provideItem(int amt, location loc, boolean doEverything, boolean speculati
 		Wet and Greedy, //25% item
 		Serendipi Tea, //25% item
 		Glowing Hands, //25% item
-		Crunching Leaves, //25% item, +5 combat
 		Eagle Eyes, //20% item
 		Juiced and Jacked, //20% item
 		The Grass... \ Is Blue..., //40% meat, 20% item
@@ -1822,7 +1821,8 @@ float provideItem(int amt, location loc, boolean doEverything, boolean speculati
 		shadow waters, //200% meat, 100% item, 100% init, -10% combat
 		One Very Clear Eye, //100% item
 		Car-Charged, //100% meat, 100% item, 5-10MP, 50% init, 50% spell dmg, +3 stats per fight
-		Incredibly Well Lit //100% meat, 50% item
+		Incredibly Well Lit, //100% meat, 50% item
+		Crunching Leaves //25% item, +5 combat
 		]))
 			if(pass())
 				return result();

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1691,14 +1691,14 @@ float provideItem(int amt, location loc, boolean doEverything, boolean speculati
 
 	if(auto_birdModifier("Item Drop") > 0)
 	{
-		//Can be 10/20/30/40/50% meat drop
+		//Can be 10/20/30/40/50% item drop
 		if(tryEffects($effects[Blessing of the Bird]))
 			return result();
 	}
 
 	if(auto_favoriteBirdModifier("Item Drop") > 0)
 	{
-		//Can be 10/20/30/40/50% meat drop
+		//Can be 10/20/30/40/50% item drop
 		if(tryEffects($effects[Blessing of Your Favorite Bird]))
 			return result();
 	}
@@ -1707,9 +1707,11 @@ float provideItem(int amt, location loc, boolean doEverything, boolean speculati
 	if(tryEffects($effects[
 		Unusual Perspective, //50% item
 		Five Sticky Fingers, //50% item
+		Spitting Rhymes, //50% item
 		Wet and Greedy, //25% item
 		Serendipi Tea, //25% item
 		Glowing Hands, //25% item
+		Crunching Leaves, //25% item, +5 combat
 		Eagle Eyes, //20% item
 		Juiced and Jacked, //20% item
 		The Grass... \ Is Blue..., //40% meat, 20% item


### PR DESCRIPTION
# Description

Add a couple more item sources I have available at the end of a run.

Autumn leaf also gives +combat but I had spares. Loathing Idol also gives init and +combat, but I had /lots/ of spares.

## How Has This Been Tested?

Did a run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
