### PR TITLE
QT Fix

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1831,6 +1831,7 @@ boolean doTasks()
 	boris_buySkills();
 	pete_buySkills();
 	zombieSlayer_buySkills();
+	auto_refreshQTFam();
 	lol_buyReplicas();
 	iluh_buyEquiq();
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -915,6 +915,7 @@ boolean LX_quantumTerrarium();
 void qt_initializeSettings();
 boolean qt_FamiliarAvailable (familiar fam);
 boolean qt_FamiliarSwap (familiar fam);
+void auto_refreshQTFam();
 
 ########################################################################################################
 //Defined in autoscend/paths/the_source.ash

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -114,6 +114,9 @@ boolean qt_FamiliarSwap (familiar fam)
 
 void auto_refreshQTFam()
 {
-	// go to familiar page to ensure QT mafia prefs are up to date
-	visit_url("familiar.php");
+	if(in_quantumTerrarium())
+	{
+		// go to familiar page to ensure QT mafia prefs are up to date
+		visit_url("familiar.php");
+	}
 }

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -111,3 +111,9 @@ boolean qt_FamiliarSwap (familiar fam)
 		return false;
 	}
 }
+
+void auto_refreshQTFam()
+{
+	// go to familiar page to ensure QT mafia prefs are up to date
+	visit_url("familiar.php");
+}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1794,7 +1794,7 @@ boolean L11_hiddenCity()
 		return false;
 	}	
 
-	if (internalQuestStatus("questL11Curses") < 2 && have_effect($effect[Ancient Fortitude]) == 0)
+	if (internalQuestStatus("questL11Curses") == 0 && have_effect($effect[Ancient Fortitude]) == 0)
 	{
 		auto_log_info("The idden [sic] apartment!", "blue");
 
@@ -1931,7 +1931,7 @@ boolean L11_hiddenCity()
 		}
 	}
 
-	if (internalQuestStatus("questL11Business") < 2 && (my_adventures() + $location[The Hidden Office Building].turns_spent) >= 11)
+	if (internalQuestStatus("questL11Business") == 0 && (my_adventures() + $location[The Hidden Office Building].turns_spent) >= 11)
 	{
 		auto_log_info("The idden [sic] office!", "blue");
 
@@ -2002,7 +2002,7 @@ boolean L11_hiddenCity()
 		return autoAdv($location[The Hidden Office Building]);
 	}
 
-	if (internalQuestStatus("questL11Spare") < 2)
+	if (internalQuestStatus("questL11Spare") == 0)
 	{
 		auto_log_info("The idden [sic] bowling alley!", "blue");
 		L11_hiddenTavernUnlock(true);
@@ -2041,7 +2041,7 @@ boolean L11_hiddenCity()
 		return autoAdv($location[The Hidden Bowling Alley]);
 	}
 
-	if (internalQuestStatus("questL11Doctor") < 2)
+	if (internalQuestStatus("questL11Doctor") == 0)
 	{
 		if(item_amount($item[Dripping Stone Sphere]) > 0)
 		{


### PR DESCRIPTION
# Description

Did a few QT runs and fixed 2 issues I found
1. Sometimes it aborted turn after fam switching to a new one. Cause was not keeping QT prefs up to date. Fix is to go to fam page each task loop
2. Got into a werid state where I was drinking cursed punches and then not going to hidden apt. Cause was zones weren't unlocked. Updated conditional to only go to hidden zones if quest progress is 0 (started)
https://wiki.kolmafia.us/index.php/Quest_Tracking_Preferences#hiddenOfficeProgress

## How Has This Been Tested?

Couple QT runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
