### PR TITLE
Delay palindrome if out of pulls

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -175,6 +175,7 @@ void initializeSettings() {
 	remove_property("auto_beatenUpLocations");
 	set_property("auto_getBeehive", false);
 	set_property("auto_bruteForcePalindome", false);
+	set_property("auto_doWhiteys", false);
 	set_property("auto_cabinetsencountered", 0);
 	set_property("auto_chasmBusted", true);
 	set_property("auto_chewed", "");

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -299,6 +299,11 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 			couldInstaKill = false;
 		}
 	}
+	else if($monsters[Racecar Bob, Bob Racecar] contains enemy && item_amount($item[photograph of a dog]) == 0 && internalQuestStatus("questL11Palindome") < 2)
+	{
+		//don't want to instakill if we haven't used the disposable camera yet
+		couldInstaKill = false;
+	}
 	else if(wantToForceDrop(enemy))
 	{
 		//want drops from this enemy

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2924,13 +2924,57 @@ boolean L11_palindome()
 	#	In hardcore, guild-class, the right side of the or doesn't happen properly due us farming the
 	#	Mega Gem within the if, with pulls, it works fine. Need to fix this. This is bad.
 	#
-	if((item_amount($item[Bird Rib]) > 0) && (item_amount($item[Lion Oil]) > 0) && (item_amount($item[Wet Stew]) == 0))
+	boolean doWhiteys()
 	{
-		autoCraft("cook", 1, $item[Bird Rib], $item[Lion Oil]);
+		if(item_amount($item[white page]) > 0)
+		{
+			set_property("choiceAdventure940", 1);
+			if(item_amount($item[Bird Rib]) > 0)
+			{
+				set_property("choiceAdventure940", 2);
+			}
+
+			if(get_property("lastGuildStoreOpen").to_int() < my_ascensions())
+			{
+				auto_log_warning("This is probably no longer needed as of r16907. Please remove me", "blue");
+				auto_log_warning("Going to pretend we have unlocked the Guild because Mafia will assume we need to do that before going to Whitey's Grove and screw up us. We'll fix it afterwards.", "red");
+			}
+			backupSetting("lastGuildStoreOpen", my_ascensions());
+			string[int] pages;
+			pages[0] = "inv_use.php?pwd&which=3&whichitem=7555";
+			pages[1] = "choice.php?pwd&whichchoice=940&option=" + get_property("choiceAdventure940");
+			if(autoAdvBypass(0, pages, $location[Whitey\'s Grove], "")) {}
+			restoreSetting("lastGuildStoreOpen");
+			return true;
+		}
+		// +item is nice to get that food
+		bat_formBats();
+		auto_lostStomach(true);
+		auto_log_info("Off to the grove for some doofy food!", "blue");
+		return autoAdv(1, $location[Whitey\'s Grove]);
 	}
-	if((item_amount($item[Stunt Nuts]) > 0) && (item_amount($item[Wet Stew]) > 0) && (item_amount($item[Wet Stunt Nut Stew]) == 0))
+
+	boolean makeWetStuntNutStew()
 	{
-		autoCraft("cook", 1, $item[wet stew], $item[stunt nuts]);
+		 if((item_amount($item[Bird Rib]) > 0) && (item_amount($item[Lion Oil]) > 0) && (item_amount($item[Wet Stew]) == 0))
+		{
+			autoCraft("cook", 1, $item[Bird Rib], $item[Lion Oil]);
+		}
+
+		if((item_amount($item[Stunt Nuts]) > 0) && (item_amount($item[Wet Stew]) > 0) && (item_amount($item[Wet Stunt Nut Stew]) == 0))
+		{
+			autoCraft("cook", 1, $item[wet stew], $item[stunt nuts]);
+		}
+		if(item_amount($item[wet stunt nut stew]) > 0)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	if(item_amount($item[wet stunt nut stew]) == 0 && internalQuestStatus("questL11Palindome") > 3)
+	{
+		return makeWetStuntNutStew();
 	}
 
 	if((item_amount($item[Wet Stunt Nut Stew]) > 0) && !possessEquipment($item[Mega Gem]))
@@ -2940,39 +2984,14 @@ boolean L11_palindome()
 		visit_url("place.php?whichplace=palindome&action=pal_mrlabel");
 	}
 
-	if((total == 0) && !possessEquipment($item[Mega Gem]) && lovemeDone && in_hardcore() && (item_amount($item[Wet Stunt Nut Stew]) == 0) && ((internalQuestStatus("questL11Palindome") >= 3) || isGuildClass()) && !get_property("auto_bruteForcePalindome").to_boolean())
+	if((total == 0) && !possessEquipment($item[Mega Gem]) && lovemeDone && (in_hardcore() || get_property("auto_doWhiteys").to_boolean()) && (item_amount($item[Wet Stunt Nut Stew]) == 0) && ((internalQuestStatus("questL11Palindome") >= 3) || isGuildClass()) && !get_property("auto_bruteForcePalindome").to_boolean())
 	{
 		if(item_amount($item[Wet Stunt Nut Stew]) == 0)
 		{
 			equipBaseline();
 			if((item_amount($item[Bird Rib]) == 0) || (item_amount($item[Lion Oil]) == 0))
 			{
-				if(item_amount($item[white page]) > 0)
-				{
-					set_property("choiceAdventure940", 1);
-					if(item_amount($item[Bird Rib]) > 0)
-					{
-						set_property("choiceAdventure940", 2);
-					}
-
-					if(get_property("lastGuildStoreOpen").to_int() < my_ascensions())
-					{
-						auto_log_warning("This is probably no longer needed as of r16907. Please remove me", "blue");
-						auto_log_warning("Going to pretend we have unlocked the Guild because Mafia will assume we need to do that before going to Whitey's Grove and screw up us. We'll fix it afterwards.", "red");
-					}
-					backupSetting("lastGuildStoreOpen", my_ascensions());
-					string[int] pages;
-					pages[0] = "inv_use.php?pwd&which=3&whichitem=7555";
-					pages[1] = "choice.php?pwd&whichchoice=940&option=" + get_property("choiceAdventure940");
-					if(autoAdvBypass(0, pages, $location[Whitey\'s Grove], "")) {}
-					restoreSetting("lastGuildStoreOpen");
-					return true;
-				}
-				// +item is nice to get that food
-				bat_formBats();
-				auto_lostStomach(true);
-				auto_log_info("Off to the grove for some doofy food!", "blue");
-				autoAdv(1, $location[Whitey\'s Grove]);
+				doWhiteys();
 			}
 			else if(item_amount($item[Stunt Nuts]) == 0)
 			{
@@ -3041,16 +3060,6 @@ boolean L11_palindome()
 			}
 		}
 
-		if((item_amount($item[Bird Rib]) > 0) && (item_amount($item[Lion Oil]) > 0) && (item_amount($item[Wet Stew]) == 0))
-		{
-			autoCraft("cook", 1, $item[Bird Rib], $item[Lion Oil]);
-		}
-
-		if((item_amount($item[Stunt Nuts]) > 0) && (item_amount($item[Wet Stew]) > 0) && (item_amount($item[Wet Stunt Nut Stew]) == 0))
-		{
-			autoCraft("cook", 1, $item[wet stew], $item[stunt nuts]);
-		}
-
 		if(!possessEquipment($item[Mega Gem]))
 		{
 			if (equipped_amount($item[Talisman o\' Namsilat]) == 0)
@@ -3095,8 +3104,36 @@ boolean L11_palindome()
 			}
 			else
 			{
-				// ran out of things to do, brute force it
-				set_property("auto_bruteForcePalindome",true);
+				//After we get the photos
+				//First try wishing, then try Whitey's if we have enough +item, then brute force.
+				//If we hit this, we should only need to finish the L11 quest so it won't hurt to do everything in provideItem
+				//since we will need +item for tomb rats in ~15 turns anyway. Buffs from wishes should still be active
+				//since they are 30 turns from monkey paw wishes and 20 turns from pocket/genie wishes.
+				if (internalQuestStatus("questL11Palindome") > 2)
+				{
+					if(auto_monkeyPawWishesLeft() > 0)
+					{
+						foreach it in $items[Lion Oil, Bird Rib]
+						{
+							if(item_amount(it) > 0) continue;
+							auto_makeMonkeyPawWish(it);
+						}
+						if(item_amount($item[Lion Oil]) > 0 && item_amount($item[Bird Rib]) > 0)
+						{
+							return makeWetStuntNutStew();
+						}
+						return false; //wasn't able to make the stew
+					}
+					else if(provideItem(300, $location[Whitey's Grove], true, true) >= 300)
+					{
+						set_property("auto_doWhiteys", true);
+						return doWhiteys(); //Initial call to do Whitey's Grove
+					}
+					else
+					{
+						set_property("auto_bruteForcePalindome",true);
+					}
+				}
 			}
 		}
 		if((my_mp() > 60) || considerGrimstoneGolem(true))

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2972,7 +2972,7 @@ boolean L11_palindome()
 		return false;
 	}
 
-	if(item_amount($item[wet stunt nut stew]) == 0 && internalQuestStatus("questL11Palindome") > 3)
+	if(item_amount($item[wet stunt nut stew]) == 0 && internalQuestStatus("questL11Palindome") >= 3)
 	{
 		return makeWetStuntNutStew();
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3085,11 +3085,19 @@ boolean L11_palindome()
 	}
 	else
 	{
-		if(!in_hardcore() && pulls_remaining() == 0 && !isAboutToPowerlevel())
+		if(!in_hardcore() && pulls_remaining() == 0)
 		{
 			// used our pulls today before getting to palindrome. Delay until next day or run out of other stuff to do
-			auto_log_debug("Delaying palindrome. In a normal run and don't have enough pulls to create wet stunt nut stew.");
-			return false;
+			if(!isAboutToPowerlevel())
+			{
+				auto_log_debug("Delaying palindrome. In a normal run and don't have enough pulls to create wet stunt nut stew.");
+				return false;
+			}
+			else
+			{
+				// ran out of things to do, brute force it
+				set_property("auto_bruteForcePalindome",true);
+			}
 		}
 		if((my_mp() > 60) || considerGrimstoneGolem(true))
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3085,6 +3085,12 @@ boolean L11_palindome()
 	}
 	else
 	{
+		if(!in_hardcore() && pulls_remaining() == 0 && !isAboutToPowerlevel())
+		{
+			// used our pulls today before getting to palindrome. Delay until next day or run out of other stuff to do
+			auto_log_debug("Delaying palindrome. In a normal run and don't have enough pulls to create wet stunt nut stew.");
+			return false;
+		}
 		if((my_mp() > 60) || considerGrimstoneGolem(true))
 		{
 			handleBjornify($familiar[Grimstone Golem]);


### PR DESCRIPTION
# Description

Aborting due to not having enough pulls to make wet stunt nut stew. Same as issue below

Fixes #1487 
## How Has This Been Tested?

Got this error in a normal QT run. Issue caused abort every time. Made this change, script moved along and running.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
