### PR TITLE
Detect combat in autoAdvBypass

### DIFF
--- a/RELEASE/scripts/autoscend/auto_adventure.ash
+++ b/RELEASE/scripts/autoscend/auto_adventure.ash
@@ -132,9 +132,9 @@ boolean autoAdvBypass(int urlGetFlags, string[int] url, location loc, string opt
 	}
 
 	// handle the initial combat or choice the easy way.
-	string combatPage = "<b>Combat";
+	string combatPage = ">Combat";
 	if(in_pokefam()) {
-		combatPage = "<b>Fight!";
+		combatPage = ">Fight!";
 	}
 	if (contains_text(page, combatPage)) {
 		auto_log_info("autoAdvBypass has encountered a combat! (param: '" + option + "')", "green");


### PR DESCRIPTION
# Description

There was a change to the HTML that we use to detect whether we are in combat or not when we call autoAdvBypass. This fixes that

## How Has This Been Tested?

Multiple standard normal runs. Also anecdotal evidence from Loathers Discord.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [X] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
