### PR TITLE
finish implementing the yellow ray from Roman Candelabra

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -579,7 +579,7 @@ boolean canYellowRay(monster target)
 		}
 		
 		// roman candelabra, also a 75 turn cooldown
-		if(auto_haveRoman())
+		if(auto_haveRoman() && auto_is_valid($skill[Blow the Yellow Candle\!]))
 		{
 			return yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "";
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -579,7 +579,7 @@ boolean canYellowRay(monster target)
 		}
 		
 		// roman candelabra, also a 75 turn cooldown
-		if(auto_haveRoman() && auto_is_valid($skill[Blow the Yellow Candle\!]))
+		if(auto_haveRoman() && auto_can_equip($item[Roman Candelabra]) && auto_is_valid($skill[Blow the Yellow Candle\!]))
 		{
 			return yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "";
 		}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -577,6 +577,12 @@ boolean canYellowRay(monster target)
 		{
 			return true;
 		}
+		
+		// roman candelabra, also a 75 turn cooldown
+		if(auto_haveRoman())
+		{
+			return yellowRayCombatString(target, false, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains target) != "";
+		}
 
 		if(auto_hasRetrocape())
 		{
@@ -1010,6 +1016,10 @@ boolean adjustForYellowRay(string combat_string)
 	if(combat_string == ("skill " + $skill[Unleash the Devil\'s Kiss]))
 	{
 		auto_configureRetrocape("heck", "kiss");
+	}
+	if(combat_string == ("skill " + $skill[Blow the Yellow Candle\!]))
+	{
+		return autoEquip($slot[weapon], wrap_item($item[Roman candelabra]));
 	}
 	// craft and consume 9-volt battery if we are using shocking lick and don't have any charges already
 	if(combat_string == ("skill " + $skill[Shocking Lick]) && get_property("shockingLickCharges").to_int() < 1)

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1019,7 +1019,7 @@ boolean adjustForYellowRay(string combat_string)
 	}
 	if(combat_string == ("skill " + $skill[Blow the Yellow Candle\!]))
 	{
-		return autoEquip($slot[weapon], wrap_item($item[Roman candelabra]));
+		return autoEquip($slot[off-hand], wrap_item($item[Roman candelabra]));
 	}
 	// craft and consume 9-volt battery if we are using shocking lick and don't have any charges already
 	if(combat_string == ("skill " + $skill[Shocking Lick]) && get_property("shockingLickCharges").to_int() < 1)


### PR DESCRIPTION
# Description

When the Roman Candelabra was added, the yellow ray was only half implemented. I guess this got missed because it was always overruled by the Parka for any shiny player.

Now Candelabra is the only yellow in standard, it needs fixing. This does that.

Fixes # (issue)

## How Has This Been Tested?

1 day 1 of a HC Standard run. Please help test.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
