### PR TITLE
Add list of locations where turns have been spent to the bottom of the relay browser page

### DIFF
--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -161,6 +161,35 @@ void write_settings_key()
 	writeln("</table>");
 }
 
+void write_locations_visited()
+{
+	// Display the locations we've spent turns
+	
+	// Make a list of the locations we've visited
+	//~ location[int] locs;
+	int[location] locs;
+	foreach l in $locations[]
+	{
+		int turns = l.turns_spent;
+		if (turns!=0)
+		{
+			locs[l] = turns;
+		}
+	}
+	// Sort in descending order
+	sort locs by -value;
+	
+	// Write the table
+	writeln("<table style=\"margin-left:auto;margin-right:auto;\">");
+	writeln("<tr><th>Location</th> <th>Turns</th></tr>");
+	foreach l,turns in locs
+	{
+		print(l.to_string()+"\t"+turns);
+		writeln("<tr><td>"+l.to_string()+"</td><td>"+turns+"</td></tr>");
+	}
+	writeln("</table>");
+}
+
 void main()
 {
 	auto_settings();			//runs every time. upgrades old settings to newest format, delete obsolete settings, and configures defaults.
@@ -345,6 +374,9 @@ void main()
 
 	//TODO: need way to track version independent of svn branch since you can have different branches checked out
 	writeln("Autoscend Version: " + autoscend_current_version() + "<br>");
+	
+	writeln("<h2>Locations visited</h2>");
+	write_locations_visited();
 
 	writeln("<br>");
 	writeln("</body></html>");

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -182,7 +182,6 @@ void write_locations_visited()
 	writeln("<tr><th>Location</th> <th>Turns</th></tr>");
 	foreach i,loc in ranked_list
 	{
-		print(loc.to_string()+"\t"+loc.turns_spent);
 		writeln("<tr><td>"+loc.to_string()+"</td><td>"+loc.turns_spent+"</td></tr>");
 	}
 	writeln("</table>");

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -166,26 +166,24 @@ void write_locations_visited()
 	// Display the locations we've spent turns
 	
 	// Make a list of the locations we've visited
-	//~ location[int] locs;
-	int[location] locs;
-	foreach l in $locations[]
+	location[int] ranked_list;
+	foreach loc in $locations[]
 	{
-		int turns = l.turns_spent;
-		if (turns!=0)
+		if (loc.turns_spent > 0)
 		{
-			locs[l] = turns;
+			ranked_list[count(ranked_list)] = loc;
 		}
 	}
 	// Sort in descending order
-	sort locs by -value;
+	sort ranked_list by -value.turns_spent;
 	
 	// Write the table
 	writeln("<table style=\"margin-left:auto;margin-right:auto;\">");
 	writeln("<tr><th>Location</th> <th>Turns</th></tr>");
-	foreach l,turns in locs
+	foreach i,loc in ranked_list
 	{
-		print(l.to_string()+"\t"+turns);
-		writeln("<tr><td>"+l.to_string()+"</td><td>"+turns+"</td></tr>");
+		print(loc.to_string()+"\t"+loc.turns_spent);
+		writeln("<tr><td>"+loc.to_string()+"</td><td>"+loc.turns_spent+"</td></tr>");
 	}
 	writeln("</table>");
 }


### PR DESCRIPTION
# Description

I wanted to know where we were spending turns in execution, so I stuck a table on the relay browser page.

Note that this is *all* turns, not just turns run by autoscend.

## How Has This Been Tested?

One character in HC, done one day. Couple of characters in aftercore.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
