### PR TITLE
add 2024 crimbo combat modifiers

### DIFF
--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -188,6 +188,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		{
 			useSkill = $skill[Astral Shell];
 		}																						break;
+	case $effect[Attracting Snakes]:		useSkill = $skill[Attract Snakes];			break;
 	case $effect[Attractive to Fire Ants]:		useItem = $item[fire ant pheromones];			break;
 	case $effect[Aware of Bees]:
 		if(!get_property("_aug19Cast").to_boolean())
@@ -460,6 +461,7 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 	case $effect[Heart of White]:				useItem = $item[white candy heart];				break;
 	case $effect[Heart of Yellow]:				useItem = $item[yellow candy heart];			break;
 	case $effect[Hide of Sobek]:				useSkill = $skill[Hide of Sobek];				break;
+	case $effect[Hiding From Seekers]:			useSkill = $skill[Hide From Seekers];				break;
 	case $effect[High Colognic]:				useItem = $item[Musk Turtle];					break;
 	case $effect[Hippy Antimilitarism]:			useItem = $item[mini kiwi antimilitaristic hippy petition];	break;
 	case $effect[Hippy Stench]:					useItem = $item[reodorant];						break;

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -104,6 +104,7 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 	if (tryEffects($effects[
 		Musk of the Moose,
 		Carlweather's Cantata of Confrontation,
+		Attracting Snakes,
 		Blinking Belly,
 		Song of Battle,
 		Frown,
@@ -301,6 +302,7 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 		Muffled,
 		Smooth Movements,
 		The Sonata of Sneakiness,
+		Hiding From Seekers,
 		Song of Solitude,
 		Inked Well,
 		Bent Knees,


### PR DESCRIPTION
# Description

There is a new + and - combat skill each from Crimbo 2024. This adds using them.

## How Has This Been Tested?

2 runs on shiny player, 1 run on non-shiny. Shiny player doesn't use them due to +-25 combat keep easily being reached, non-shiny player does.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
