### PR TITLE
fix: don't circade a 151 summon

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -750,7 +750,7 @@ boolean auto_circadianRhythmTarget(phylum target)
 	{
 		return false;
 	}
-	if (!($phylums[Orc, Hippy] contains target) && $locations[The Battlefield (Hippy Uniform), The Battlefield (Frat Uniform)] contains my_location())
+	if (!($phylums[Orc, Hippy] contains target && $locations[The Battlefield (Hippy Uniform), The Battlefield (Frat Uniform)] contains my_location()))
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Autoscend uses circadian rhythms against a 151 Infantryman summoned at the start of the run, but is probably only intended to do that when on the battlefield.

## How Has This Been Tested?

Ran fine.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
