### PR TITLE
fix: do cast using bat wings if Mafia won't

### DIFF
--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1708,6 +1708,18 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 
 		if(!success)
 		{
+			// did we have exactly one option and fail to cast rest upside down because we have a back item with +HP/MP?
+			if (count(options) == 1 && options[0].metadata.name == "Rest upside down") {
+				item current_back = equipped_item($slot[back]);
+				// do we have less than max minus what the back item provides
+				if (current_resource() < max_resource() - numeric_modifier(current_back, "Maximum " + resource_type))
+				{
+					auto_log_info("Manually equipping the bat wings");
+					equip($item[bat wings]);
+					recover_discount_pants();
+					return use_skill(1, $skill[rest upside down]);
+				}
+			}
 			auto_log_warning("Target "+resource_type+" => " + goal + " - Uh oh. All restore options tried ("+count(options)+") failed. Sorry.", "red");
 			recover_discount_pants();
 			return false;

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1709,7 +1709,7 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 		if(!success)
 		{
 			// did we have exactly one option and fail to cast rest upside down because we have a back item with +HP/MP?
-			if (count(options) == 1 && options[0].metadata.name == "Rest upside down") {
+			if (count(options) == 1 && options[0].metadata.name == "rest upside down") {
 				item current_back = equipped_item($slot[back]);
 				// do we have less than max minus what the back item provides
 				if (current_resource() < max_resource() - numeric_modifier(current_back, "Maximum " + resource_type))

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -1717,7 +1717,9 @@ boolean __restore(string resource_type, int goal, int meat_reserve, boolean useF
 					auto_log_info("Manually equipping the bat wings");
 					equip($item[bat wings]);
 					recover_discount_pants();
-					return use_skill(1, $skill[rest upside down]);
+					success = use_skill(1, $skill[rest upside down]);
+					equip(current_back);
+					return success;
 				}
 			}
 			auto_log_warning("Target "+resource_type+" => " + goal + " - Uh oh. All restore options tried ("+count(options)+") failed. Sorry.", "red");


### PR DESCRIPTION
# Description

Mafia refuses to equip the bat wings to cast rest upside down if doing so would reduce your maximum HP / MP leading to a loop. However, autoscend seems to only try the best restore. This leads to a situation where autoscend won't restore HP at all, leading you to your death. 

## How Has This Been Tested?

Going to do some runs with it.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
