### PR TITLE
Avalanche bugfix, towerkilling upgrade

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -294,6 +294,72 @@ boolean LX_getStarKey()
 
 boolean beehiveConsider()
 {
+	int damage_sources = 1; // basic hit
+	
+	// Familiars
+	if (have_familiar($familiar[shorter-order cook]) && auto_is_valid($familiar[shorter-order cook]))
+	{
+		damage_sources += 5;
+	}
+	else if (have_familiar($familiar[mu]) && auto_is_valid($familiar[mu]))
+	{
+		damage_sources += 5;
+	}
+	else if (have_familiar($familiar[imitation crab]) && auto_is_valid($familiar[imitation crab]))
+	{
+		damage_sources += 4;
+	}
+	
+	// Prismatic damage sources
+	if (possessEquipment($item[june cleaver])&&auto_is_valid($item[june cleaver]))
+	{
+		damage_sources += 5;
+		if (have_skill($skill[double-fisted skull smashing]))
+		{
+			damage_sources += 1;
+		}
+	}
+	else if (possessEquipment($item[giant bow tie])&&auto_is_valid($item[giant bow tie]))
+	{
+		damage_sources += 5;
+		if (have_skill($skill[double-fisted skull smashing]))
+		{
+			damage_sources += 1;
+		}
+	}
+	else if (possessEquipment($item[roman candelabra])&&auto_is_valid($item[roman candelabra]))
+	{
+		damage_sources += 4; // doesn't do spooky, so let's get that from a spookyraven skill
+		if (have_skill($skill[Snarl of the Timberwolf]) || have_skill($skill[Dirge of Dreadfulness]))
+		{
+			damage_sources += 1;
+		}
+	}
+	
+	// Combat skill to use
+	if (have_skill($skill[kneebutt]))
+	{
+		damage_sources += 1;
+	}
+	
+	// Retatiatory skills
+	foreach sk in $skills[the psalm of pointiness, spiky shell, scarysauce, Jalape&ntilde;o Saucesphere]
+	{
+		if (have_skill(sk))
+		{
+			damage_sources += 1;
+		}
+	}
+	
+	print("Damage sources: "+to_string(damage_sources));
+	
+	if (damage_sources >= 13)
+	{
+		set_property("auto_getBeehive", false);
+		return true;
+	}
+	
+	// Old method
 	if(in_hardcore())
 	{
 		if(have_skill($skill[Shell Up]) && have_skill($skill[Sauceshell]))

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -980,6 +980,8 @@ boolean LX_ForceNC()
 		case $location[The Hidden Apartment Building]:
 		case $location[The Hidden Office Building]:
 			return L11_hiddenCity();
+		case $location[The eXtreme Slope]:
+			return L8_trapperQuest();
 		default:
 			auto_log_warning("Attempted to force NC in unexpected location: " + desiredNCLocation);
 			return false;


### PR DESCRIPTION
# Description

The recent update to implement the McHugeLarge avalanche missed out a step to make sure it goes back to the Extreme Slope after engaging the avalanche.

Additionally, we were assuming we couldn't towerkill the Wall of Skin in HC if we didn't have Shell Up - this is now calculated more intelligently.

## How Has This Been Tested?

Briefly

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
