### PR TITLE
feat: get rum and tamales with spare Takerspace ingredients

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -482,8 +482,18 @@ void auto_checkTakerSpace()
 		create(1, $item[anchor bomb]);
 	}
 	// goldschlepper is EPIC booze
-	int creatableGold = creatable_amount($item[tankard of spiced Goldschlepper]);
-	if(creatableGold > 0) {
-		create(creatableGold, $item[tankard of spiced Goldschlepper]);
+	int createable = creatable_amount($item[tankard of spiced Goldschlepper]);
+	if(createable > 0) {
+		create(createable, $item[tankard of spiced Goldschlepper]);
+	}
+	// tankard of spiced rum is awesome booze
+	createable = creatable_amount($item[tankard of spiced rum]);
+	if(createable > 0) {
+		create(createable, $item[tankard of spiced rum]);
+	}
+	// cursed Aztec tamale is awesome food, and only uses spices
+	createable = creatable_amount($item[cursed Aztec tamale]);
+	if(createable > 0) {
+		create(createable, $item[cursed Aztec tamale]);
 	}
 }


### PR DESCRIPTION
Follow-up to #1532.

# Description

As suggested, spend spare ingredients on consumables. Also get spiced rum in addition to tamale; they are awesome at least.

Over 2 days, I think this will provide:
* with spring shoes: dinghy, goldschlepper, tamale; goldschlepper, rum, tamale
* without spring shoes: dinghy, anchor bomb, rum, tamale; anchor bomb, rum, tamale

## How Has This Been Tested?

Did some runs (okay, d1 on one account and d2 on another).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
