### PR TITLE
fix: use Mafia's knowledge of watches

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -1254,5 +1254,5 @@ boolean auto_forceEquipSword() {
 boolean is_watch(item it)
 {
 	//watches are accessories that conflict with each other. you can only equip one watch total.
-	return $items[dead guy's memento, dead guy's watch, Counterclockwise Watch, glow-in-the-dark wristwatch, grandfather watch, imitation nice watch, wristwatch of the white knight, Crimbolex watch, Sasq&trade; watch] contains it;
+	return boolean_modifier(it, $modifier[Nonstackable Watch]);
 }


### PR DESCRIPTION
The function was missing baywatch.

# Description

Use Mafia's "Nonstackable Watch" modifier instead of a list of items for determining watches.

## How Has This Been Tested?

One run, worked as expected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
