### PR TITLE
NC Forcer/Logging Fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -82,7 +82,7 @@ boolean auto_post_adventure()
 		(get_property("auto_forceNonCombatSource") != "McHugeLarge left ski") || get_property("auto_avalancheDeployed").to_boolean())
 		{
 			auto_log_info("Encountered forced noncombat: " + get_property("lastEncounter"), "blue");
-			handleTracker(get_property("auto_forceNonCombatSource"), to_string(my_location()) + " - " + get_property("lastEncounter"), "auto_forcedNC");
+			handleTracker(get_property("auto_forceNonCombatSource"), to_string(my_location()) + "-" + get_property("lastEncounter"), "auto_forcedNC");
 		}
 		set_property("auto_forceNonCombatSource", "");
 		set_property("auto_forceNonCombatLocation", "");

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -78,7 +78,6 @@ boolean auto_post_adventure()
 	if(get_property("auto_forceNonCombatSource") != "" && !auto_haveQueuedForcedNonCombat() && !(get_property("auto_instakillSuccess").to_boolean()))
 	{
 		// possible to get desired NC when preparing spikes/avalanche. Only log usage if NC was actually forced
-		// I have no idea how to make this check work for avalanche too?
 		if((get_property("auto_forceNonCombatSource") != "jurassic parka" || get_property("auto_parkaSpikesDeployed").to_boolean()) &&
 		(get_property("auto_forceNonCombatSource") != "McHugeLarge left ski") || get_property("auto_avalancheDeployed").to_boolean())
 		{

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -75,7 +75,7 @@ boolean auto_post_adventure()
 	 * Cosmetics Wraith in the Haunted Bathroom), and we SHOULD reset the
 	 * noncombat-forcer in those cases.*/
 
-	if(get_property("auto_forceNonCombatSource") != "" && !auto_haveQueuedForcedNonCombat() && !(get_property("auto_instakillSuccess").to_boolean()))
+	if(get_property("auto_forceNonCombatSource") != "" && !auto_haveQueuedForcedNonCombat())
 	{
 		// possible to get desired NC when preparing spikes/avalanche. Only log usage if NC was actually forced
 		if((get_property("auto_forceNonCombatSource") != "jurassic parka" || get_property("auto_parkaSpikesDeployed").to_boolean()) &&

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -82,7 +82,7 @@ boolean auto_post_adventure()
 		(get_property("auto_forceNonCombatSource") != "McHugeLarge left ski") || get_property("auto_avalancheDeployed").to_boolean())
 		{
 			auto_log_info("Encountered forced noncombat: " + get_property("lastEncounter"), "blue");
-			handleTracker(get_property("auto_forceNonCombatSource"), my_location() + ": " + get_property("lastEncounter"), "auto_forcedNC");
+			handleTracker(get_property("auto_forceNonCombatSource"), to_string(my_location()) + " - " + get_property("lastEncounter"), "auto_forcedNC");
 		}
 		set_property("auto_forceNonCombatSource", "");
 		set_property("auto_forceNonCombatLocation", "");

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -75,14 +75,15 @@ boolean auto_post_adventure()
 	 * Cosmetics Wraith in the Haunted Bathroom), and we SHOULD reset the
 	 * noncombat-forcer in those cases.*/
 
-	if(get_property("auto_forceNonCombatSource") != "" && !auto_haveQueuedForcedNonCombat())
+	if(get_property("auto_forceNonCombatSource") != "" && !auto_haveQueuedForcedNonCombat() && !(get_property("auto_instakillSuccess").to_boolean()))
 	{
 		// possible to get desired NC when preparing spikes/avalanche. Only log usage if NC was actually forced
 		// I have no idea how to make this check work for avalanche too?
-		if(get_property("auto_forceNonCombatSource") != "jurassic parka" || get_property("auto_parkaSpikesDeployed").to_boolean())
+		if((get_property("auto_forceNonCombatSource") != "jurassic parka" || get_property("auto_parkaSpikesDeployed").to_boolean()) &&
+		(get_property("auto_forceNonCombatSource") != "McHugeLarge left ski") || get_property("auto_avalancheDeployed").to_boolean())
 		{
 			auto_log_info("Encountered forced noncombat: " + get_property("lastEncounter"), "blue");
-			handleTracker(get_property("auto_forceNonCombatSource"), get_property("lastEncounter"), "auto_forcedNC");
+			handleTracker(get_property("auto_forceNonCombatSource"), my_location() + ": " + get_property("lastEncounter"), "auto_forcedNC");
 		}
 		set_property("auto_forceNonCombatSource", "");
 		set_property("auto_forceNonCombatLocation", "");
@@ -93,7 +94,10 @@ boolean auto_post_adventure()
 	if(get_property("auto_instakillSource") != "" && get_property("auto_instakillSuccess").to_boolean())
 	{
 		auto_log_info("Successful instakill with: " + get_property("auto_instakillSource"), "blue");
-		handleTracker(get_property("lastEncounter"), get_property("auto_instakillSource"), "auto_instakill");
+		if(get_property("lastEncounter").to_monster() == last_monster()) //only track the combat part of a combat+NC encounter (like everfull dart perks)
+		{
+			handleTracker(get_property("lastEncounter"), get_property("auto_instakillSource"), "auto_instakill");
+		}
 		set_property("auto_instakillSource", "");
 		set_property("auto_instakillSuccess", false);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -591,7 +591,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		}
 
 		//If you have tearaway pants equipped, use its skill
-		if(canUse($skill[Tear Away your Pants!]) && get_property("auto_forceNonCombatSource") == "")
+		if(canUse($skill[Tear Away your Pants!]) && (get_property("auto_forceNonCombatSource") == "" || monster_phylum() == $phylum[plant]))
 		{
 			return useSkill($skill[Tear Away your Pants!]);
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -591,7 +591,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		}
 
 		//If you have tearaway pants equipped, use its skill
-		if(canUse($skill[Tear Away your Pants!]))
+		if(canUse($skill[Tear Away your Pants!]) && get_property("auto_forceNonCombatSource") == "")
 		{
 			return useSkill($skill[Tear Away your Pants!]);
 		}


### PR DESCRIPTION
# Description

Fixes a few things with logging

- Only logs the combat for chained combats that end with an NC (like dart perks)
- Only logs once an Avalanche has actually been triggered in combat
- Log the location of the NC as well as the forcer, NC, and turn for clarity in our tracker
- Don't tearaway pants if you want an NC forcer, unless the monster is a plant (tearaway pants could kill the monster before casting the NC forcer)

## How Has This Been Tested?

One NC for avalanche because I had used up the other 2 charges figuring this out. Other items have been tested during the run.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
