### PR TITLE
Add support for burning leaf fights to powerlevel task

### DIFF
--- a/RELEASE/scripts/autoscend/auto_powerlevel.ash
+++ b/RELEASE/scripts/autoscend/auto_powerlevel.ash
@@ -398,6 +398,28 @@ boolean LX_freeCombats(boolean powerlevel)
 		adv_done = autoAdv(1, $location[An Unusually Quiet Barroom Brawl]);
 		if(adv_done) return true;
 	}
+	
+	if(auto_haveBurningLeaves() && get_property("_leafMonstersFought).to_int() < 5) {
+		auto_log_debug("LX_freeCombats is summoning leaf monsters");
+		int remainingLeafFights = get_property("_leafMonstersFought).to_int();
+
+		while(remainingLeafFights > 0 && item_amount($item[inflammable leaf]) >= 11){
+			remainingLeafFights--;
+			if(item_amount($item[inflammable leaf]) >= 666 + (11 * remainingLeafFights)) {
+				if (!fightLeaviathan()) {
+					auto_log_debug("Failed to summon leaviathan");
+				}
+			} else if(item_amount($item[inflammable leaf]) >= 111 + (11 * remainingLeafFights)) {
+				if (!fightFlamingMonstera()) {
+					auto_log_debug("Failed to summon flaming monstera");
+				}
+			} else {
+				if (!fightFlamingLeaflet()) {
+					auto_log_debug("Failed to summon flaming leaflet");
+				}
+			}
+		}
+	}
 
 	// tentacle should be last so it can be backed up, if script wants to
 	// see auto_backupTarget()

--- a/RELEASE/scripts/autoscend/auto_powerlevel.ash
+++ b/RELEASE/scripts/autoscend/auto_powerlevel.ash
@@ -399,9 +399,9 @@ boolean LX_freeCombats(boolean powerlevel)
 		if(adv_done) return true;
 	}
 	
-	if(auto_haveBurningLeaves() && get_property("_leafMonstersFought).to_int() < 5) {
+	if(auto_haveBurningLeaves() && get_property("auto_remainingFlamingLeafFights").to_int() > 0) {
 		auto_log_debug("LX_freeCombats is summoning leaf monsters");
-		int remainingLeafFights = get_property("_leafMonstersFought).to_int();
+		int remainingLeafFights = get_property("auto_remainingFlamingLeafFights").to_int();
 
 		while(remainingLeafFights > 0 && item_amount($item[inflammable leaf]) >= 11){
 			remainingLeafFights--;

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -541,10 +541,14 @@ boolean auto_circadianRhythmTarget(phylum target);
 boolean auto_haveJillOfAllTrades();
 void auto_handleJillOfAllTrades();
 boolean auto_haveBurningLeaves();
+int auto_remainingFlamingLeafFights();
 boolean auto_burnLeaves();
 boolean auto_haveCCSC();
 boolean auto_handleCCSC();
 void auto_useWardrobe();
+boolean fightFlamingLeaflet();
+boolean fightFlamingMonstera();
+boolean fightLeaviathan();
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2024.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -989,3 +989,36 @@ void auto_useWardrobe()
 	// let maximizer handle if any of it is worth equipping
 	use($item[wardrobe-o-matic]);
 }
+
+boolean fightFlamingLeaflet() {
+	if(item_amount($item[inflammable leaf]) >= 11) {
+		auto_log_debug("summoning flaming leaflet (2389)");
+		leaves 11;
+
+		return true;
+	}
+
+	return false;
+}
+
+boolean fightFlamingMonstera() {
+	if(item_amount($item[inflammable leaf]) >= 111) {
+		auto_log_debug("summoning flaming monstera (2390)");
+		leaves 111;
+
+		retun true;
+	}
+
+	return false;
+}
+
+boolean fightLeaviathan() {
+	if(item_amount($item[inflammable leaf]) >= 666) {
+		auto_log_debug("summoning leaviathan (2391)");
+		leaves 666;
+
+		return true;
+	}
+
+	return false;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -873,6 +873,12 @@ boolean auto_haveBurningLeaves()
 	return auto_is_valid($item[A Guide to Burning Leaves]) && get_campground() contains $item[A Guide to Burning Leaves];
 }
 
+into auto_remainingFlamingLeafFights()
+{
+	readonly int baseFightsPerDay = 5;
+	return baseFightsPerDay - get_property("_leafMonstersFought).to_int();
+}
+
 boolean auto_burnLeaves()
 {
 	if (!auto_haveBurningLeaves())

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -873,7 +873,7 @@ boolean auto_haveBurningLeaves()
 	return auto_is_valid($item[A Guide to Burning Leaves]) && get_campground() contains $item[A Guide to Burning Leaves];
 }
 
-into auto_remainingFlamingLeafFights()
+int auto_remainingFlamingLeafFights()
 {
 	readonly int baseFightsPerDay = 5;
 	return baseFightsPerDay - get_property("_leafMonstersFought).to_int();


### PR DESCRIPTION
# Description

In order to support summoning leaf monsters as part of the powerlevel task, I added a block to utilize leaves as well as possible for combat purposes. It is worth discussing whether leaves should be reserved for beds or other items. It might be worth hiding this behind a setting as optimal leaf usage is purely subjective.

Summary of changes
Added fight summoned monster functions to mr2023
Added flaming summon leaflet block to powerlevel task

Fixes # (issue)

## How Has This Been Tested?

Tested functions in isolation, but I consider this a WIP PR pending review

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
