### PR TITLE
Mouthwash changes

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1203,6 +1203,7 @@ boolean dailyEvents()
 	auto_useBlackMonolith();
 	auto_scepterSkills();
 	auto_getAprilingBandItems();
+	auto_MayamClaimAll();
 	auto_buyFromSeptEmberStore();
 	
 	return true;

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -313,7 +313,9 @@ boolean auto_MayamClaimWhatever()
 	else if (!auto_MayamIsUsed("meat"))   { ring2 = "meat"; }
 	else { failure = true; }
 	
-	if      (!auto_MayamIsUsed("yam3"))   { ring3 = "yam"; }
+	boolean going_to_use_mouthwash = my_level()<13 && remainingEmbers() >= 2;
+	if (going_to_use_mouthwash && !auto_MayamIsUsed("wall")) { ring3 = "wall"; }
+	else if (!auto_MayamIsUsed("yam3"))   { ring3 = "yam"; }
 	else if (!auto_MayamIsUsed("cheese")) { ring3 = "cheese"; }
 	else if (!auto_MayamIsUsed("wall"))   { ring3 = "wall"; }
 	else { failure = true; }
@@ -419,6 +421,7 @@ void auto_buyFromSeptEmberStore()
 	// mouthwash for leveling
 	item mouthwash = $item[Mmm-brr! brand mouthwash];
 	boolean disregard_karma = get_property("auto_disregardInstantKarma").to_boolean();
+	auto_openMcLargeHugeSkis(); // make sure our skis are open for cold res
 	for (int imw = 0 ; imw < 3 ; imw++) // We can use up to 3 mouthwash
 	{
 		// If we have at least 4 embers remaining, don't overlevel, they can be used for something else
@@ -442,6 +445,17 @@ void auto_buyFromSeptEmberStore()
 			
 			provideResistances(resGoal, $location[noob cave], true);
 			equipMaximizedGear();
+			
+			// We could have left-hand if our off-hand is strong enough
+			if (numeric_modifier(equipped_item($slot[off-hand]),$modifier[cold resistance]) > 2.9)
+			{
+				skill lefty = $skill[Aug. 13th: Left/Off Hander's Day!];
+				if(canUse(lefty) && !get_property("_aug13Cast").to_boolean())
+				{
+					use_skill(lefty);
+				}
+			}
+			
 			if (expected_level_after_mouthwash()<13) // use a wish if really need it
 			{
 				auto_wishForEffectIfNeeded($effect[Fever From the Flavor]);

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -407,10 +407,52 @@ int remainingEmbers()
 
 void auto_buyFromSeptEmberStore()
 {
+	if(!auto_haveSeptEmberCenser())
+	{
+		return;
+	}
 	if(remainingEmbers() == 0)
 	{
 		return;
 	}
+
+	// mouthwash for leveling
+	item mouthwash = $item[Mmm-brr! brand mouthwash];
+	boolean disregard_karma = get_property("auto_disregardInstantKarma").to_boolean();
+	for (int imw = 0 ; imw < 3 ; imw++) // We can use up to 3 mouthwash
+	{
+		// If we have at least 4 embers remaining, don't overlevel, they can be used for something else
+		boolean happy_to_overlevel = disregard_karma && remainingEmbers() < 4;
+		boolean want_to_mouthwash_level = (my_level() < 13 || happy_to_overlevel) && my_level()<15;
+		// Even disregarding karma, never level above 15 using mouthwash as a sanity limit
+		want_to_mouthwash_level = want_to_mouthwash_level && my_level()<15;
+		if (remainingEmbers() >= 2 && want_to_mouthwash_level)
+		{
+			// get as much cold res as possible
+			int [element] resGoal;
+			resGoal[$element[cold]] = 100;
+			// get cold res. Use noob cave as generic place holder
+			
+			// get 1 bembershoot to support mouthwash leveling or general quest help
+			item bember = $item[bembershoot];
+			if (remainingEmbers() % 2 == 1 && !possessEquipment(bember) && auto_is_valid(bember))
+			{
+				buy($coinmaster[Sept-Ember Censer], 1, bember);
+			}
+			
+			provideResistances(resGoal, $location[noob cave], true);
+			equipMaximizedGear();
+			if (expected_level_after_mouthwash()<13) // use a wish if really need it
+			{
+				auto_wishForEffectIfNeeded($effect[Fever From the Flavor]);
+			}
+			// buy mouthwash and use it
+			buy($coinmaster[Sept-Ember Censer], 1, mouthwash);
+			auto_log_debug(`Using mouthwash with {numeric_modifier($modifier[cold resistance])} cold resistance`);
+			use(mouthwash);
+		}
+	}
+	
 	auto_log_debug("Have " + remainingEmbers() + " embers(s) to buy from Sept-Ember Censer. Let's spend them!");
 	// get structural ember if can't cross bridge
 	item itemConsidering = $item[Structural ember];
@@ -420,38 +462,21 @@ void auto_buyFromSeptEmberStore()
 		buy($coinmaster[Sept-Ember Censer], 1, itemConsidering);
 		use(itemConsidering);
 	}
-	// get 1 bembershoot to support mouthwash leveling or general quest help
-	itemConsidering = $item[bembershoot];
-	if(remainingEmbers() >= 1 && !possessEquipment(itemConsidering) && auto_is_valid(itemConsidering))
+	
+	// Spend any remaining pairs on Septapus summoning charms
+	while (remainingEmbers() >= 2)
 	{
-		buy($coinmaster[Sept-Ember Censer], 1, itemConsidering);
+		buy($coinmaster[Sept-Ember Censer], 1, $item[Septapus summoning charm]);
 	}
-	// mouthwash for leveling
-	itemConsidering = $item[Mmm-brr! brand mouthwash];
-	if(remainingEmbers() >= 2 && (my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean()) && auto_is_valid(itemConsidering))
-	{
-		// get as much cold res as possible
-		int [element] resGoal;
-		resGoal[$element[cold]] = 100;
-		// get cold res. Use noob cave as generic place holder
-		provideResistances(resGoal, $location[noob cave], true);
-		equipMaximizedGear();
-		if (expected_level_after_mouthwash()<13) // use a wish if really need it
-		{
-			auto_wishForEffectIfNeeded($effect[Fever From the Flavor]);
-		}
-		// buy mouthwash and use it
-		buy($coinmaster[Sept-Ember Censer], 1, itemConsidering);
-		auto_log_debug(`Using mouthwash with {numeric_modifier("cold Resistance")} cold resistance`);
-		use(itemConsidering);
-	}
+	
 	// if still have embers, get hat for mp regen
 	itemConsidering = $item[Hat of remembering];
 	if(remainingEmbers() >= 1 && !possessEquipment(itemConsidering) && auto_is_valid(itemConsidering))
 	{
 		buy($coinmaster[Sept-Ember Censer], 1, itemConsidering);
 	}
-	// consider throwin' ember for banish or summoning charm for pickpocket in future PR
+	
+	return;
 }
 
 float expected_mouthwash_main_substat()

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -426,7 +426,7 @@ void auto_buyFromSeptEmberStore()
 	{
 		// If we have at least 4 embers remaining, don't overlevel, they can be used for something else
 		boolean happy_to_overlevel = disregard_karma && remainingEmbers() < 4;
-		boolean want_to_mouthwash_level = (my_level() < 13 || happy_to_overlevel) && my_level()<15;
+		boolean want_to_mouthwash_level = (my_level() < 13 || happy_to_overlevel);
 		// Even disregarding karma, never level above 15 using mouthwash as a sanity limit
 		want_to_mouthwash_level = want_to_mouthwash_level && my_level()<15;
 		if (remainingEmbers() >= 2 && want_to_mouthwash_level)
@@ -447,7 +447,10 @@ void auto_buyFromSeptEmberStore()
 			equipMaximizedGear();
 			
 			// We could have left-hand if our off-hand is strong enough
-			if (numeric_modifier(equipped_item($slot[off-hand]),$modifier[cold resistance]) > 2.9)
+			float cold_res_from_oh = numeric_modifier(equipped_item($slot[off-hand]),$modifier[cold resistance]);
+			// McHugeLarge outfit off-hand is +3 cold res when whole outfit equipped, but not reported by Mafia with above check
+			boolean using_mchugelarge_oh = equipped_item($slot[off-hand]) == $item[McHugeLarge left pole];
+			if (using_mchugelarge_oh || cold_res_from_oh > 2.9)
 			{
 				skill lefty = $skill[Aug. 13th: Left/Off Hander's Day!];
 				if(canUse(lefty) && !get_property("_aug13Cast").to_boolean())


### PR DESCRIPTION
# Description

Use up to 3 mouthwashes to level, prioritised over bridge parts when < level 13.
Never level past 15 with mouthwash to prevent wastage.
Get septimus charms with remaining embers.
Use left/off hander's buff from scepter with sufficient cold res in off-hand.
Use mayam walled in for cold res.

## How Has This Been Tested?

1 HC run with character with both available IOTMs.

Note that this can be tested as part of the branch hk_mixed_branch which contains all the changes from several branches I'm independently PRing.

https://github.com/loathers/autoscend/tree/hk_mixed_branch

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
