### PR TITLE
add check on number of times clan photobooth request made

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -598,6 +598,7 @@ boolean auto_thisClanPhotoBoothHasItem(item it);
 boolean auto_thisClanPhotoBoothHasItems(boolean[item] items);
 boolean auto_getClanPhotoBoothDefaultItems();
 boolean auto_getClanPhotoBoothItem(item it);
+int auto_remainingClanPhotoBoothEffects();
 boolean auto_getClanPhotoBoothEffect(effect ef);
 boolean auto_getClanPhotoBoothEffect(effect ef, int n_times);
 boolean auto_getClanPhotoBoothEffect(string ef);

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -675,6 +675,15 @@ boolean auto_getClanPhotoBoothItem(item it)
 	return false;
 }
 
+int auto_remainingClanPhotoBoothEffects()
+{
+	if (!auto_haveClanPhotoBooth())
+	{
+		return 0;
+	}
+	return 3-get_property("_photoBoothEffects").to_int();
+}
+
 string auto_getClanPhotoBoothEffectString(effect ef)
 {
 	switch(ef)
@@ -717,6 +726,12 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 		return false;
 	}
 	if(!auto_is_valid($item[photo booth sized crate]))
+	{
+		return false;
+	}
+	
+	n_times = min(n_times,auto_remainingClanPhotoBoothEffects());
+	if (n_times <= 1)
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -731,7 +731,7 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 	}
 	
 	n_times = min(n_times,auto_remainingClanPhotoBoothEffects());
-	if (n_times <= 1)
+	if (n_times < 1)
 	{
 		return false;
 	}
@@ -762,6 +762,7 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 				cli_execute("photobooth effect wild");
 			}
 			success = to_boolean(have_effect(west_ef));
+			break;
 		case "tower":
 		case tower_string:
 			for (int i = 0 ; i < n_times ; i++)
@@ -769,6 +770,7 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 				cli_execute("photobooth effect tower");
 			}
 			success = to_boolean(have_effect(tower_ef));
+			break;
 		case "space":
 		case space_string:
 			for (int i = 0 ; i < n_times ; i++)
@@ -776,6 +778,7 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 				cli_execute("photobooth effect space");
 			}
 			success = to_boolean(have_effect(space_ef));
+			break;
 	}
 	// Go home if we BAFH'd it
 	if (orig_clan_id != get_clan_id())


### PR DESCRIPTION
# Description

Photobooth implementation did not previously check if we'd used our max number of effects before trying to cast those effects. This can cause a halt, and for some reason didn't in my previous testing. This may currently be a showstopper. This PR fixes it.

## How Has This Been Tested?

Interpreter, invocation just starting running.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
