### PR TITLE
Implement using FLUDA douses for filthworms

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -513,6 +513,12 @@ boolean auto_pre_adventure()
 		}
 	}
 	
+	item fluda = $item[Flash Liquidizer Ultra Dousing Accessory];
+	if ($locations[The Hatching Chamber, The Feeding Chamber, The Royal Guard Chamber] contains place && auto_dousesRemaining()>0)
+	{
+		autoEquip(fluda);
+	}
+	
 	item exting = wrap_item($item[industrial fire extinguisher]);
 	if(auto_FireExtinguisherCombatString(place) != "" || $locations[The Goatlet, Twin Peak, The Hidden Bowling Alley, The Hatching Chamber, The Feeding Chamber, The Royal Guard Chamber] contains place)
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -532,6 +532,7 @@ int remainingCatalogCredits();
 boolean auto_haveIdolMicrophone();
 void auto_buyFrom2002MrStore();
 void auto_useBlackMonolith();
+int auto_dousesRemaining();
 boolean auto_haveAugustScepter();
 void auto_scepterSkills();
 void auto_lostStomach();

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -180,6 +180,17 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		}
 	}
 
+	if(wantToDouse(enemy) && round < 23) // dousing can have a low chance of success, so only do it up to round 22
+	{
+		skill douse = $skill[douse foe];
+		boolean douseAvailable = canUse(douse, false) && auto_dousesRemaining()>0;
+		if(douseAvailable)
+		{
+			handleTracker(enemy, douse, "auto_otherstuff");
+			return useSkill(douse);
+		}
+	}
+	
 	if(wantToForceDrop(enemy))
 	{
 		boolean polarVortexAvailable = canUse($skill[Fire Extinguisher: Polar Vortex], false) && auto_fireExtinguisherCharges() > 10;

--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -52,6 +52,7 @@ float turns_to_kill(float dmg);
 boolean combat_status_check(string mark);
 void combat_status_add(string mark);
 boolean wantToForceDrop(monster enemy);
+boolean wantToDouse(monster enemy);
 boolean canSurviveShootGhost(monster enemy, int shots);
 
 #####################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -1069,6 +1069,20 @@ boolean wantToForceDrop(monster enemy)
 	return forceDrop;
 }
 
+boolean wantToDouse(monster enemy)
+{
+	switch (enemy)
+	{
+		case $monster[larval filthworm]:
+			return item_amount($item[filthworm hatchling scent gland  ]) == 0;
+		case $monster[filthworm drone]:
+			return item_amount($item[filthworm drone scent gland      ]) == 0;
+		case $monster[filthworm royal guard]:
+			return item_amount($item[filthworm royal guard scent gland]) == 0;
+	}
+	return false;
+}
+
 boolean canSurviveShootGhost(monster enemy, int shots) {
 	int damage;
 	switch(enemy)

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -582,6 +582,16 @@ void auto_useBlackMonolith()
 	visit_url("campground.php?action=monolith");
 }
 
+int auto_dousesRemaining()
+{
+	item fluda = $item[Flash Liquidizer Ultra Dousing Accessory];
+	if (available_amount(fluda)<1 || !auto_is_valid(fluda))
+	{
+		return 0;
+	}
+	return 3-get_property("_douseFoeUses").to_int();
+}
+
 boolean auto_haveAugustScepter()
 {
 	static item scepter = wrap_item($item[august scepter]);

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -890,6 +890,10 @@ boolean L12_filthworms()
 		auto_log_info("Will steal stench glands using [XO Skeleton]");
 		handleFamiliar($familiar[XO Skeleton]);
 	}
+	else if(auto_dousesRemaining()>0)
+	{
+		auto_log_info("Will steal stench glands using FLUDA douse");
+	}
 	else if(auto_fireExtinguisherCharges() > 10)
 	{
 		auto_log_info("Will steal stench glands using polar vortex ability of [Industrial Fire Extinguisher]");


### PR DESCRIPTION
# Description

We can force drops using the Flash Liquidizer Ultra Dousing Accessory from the 2002 Mr Store catalog. This is a pickpocket that only takes one item but can be used repeatedly. The main place is it useful is Filthworms. This adds the code to support using it, and implements it only for the filthworms, making it grab them early-on in the ascension.

## How Has This Been Tested?

Just one HC standard run through the orchard so far.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
