### PR TITLE
Smarter photobooth item picking

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -1256,3 +1256,44 @@ boolean is_watch(item it)
 	//watches are accessories that conflict with each other. you can only equip one watch total.
 	return boolean_modifier(it, $modifier[Nonstackable Watch]);
 }
+
+int[item] auto_getAllEquipabble()
+{
+	return auto_getAllEquipabble($slot[none]);
+}
+
+int[item] auto_getAllEquipabble(slot s)
+{
+	boolean ignore_slot = s==$slot[none];
+	s = (s==$slot[acc2] || s==$slot[acc3]?$slot[acc1]:s);// all accessories checked against slot 1
+	int[item] valid_and_equippable;
+	foreach it,n in get_inventory()
+	{
+		slot it_s = to_slot(it);
+		if(can_equip(it) && auto_is_valid(it) && (s==it_s || ignore_slot))
+		{
+			valid_and_equippable[it] = n;
+		}
+	}
+	// Add equipped
+	boolean[slot] my_slots;
+	if (ignore_slot)
+	{
+		my_slots = $slots[hat, weapon, off-hand, back, shirt, pants, acc1, acc2, acc3, familiar];
+	}
+	else
+	{
+		my_slots[s] = true;
+		if (s==$slot[acc1])
+		{
+			my_slots[$slot[acc2]] = true;
+			my_slots[$slot[acc3]] = true;
+		}
+	}
+	foreach my_slot in my_slots
+	{
+		item it = equipped_item(my_slot);
+		valid_and_equippable[it]++;
+	}
+	return valid_and_equippable;
+}

--- a/RELEASE/scripts/autoscend/auto_list.ash
+++ b/RELEASE/scripts/autoscend/auto_list.ash
@@ -1004,4 +1004,40 @@ string ListOutput(location[int] list)
 	return retval;
 }
 
+// Sorting.
+// Uses boolean[TYPE] to allow use on Mafia list types eg $items[]
+
+item[int] auto_sortedByModifier(int[item] map, modifier m)
+{
+	return auto_sortedByModifier(map,m,true);
+}
+
+item[int] auto_sortedByModifier(int[item] map, modifier m, boolean high_to_low)
+{
+	item[int] ranked_list;
+	foreach entry in map
+	{
+		ranked_list[count(ranked_list)] = entry;
+	}
+	// Sort
+	float sign = high_to_low ? -1 : 1;
+	sort ranked_list by sign * numeric_modifier(value,m);
+	return ranked_list;
+}
+
+item[int] auto_sortedByModifier(boolean[item] map, modifier m)
+{
+	return auto_sortedByModifier(map,m,true);
+}
+
+item[int] auto_sortedByModifier(boolean[item] map, modifier m, boolean high_to_low)
+{
+	int[item] int_map;
+	foreach entry in map
+	{
+		int_map[entry]++;
+	}
+	return auto_sortedByModifier(int_map,m,high_to_low);
+}
+
 //end of location[int]

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4716,3 +4716,57 @@ float stat_exp_percent(stat s)
 	}
 	return 0;
 }
+
+stat auto_getOffStatChallengeFromTelescope()
+{
+	string musc  = "standing around flexing";
+	string myst  = "sitting around playing chess";
+	string moxie = "all wearing sunglasses and dancing";
+	string scope = get_property("telescope1");
+	
+	if (contains_text(scope,musc))
+	{
+		return $stat[muscle];
+	}
+	else if (contains_text(scope,myst))
+	{
+		return $stat[mysticality];
+	}
+	else if (contains_text(scope,moxie))
+	{
+		return $stat[moxie];
+	}
+	return $stat[none];
+}
+
+element auto_getElementChallengeFromTelescope()
+{
+	string hot    = "fire";
+	string cold   = "igloos";
+	string spooky = "eldritch";
+	string sleaze = "greasy";
+	string stench = "garbage";
+	string scope = get_property("telescope2");
+	
+	if (contains_text(scope,hot))
+	{
+		return $element[hot];
+	}
+	else if (contains_text(scope,cold))
+	{
+		return $element[cold];
+	}
+	else if (contains_text(scope,spooky))
+	{
+		return $element[spooky];
+	}
+	else if (contains_text(scope,sleaze))
+	{
+		return $element[sleaze];
+	}
+	else if (contains_text(scope,stench))
+	{
+		return $element[stench];
+	}
+	return $element[none];
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -596,7 +596,10 @@ boolean auto_haveClanPhotoBooth();
 boolean auto_isClanPhotoBoothItem(item it);
 boolean auto_thisClanPhotoBoothHasItem(item it);
 boolean auto_thisClanPhotoBoothHasItems(boolean[item] items);
+int auto_remainingClanPhotoBoothItems();
 boolean auto_getClanPhotoBoothDefaultItems();
+boolean auto_getClanPhotoBoothDefaultItems(int n_reserve);
+boolean auto_getClanPhotoBoothItems(boolean[item] items_to_claim);
 boolean auto_getClanPhotoBoothItem(item it);
 int auto_remainingClanPhotoBoothEffects();
 boolean auto_getClanPhotoBoothEffect(effect ef);
@@ -1487,6 +1490,8 @@ void equipRollover(boolean silent);
 boolean auto_forceEquipSword(boolean speculative);
 boolean auto_forceEquipSword();
 boolean is_watch(item it);
+int[item] auto_getAllEquipabble();
+int[item] auto_getAllEquipabble(slot s);
 
 ########################################################################################################
 //Defined in autoscend/auto_familiar.ash
@@ -1576,6 +1581,12 @@ location ListOutput(location[int] list);
 effect[int] effectList();
 int[int] intList();
 item[int] itemList();
+
+// Handy sorts of item lists
+item[int] auto_sortedByModifier(int[item]     list, modifier m);
+item[int] auto_sortedByModifier(int[item]     list, modifier m, boolean high_to_low);
+item[int] auto_sortedByModifier(boolean[item] list, modifier m);
+item[int] auto_sortedByModifier(boolean[item] list, modifier m, boolean high_to_low);
 
 ########################################################################################################
 //Defined in autoscend/autoscend_migration.ash
@@ -1939,3 +1950,5 @@ float substat_to_level();
 float substat_to_level(int n);
 stat stat_to_substat(stat s);
 float stat_exp_percent(stat s);
+stat auto_getOffStatChallengeFromTelescope();
+element auto_getElementChallengeFromTelescope();

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -733,7 +733,7 @@ boolean auto_getClanPhotoBoothDefaultItems(int reserve)
 	
 	// Check sheriff items (off-stat only, for tower)
 	// Don't do this d1 unless we're in turbo
-	if (daycount()>1 || auto_turbo())
+	if (my_daycount()>1 || auto_turbo())
 	{
 		stat challenge_stat = auto_getOffStatChallengeFromTelescope();
 		if (challenge_stat == $stat[muscle])
@@ -838,6 +838,7 @@ boolean auto_getClanPhotoBoothItem(item it)
 	
 	// Actually claim the item
 	cli_execute("photobooth item "+to_string(it));
+	handleTracker("Clan Photo Booth","Claimed "+it, "auto_otherstuff");
 	
 	// Go home if we BAFH'd it
 	if (orig_clan_id != get_clan_id())


### PR DESCRIPTION
# Description

Add more granularity to photobooth item picking.

Default item logic:
- If fake arrow is better for -combat than any other hat we have, and we have no fireworks access to buy a popper, take fake arrow.
- If astronaut helmet is best cold red hat we have available and we'll mouthwash level, take fake arrow.
- If turbo or day count > 1, take off-stat sheriff items, matched to tower using telescope
  - If no telescope, reserve un-pulled slot for tower use.
- Take monocle if best-in-slot for item (special case for unbrella)
- Take feather boa

Also adds several helper funcs:
- Get all equippable items for slot
- Sort item maps by numeric modifier
- Telescope for off-stat/element test info

## How Has This Been Tested?

d2 (last) of HC Standard, d1 of HC standard.

Desperately needs testing out of unrestricted - logic has been written for out-of-standard items but not tested.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
