### PR TITLE
don't habitat tentacles if they'll be non-free

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28258;	// fix: noncomforcers avalanche name
+since r28301;	// _eldritchTentaclesFoughtToday variable
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -730,6 +730,12 @@ boolean auto_habitatTarget(monster target)
 		 	boolean sonofa_complete = get_property("sidequestLighthouseCompleted") == "hippy" || get_property("sidequestLighthouseCompleted") == "fratboy";
 			return (!sonofa_complete && item_amount($item[barrel of gunpowder])<4);
 		case $monster[eldritch tentacle]:
+			// Max tentacles fought being free is 11, so don't habitat if we've fought more than 6
+			// This variable increments at the end of combat, so we need 5 here.
+			if (get_property("eldritchTentaclesFought").to_int() > 5)
+			{
+				return false;
+			}
 			// don't habitat free fights in avant guard
 			return (!in_avantGuard() && (get_property("auto_habitatMonster").to_monster() == target || (get_property("_monsterHabitatsMonster").to_monster() == target && get_property("_monsterHabitatsFightsLeft").to_int() == 0)));
 		default:

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -742,7 +742,7 @@ boolean auto_habitatTarget(monster target)
 		case $monster[eldritch tentacle]:
 			// Max tentacles fought being free is 11, so don't habitat if we've fought more than 6
 			// This variable increments at the end of combat, so we need 5 here.
-			if (get_property("eldritchTentaclesFought").to_int() > 5)
+			if (get_property("_eldritchTentaclesFoughtToday").to_int() > 5)
 			{
 				return false;
 			}


### PR DESCRIPTION
# Description

Late nerf day made tentacles above 11 non-free. This can waste turns if we habitat them. So I turned off habitating them if they're going to be non-free.

## How Has This Been Tested?

One day on a HC Standard character with BoFa. Needs more testing, specifically checking if we're pushing it too far or maybe the limit can be increased by one.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
