### PR TITLE
fix: get wet stew in hardcore

### DIFF
--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1206,8 +1206,8 @@ boolean doBedtime()
 	if (auto_haveMonkeyPaw() && auto_monkeyPawWishesLeft() > 0)
 	{
 		boolean success = true;
-		// if we unlocked the guild and the beach, unlock Whitey's Grove so we can get bird rib / lion oil
-		if (get_property("lastGuildStoreOpen").to_int() == my_ascensions() && get_property("lastDesertUnlock").to_int() == my_ascensions()) {
+		// if we unlocked the guild and have a meatcar, unlock Whitey's Grove so we can get bird rib / lion oil
+		if (get_property("lastGuildStoreOpen").to_int() == my_ascensions() && item_amount($item[bitchin' meatcar]) > 0) {
 			// start, then finish the meatcar quest
 			if (internalQuestStatus("questG01Meatcar") < 1) {
 				visit_url("guild.php?place=paco");
@@ -1218,6 +1218,7 @@ boolean doBedtime()
 			// open Whitey's Grove
 			if (internalQuestStatus("questG02Whitecastle") < 0) {
 				visit_url("guild.php?place=paco");
+				run_choice(1);
 			}
 			foreach it in $items[Lion Oil, Bird Rib]
 			{

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -1203,9 +1203,28 @@ boolean doBedtime()
 			effect_to_wish = $effect[One Very Clear Eye];
 		}
 	}
-	if (auto_haveMonkeyPaw())
+	if (auto_haveMonkeyPaw() && auto_monkeyPawWishesLeft() > 0)
 	{
 		boolean success = true;
+		// if we unlocked the guild and the beach, unlock Whitey's Grove so we can get bird rib / lion oil
+		if (get_property("lastGuildStoreOpen").to_int() == my_ascensions() && get_property("lastDesertUnlock").to_int() == my_ascensions()) {
+			// start, then finish the meatcar quest
+			if (internalQuestStatus("questG01Meatcar") < 1) {
+				visit_url("guild.php?place=paco");
+			}
+			if (internalQuestStatus("questG01Meatcar") < 1) {
+				visit_url("guild.php?place=paco");
+			}
+			// open Whitey's Grove
+			if (internalQuestStatus("questG02Whitecastle") < 0) {
+				visit_url("guild.php?place=paco");
+			}
+			foreach it in $items[Lion Oil, Bird Rib]
+			{
+				if(item_amount(it) > 0) continue;
+				auto_makeMonkeyPawWish(it);
+			}
+		}
 		while (auto_monkeyPawWishesLeft() > 0 && success)
 		{
 			success = auto_makeMonkeyPawWish(effect_to_wish);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2921,6 +2921,25 @@ boolean L11_palindome()
 	}
 
 	auto_log_info("In the palindome : emodnilap eht nI", "blue");
+
+	boolean makeWetStuntNutStew()
+	{
+		 if((item_amount($item[Bird Rib]) > 0) && (item_amount($item[Lion Oil]) > 0) && (item_amount($item[Wet Stew]) == 0))
+		{
+			autoCraft("cook", 1, $item[Bird Rib], $item[Lion Oil]);
+		}
+
+		if((item_amount($item[Stunt Nuts]) > 0) && (item_amount($item[Wet Stew]) > 0) && (item_amount($item[Wet Stunt Nut Stew]) == 0))
+		{
+			autoCraft("cook", 1, $item[wet stew], $item[stunt nuts]);
+		}
+		if(item_amount($item[wet stunt nut stew]) > 0)
+		{
+			return true;
+		}
+		return false;
+	}
+
 	#
 	#	In hardcore, guild-class, the right side of the or doesn't happen properly due us farming the
 	#	Mega Gem within the if, with pulls, it works fine. Need to fix this. This is bad.
@@ -2975,24 +2994,6 @@ boolean L11_palindome()
 		auto_lostStomach(true);
 		auto_log_info("Off to the grove for some doofy food!", "blue");
 		return autoAdv(1, $location[Whitey\'s Grove]);
-	}
-
-	boolean makeWetStuntNutStew()
-	{
-		 if((item_amount($item[Bird Rib]) > 0) && (item_amount($item[Lion Oil]) > 0) && (item_amount($item[Wet Stew]) == 0))
-		{
-			autoCraft("cook", 1, $item[Bird Rib], $item[Lion Oil]);
-		}
-
-		if((item_amount($item[Stunt Nuts]) > 0) && (item_amount($item[Wet Stew]) > 0) && (item_amount($item[Wet Stunt Nut Stew]) == 0))
-		{
-			autoCraft("cook", 1, $item[wet stew], $item[stunt nuts]);
-		}
-		if(item_amount($item[wet stunt nut stew]) > 0)
-		{
-			return true;
-		}
-		return false;
 	}
 
 	if(item_amount($item[wet stunt nut stew]) == 0 && internalQuestStatus("questL11Palindome") >= 3)

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3095,18 +3095,19 @@ boolean L11_palindome()
 	}
 	else
 	{
-		if(!in_hardcore() && pulls_remaining() == 0)
+		if(pulls_remaining() == 0)
 		{
 			// used our pulls today before getting to palindrome. Delay until next day or run out of other stuff to do
 			if(!isAboutToPowerlevel())
 			{
-				auto_log_debug("Delaying palindrome. In a normal run and don't have enough pulls to create wet stunt nut stew.");
+				auto_log_debug("Delaying palindrome.");
 				return false;
 			}
 			else
 			{
 				//After we get the photos
-				//First try wishing, then try Whitey's if we have enough +item, then brute force.
+				//First try wishing, then try Whitey's. At 0% item / combat / food drop, this expects to take ~19 turns. At a very achievable 100% item, 10 turns.
+				//The alternate route takes 14 turns so always worth trying Whitey's IMO.
 				//If we hit this, we should only need to finish the L11 quest so it won't hurt to do everything in provideItem
 				//since we will need +item for tomb rats in ~15 turns anyway. Buffs from wishes should still be active
 				//since they are 30 turns from monkey paw wishes and 20 turns from pocket/genie wishes.
@@ -3125,14 +3126,12 @@ boolean L11_palindome()
 						}
 						return false; //wasn't able to make the stew
 					}
-					else if(provideItem(300, $location[Whitey's Grove], true, true) >= 300)
+					else 
 					{
+						provideItem(300, $location[Whitey's Grove], true);
+						providePlusCombat(15, $location[Whitey's Grove], false);
 						set_property("auto_doWhiteys", true);
 						return doWhiteys(); //Initial call to do Whitey's Grove
-					}
-					else
-					{
-						set_property("auto_bruteForcePalindome",true);
 					}
 				}
 			}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2965,7 +2965,8 @@ boolean L11_palindome()
 			}
 			//wasn't able to make the stew so continue to Whitey's
 		}
-		provideItem(300, $location[Whitey's Grove], true);
+		// in normal, we delayed until this was all we had to do. In hardcore we do it earlier.
+		provideItem(300, $location[Whitey's Grove], !in_hardcore());
 		set_property("auto_doWhiteys", true);
 		if(item_amount($item[white page]) > 0)
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -2927,6 +2927,27 @@ boolean L11_palindome()
 	#
 	boolean doWhiteys()
 	{
+		//After we get the photos
+		//First try wishing, then try Whitey's. At 0% item / combat / food drop, this expects to take ~19 turns. At a very achievable 100% item, 10 turns.
+		//The alternate route takes 14 turns so always worth trying Whitey's IMO.
+		//If we hit this, we should only need to finish the L11 quest so it won't hurt to do everything in provideItem
+		//since we will need +item for tomb rats in ~15 turns anyway. Buffs from wishes should still be active
+		//since they are 30 turns from monkey paw wishes and 20 turns from pocket/genie wishes.
+		if(auto_monkeyPawWishesLeft() > 0)
+		{
+			foreach it in $items[Lion Oil, Bird Rib]
+			{
+				if(item_amount(it) > 0) continue;
+				auto_makeMonkeyPawWish(it);
+			}
+			if(item_amount($item[Lion Oil]) > 0 && item_amount($item[Bird Rib]) > 0)
+			{
+				return makeWetStuntNutStew();
+			}
+			//wasn't able to make the stew so continue to Whitey's
+		}
+		provideItem(300, $location[Whitey's Grove], true);
+		set_property("auto_doWhiteys", true);
 		if(item_amount($item[white page]) > 0)
 		{
 			set_property("choiceAdventure940", 1);
@@ -2948,6 +2969,7 @@ boolean L11_palindome()
 			restoreSetting("lastGuildStoreOpen");
 			return true;
 		}
+		providePlusCombat(15, $location[Whitey's Grove], false);
 		// +item is nice to get that food
 		bat_formBats();
 		auto_lostStomach(true);
@@ -2975,7 +2997,9 @@ boolean L11_palindome()
 
 	if(item_amount($item[wet stunt nut stew]) == 0 && internalQuestStatus("questL11Palindome") >= 3)
 	{
-		return makeWetStuntNutStew();
+		if (makeWetStuntNutStew()) {
+			return true;
+		}
 	}
 
 	if((item_amount($item[Wet Stunt Nut Stew]) > 0) && !possessEquipment($item[Mega Gem]))
@@ -3105,34 +3129,9 @@ boolean L11_palindome()
 			}
 			else
 			{
-				//After we get the photos
-				//First try wishing, then try Whitey's. At 0% item / combat / food drop, this expects to take ~19 turns. At a very achievable 100% item, 10 turns.
-				//The alternate route takes 14 turns so always worth trying Whitey's IMO.
-				//If we hit this, we should only need to finish the L11 quest so it won't hurt to do everything in provideItem
-				//since we will need +item for tomb rats in ~15 turns anyway. Buffs from wishes should still be active
-				//since they are 30 turns from monkey paw wishes and 20 turns from pocket/genie wishes.
 				if (internalQuestStatus("questL11Palindome") > 2)
 				{
-					if(auto_monkeyPawWishesLeft() > 0)
-					{
-						foreach it in $items[Lion Oil, Bird Rib]
-						{
-							if(item_amount(it) > 0) continue;
-							auto_makeMonkeyPawWish(it);
-						}
-						if(item_amount($item[Lion Oil]) > 0 && item_amount($item[Bird Rib]) > 0)
-						{
-							return makeWetStuntNutStew();
-						}
-						return false; //wasn't able to make the stew
-					}
-					else 
-					{
-						provideItem(300, $location[Whitey's Grove], true);
-						providePlusCombat(15, $location[Whitey's Grove], false);
-						set_property("auto_doWhiteys", true);
-						return doWhiteys(); //Initial call to do Whitey's Grove
-					}
+					return doWhiteys(); //Initial call to do Whitey's Grove
 				}
 			}
 		}


### PR DESCRIPTION
# Description
Hopefully fix the issue with not getting wet stew in hardcore.

Also redo the logic a bit: don't force us to have +300 item to do Whitey's: it is normally worth doing. Additionally, +food drops count, and a shiny character will have rollercoaster / bat wings that aren't counted in the 300.

Also try to monkeypaw items at the end of day 1 with the guild and beach unlocked, that happens e.g. with a tearaway pants moxie class.

## How Has This Been Tested?

Not yet.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
