### PR TITLE
Lucky tracker, tracker changes, try to clover baa'baa before summon

### DIFF
--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -406,6 +406,12 @@ void main()
 		generateTrackingData("auto_powerfulglove");
 	}
 
+	if(get_property("auto_iotm_claim") != "")
+	{
+		writeln("<h2>IOTM Item/Effects Claimed.</h2>");
+		generateTrackingData("auto_iotm_claim");
+	}
+	
 	writeln("<h2>Other Stuff</h2>");
 	generateTrackingData("auto_otherstuff");
 

--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -70,7 +70,7 @@ void handleSetting(string type, int x)
 	writeln("<input type='hidden' name='"+set.name+"_oldvalue' value='"+get_property(set.name)+"' />");
 }
 
-void generateTrackingData(string tracked)
+void generateTrackingData(string tracked, string print_between, boolean stacked)
 {
 	int day = 0;
 	string[int] tracking = split_string(get_property(tracked), ",");
@@ -78,19 +78,40 @@ void generateTrackingData(string tracked)
 	{
 		return;
 	}
-	foreach x in tracking
+	string[int] tracking_stacked;
+	int[int] stack_counts;
+	int unique_idx = -1;
+	string last_event = "";
+	foreach idx,event in tracking
 	{
-		if(tracking[x] == "")
+		if (last_event != event)
+		{
+			unique_idx++;
+			tracking_stacked[unique_idx] = event;
+			stack_counts[unique_idx] = 1;
+			last_event = event;
+		}
+		else
+		{
+			stack_counts[unique_idx]++;
+		}
+	}
+	
+	string[int] tracking_to_use = (stacked?tracking_stacked:tracking);
+	
+	foreach idx,event in tracking_to_use
+	{
+		if(event == "")
 		{
 			continue;
 		}
-		matcher paren = create_matcher("[()]", tracking[x]);
-		tracking[x] = replace_all(paren, "");
-		matcher asdon = create_matcher("Asdon Martin:", tracking[x]);
-		tracking[x] = replace_all(asdon, "Asdon Martin -");
-		matcher cheat = create_matcher("CHEAT CODE:", tracking[x]);
-		tracking[x] = replace_all(cheat, "CHEAT CODE -");
-		string[int] current = split_string(tracking[x], ":");
+		matcher paren = create_matcher("[()]", event);
+		event = replace_all(paren, "");
+		matcher asdon = create_matcher("Asdon Martin:", event);
+		event = replace_all(asdon, "Asdon Martin -");
+		matcher cheat = create_matcher("CHEAT CODE:", event);
+		event = replace_all(cheat, "CHEAT CODE -");
+		string[int] current = split_string(event, ":");
 		int curDay = to_int(current[0]);
 		if(curDay > day)
 		{
@@ -99,7 +120,7 @@ void generateTrackingData(string tracked)
 			{
 				writeln("<br><br>");
 			}
-			writeln("Day " + day + ": ");
+			writeln("<b>Day " + day + ":</b>");
 		}
 		string toWrite = "(";
 		for i from 1 to count(current) - 1
@@ -110,9 +131,36 @@ void generateTrackingData(string tracked)
 				toWrite = toWrite + ":";
 			}
 		}
-		toWrite = toWrite + "),";
+		if (stacked)
+		{
+			if (stack_counts[idx] > 1)
+			{
+				toWrite = toWrite + " <b>x"+to_string(stack_counts[idx])+"</b>";
+			}
+		}
+		toWrite = toWrite + ")"+print_between;
 		writeln(toWrite);
 	}
+}
+
+void generateTrackingData(string tracked, boolean stacked)
+{
+	generateTrackingData(tracked, ",", stacked);
+}
+
+void generateTrackingData(string tracked)
+{
+	generateTrackingData(tracked, true);
+}
+
+void generateTrackingDataSplitByNewLine(string tracked, boolean stacked)
+{
+	generateTrackingData(tracked, "<br>", stacked);
+}
+
+void generateTrackingDataSplitByNewLine(string tracked)
+{
+	generateTrackingDataSplitByNewLine(tracked, true);
 }
 
 void write_familiar()
@@ -310,7 +358,7 @@ void main()
 	writeln(get_property("auto_beatenUpLocations"));
 
 	writeln("<h2>Forced Noncombats</h2>");
-	generateTrackingData("auto_forcedNC");
+	generateTrackingDataSplitByNewLine("auto_forcedNC");
 
 	writeln("<h2>Eated</h2>");
 	generateTrackingData("auto_eaten");
@@ -327,6 +375,9 @@ void main()
 		writeln("<h2>Wishes</h2>");
 		generateTrackingData("auto_wishes");
 	}
+
+	writeln("<h2>Lucky Adventures</h2>");
+	generateTrackingDataSplitByNewLine("auto_lucky");
 
 	if(isActuallyEd())
 	{

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -219,6 +219,8 @@ void initializeSettings() {
 	set_property("auto_instakill", "");
 	set_property("auto_instakillSource", "");
 	set_property("auto_instakillSuccess", false);
+	set_property("auto_iotm_claim", "");
+	set_property("auto_lucky", "");
 	set_property("auto_luckySource", "none");
 	set_property("auto_modernzmobiecount", "");
 	set_property("auto_powerfulglove", "");

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -219,6 +219,7 @@ void initializeSettings() {
 	set_property("auto_instakill", "");
 	set_property("auto_instakillSource", "");
 	set_property("auto_instakillSuccess", false);
+	set_property("auto_luckySource", "none");
 	set_property("auto_modernzmobiecount", "");
 	set_property("auto_powerfulglove", "");
 	set_property("auto_otherstuff", "");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1371,10 +1371,13 @@ boolean cloverUsageInit(boolean override)
 		return true;
 	}
 	
+	set_property("auto_luckySource","none");
+	
 	if (auto_AprilSaxLuckyLeft() > 0)
 	{
 		if (auto_playAprilSax()) {
 			auto_log_info("Clover usage initialized, using Apriling sax.");
+			set_property("auto_luckySource",to_string($item[Apriling Band Saxophone]));
 			return true;
 		}
 		else
@@ -1389,7 +1392,8 @@ boolean cloverUsageInit(boolean override)
 		use_skill($skill[Aug. 2nd: Find an Eleven-Leaf Clover Day]);
 		if (have_effect($effect[Lucky!]) > 0)
 		{
-			auto_log_info("Clover usage initialized");
+			auto_log_info("Clover usage initialized using August Scepter.");
+			set_property("auto_luckySource",to_string($item[August Scepter]));
 			return true;
 		}
 		else
@@ -1409,7 +1413,8 @@ boolean cloverUsageInit(boolean override)
 		use(1, $item[11-Leaf Clover]);
 		if (have_effect($effect[Lucky!]) > 0)
 		{
-			auto_log_info("Clover usage initialized");
+			auto_log_info("Clover usage initialized using clover.");
+			set_property("auto_luckySource",to_string($item[11-Leaf Clover]));
 			return true;
 		}
 		else
@@ -1431,7 +1436,8 @@ boolean cloverUsageInit(boolean override)
 			chew(1, $item[[10883]Astral Energy Drink]);
 			if (have_effect($effect[Lucky!]) > 0)
 			{
-				auto_log_info("Clover usage initialized");
+				auto_log_info("Clover usage initialized using Astral Energy Drink");
+				set_property("auto_luckySource",to_string($item[[10883]Astral Energy Drink]));
 				return true;
 			}
 			else
@@ -1470,6 +1476,11 @@ boolean cloverUsageFinish()
 	if(have_effect($effect[Lucky!]) > 0)
 	{
 		abort("Wandering adventure interrupted our clover adventure (" + my_location() + ").");
+	}
+	else
+	{
+		handleTracker(get_property("auto_luckySource"),my_location()+" - "+get_property("lastEncounter"),"auto_lucky");
+		set_property("auto_luckySource", "none");
 	}
 	return true;
 }

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1479,7 +1479,7 @@ boolean cloverUsageFinish()
 	}
 	else
 	{
-		handleTracker(get_property("auto_luckySource"),my_location()+" - "+get_property("lastEncounter"),"auto_lucky");
+		handleTracker(get_property("auto_luckySource"), my_location().to_string(), get_property("lastEncounter"), "auto_lucky");
 		set_property("auto_luckySource", "none");
 	}
 	return true;

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -544,33 +544,44 @@ boolean auto_haveTakerSpace()
 void auto_checkTakerSpace()
 {
 	if(!auto_haveTakerSpace()) return;
+	static item ts_letter = $item[TakerSpace letter of Marque];
 	if(!get_property("_takerSpaceSuppliesDelivered").to_boolean()) {
 		// visit the workshed to get the supplies
 		visit_url("campground.php?action=workshed");
 	}
 	// unlock the island if we can (6 turn save)
 	if(get_property("lastIslandUnlock").to_int() < my_ascensions() && item_amount($item[pirate dinghy]) == 0 && creatable_amount($item[pirate dinghy]) > 0) {
-		create(1, $item[pirate dinghy]);
+		if (create(1, $item[pirate dinghy])) {
+			handleTracker(to_string(ts_letter),$item[pirate dinghy],"auto_iotm_claim");
+		}
 	}
 	// deft pirate hook would be worth it but hard for autoscend to use
 	// anchor bomb is a free banish but only for 30 turns, if we have Spring Kick we won't use it
 	if(!(auto_haveSpringShoes() && auto_is_valid($skill[Spring Kick])) && creatable_amount($item[anchor bomb]) > 0) {
-		create(1, $item[anchor bomb]);
+		if (create(1, $item[anchor bomb])) {
+			handleTracker(to_string(ts_letter),$item[anchor bomb],"auto_iotm_claim");
+		}
 	}
 	// goldschlepper is EPIC booze
 	int createable = creatable_amount($item[tankard of spiced Goldschlepper]);
 	if(createable > 0) {
-		create(createable, $item[tankard of spiced Goldschlepper]);
+		if (create(1, $item[tankard of spiced Goldschlepper])) {
+			handleTracker(to_string(ts_letter),$item[tankard of spiced Goldschlepper],"auto_iotm_claim");
+		}
 	}
 	// tankard of spiced rum is awesome booze
 	createable = creatable_amount($item[tankard of spiced rum]);
 	if(createable > 0) {
-		create(createable, $item[tankard of spiced rum]);
+		if (create(1, $item[tankard of spiced rum])) {
+			handleTracker(to_string(ts_letter),$item[tankard of spiced rum],"auto_iotm_claim");
+		}
 	}
 	// cursed Aztec tamale is awesome food, and only uses spices
 	createable = creatable_amount($item[cursed Aztec tamale]);
 	if(createable > 0) {
-		create(createable, $item[cursed Aztec tamale]);
+		if (create(1, $item[cursed Aztec tamale])) {
+			handleTracker(to_string(ts_letter),$item[cursed Aztec tamale],"auto_iotm_claim");
+		}
 	}
 }
 
@@ -703,6 +714,7 @@ boolean auto_getClanPhotoBoothItem(item it)
 	
 	// Actually claim the item
 	cli_execute("photobooth item "+to_string(it));
+	handleTracker("Clan Photo Booth","Claimed "+it, "auto_iotm_claim");
 	
 	// Go home if we BAFH'd it
 	if (orig_clan_id != get_clan_id())
@@ -802,6 +814,7 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 			for (int i = 0 ; i < n_times ; i++)
 			{
 				cli_execute("photobooth effect wild");
+				handleTracker("Clan Photo Booth","Claimed "+west_ef, "auto_iotm_claim");
 			}
 			success = to_boolean(have_effect(west_ef));
 			break;
@@ -810,6 +823,7 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 			for (int i = 0 ; i < n_times ; i++)
 			{
 				cli_execute("photobooth effect tower");
+				handleTracker("Clan Photo Booth","Claimed "+tower_ef, "auto_iotm_claim");
 			}
 			success = to_boolean(have_effect(tower_ef));
 			break;
@@ -818,6 +832,7 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 			for (int i = 0 ; i < n_times ; i++)
 			{
 				cli_execute("photobooth effect space");
+				handleTracker("Clan Photo Booth","Claimed "+space_ef, "auto_iotm_claim");
 			}
 			success = to_boolean(have_effect(space_ef));
 			break;

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1445,9 +1445,8 @@ boolean L11_unlockHiddenCity()
 	auto_log_info("Searching for the Hidden City", "blue");
 	if(!in_glover() && !in_tcrs()) 
 	{
-		if(item_amount($item[Stone Wool]) == 0 && have_effect($effect[Stone-Faced]) == 0 && canSummonMonster($monster[Baa\'baa\'bu\'ran]))
-		{
-			//attempt to summon before using a clover
+		if(item_amount($item[Stone Wool]) == 0 && have_effect($effect[Stone-Faced]) == 0)
+		{	// try to clover/summon baa baa first
 			if(auto_haveGreyGoose()){
 				auto_log_info("Bringing the Grey Goose to emit some drones at a Sheep carving.");
 				handleFamiliar($familiar[Grey Goose]);
@@ -1456,15 +1455,17 @@ boolean L11_unlockHiddenCity()
 				handleFamiliar("item");
 			}
 			addToMaximize("20 item 400max");
-			if(summonMonster($monster[Baa\'baa\'bu\'ran]))
+			
+			// Right now clovers are "cheaper" than summons, so use clover first, but not our last.
+			if(cloversAvailable() > 1)
 			{
-				return true;
+				return autoLuckyAdv($location[The Hidden Temple]);
 			}
-		}
-		if(item_amount($item[Stone Wool]) == 0 && have_effect($effect[Stone-Faced]) == 0 && cloversAvailable() > 0) 
-		{
-			//use clover to get 2x Stone Wool
-			return autoLuckyAdv($location[The Hidden Temple]);
+			
+			if(canSummonMonster($monster[Baa\'baa\'bu\'ran]))
+			{
+				return summonMonster($monster[Baa\'baa\'bu\'ran]);
+			}
 		}
 		if(item_amount($item[Stone Wool]) == 0 && have_effect($effect[Stone-Faced]) == 0)
 		{


### PR DESCRIPTION
# Description

- We've needed tracking of lucky adventures for a while, so this adds that.
- Lucky is now abundant, summons rare. So this switchess the priorities for how to get Baa'baa'bu'ran to clovering first.
- The tracker has got busy recently. We have some long entries, and some multiples (douse, for example, spams).
  - We can now specify the delimiter per tracker, so short entries can still be commas while long ones might be newlines.
  - We can now stack multiple identical entries in the tracker. What was before (shadow slab:Perpetrate Mild Evil:0),(shadow slab:Perpetrate Mild Evil:0),(shadow slab:Perpetrate Mild Evil:0) now shows as (shadow slab:Perpetrate Mild Evil:0 x3).
  - Bold daycount.

Fixes # (issue)

## How Has This Been Tested?

D1 standard HC, shiny character, forced some lucky adventures (by manually calling `autoLuckyAdv()`). Lots of checks of relay page.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
