### PR TITLE
fix McHugeLarge slash and Monkey paw sniffs

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -612,6 +612,7 @@ boolean auto_haveMcHugeLargeSkis();
 boolean auto_equipAllMcHugeLarge();
 boolean auto_openMcLargeHugeSkis();
 int auto_McLargeHugeForcesLeft();
+int auto_McLargeHugeSniffsLeft();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -253,17 +253,31 @@ skill getSniffer(monster enemy, boolean inCombat)
 	{
 		return $skill[Motif];
 	}
+	if (inCombat)
+	{
+		if(canUse($skill[Monkey Point], true , inCombat) && !isSniffed(enemy, $skill[Monkey Point]))
+		{
+			return $skill[Monkey Point];
+		}
+		if(canUse($skill[McHugeLarge Slash], true , inCombat) && !isSniffed(enemy, $skill[McHugeLarge Slash]))
+		{
+			return $skill[McHugeLarge Slash];
+		}
+	}
+	else
+	{
+		if (auto_monkeyPawWishesLeft()==1 && !isSniffed(enemy, $skill[Monkey Point]))
+		{
+			return $skill[Monkey Point];
+		}
+		if (possessEquipment($item[McHugeLarge left pole]) && !isSniffed(enemy, $skill[McHugeLarge Slash]))
+		{
+			return $skill[McHugeLarge Slash];
+		}
+	}
 	if(canUse($skill[Gallapagosian Mating Call], true , inCombat) && !isSniffed(enemy, $skill[Gallapagosian Mating Call]))
 	{
 		return $skill[Gallapagosian Mating Call];
-	}
-	if(canUse($skill[Monkey Point], true , inCombat) && !isSniffed(enemy, $skill[Monkey Point]))
-	{
-		return $skill[Monkey Point];
-	}
-	if(canUse($skill[McHugeLarge Slash], true , inCombat) && !isSniffed(enemy, $skill[McHugeLarge Slash]))
-	{
-		return $skill[McHugeLarge Slash];
 	}
 	if(my_familiar() == $familiar[Nosy Nose] && canUse($skill[Get a Good Whiff of This Guy]) && !isSniffed(enemy,$skill[Get a Good Whiff of This Guy]))
 	{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -259,7 +259,7 @@ skill getSniffer(monster enemy, boolean inCombat)
 		{
 			return $skill[Monkey Point];
 		}
-		if(canUse($skill[McHugeLarge Slash], true , inCombat) && !isSniffed(enemy, $skill[McHugeLarge Slash]))
+		if(canUse($skill[McHugeLarge Slash], true , inCombat) && !isSniffed(enemy, $skill[McHugeLarge Slash]) && auto_McLargeHugeSniffsLeft()>0)
 		{
 			return $skill[McHugeLarge Slash];
 		}
@@ -270,7 +270,7 @@ skill getSniffer(monster enemy, boolean inCombat)
 		{
 			return $skill[Monkey Point];
 		}
-		if (possessEquipment($item[McHugeLarge left pole]) && !isSniffed(enemy, $skill[McHugeLarge Slash]))
+		if (possessEquipment($item[McHugeLarge left pole]) && !isSniffed(enemy, $skill[McHugeLarge Slash]) && auto_McLargeHugeSniffsLeft()>0)
 		{
 			return $skill[McHugeLarge Slash];
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2025.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2025.ash
@@ -51,3 +51,13 @@ int auto_McLargeHugeForcesLeft()
 	int used = get_property("_mcHugeLargeAvalancheUses").to_int();
 	return 3-used;
 }
+
+int auto_McLargeHugeSniffsLeft()
+{
+	if (!auto_haveMcHugeLargeSkis())
+	{
+		return 0;
+	}
+	int used = get_property("_mcHugeLargeSlashUses").to_int();
+	return 3-used;
+}


### PR DESCRIPTION
# Description

In standard right now, we have 2 IOTM sniffs once you're out of olfaction: Monkey Point and McHugeLarge Slash.

This didn't work. This makes them work.

## How Has This Been Tested?

D2 of standard HC run on shiny character.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
