### PR TITLE
fix: don't try to comb with no adventures

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -809,6 +809,7 @@ int auto_beachCombFreeUsesLeft(){
 
 boolean auto_beachUseFreeCombs() {
 	int freeCombs = auto_beachCombFreeUsesLeft();
+	if(my_adventures() == 0) { return false; }
 	if(freeCombs <= 0) { return false; }
 	cli_execute(`combo {freeCombs}`);
 	return true;


### PR DESCRIPTION
# Description

You can't beach comb with no adventures left, so don't try.

## How Has This Been Tested?

Ran it when I hit the bug.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
