### PR TITLE
Add functions to sort raw Mafia variable container types by numeric modifiers

### DIFF
--- a/RELEASE/scripts/autoscend/auto_list.ash
+++ b/RELEASE/scripts/autoscend/auto_list.ash
@@ -1004,4 +1004,73 @@ string ListOutput(location[int] list)
 	return retval;
 }
 
+// Sorting.
+// Uses boolean[TYPE] to allow use on Mafia list types eg $items[]
+
+item[int] auto_sortedByModifier(int[item] map, modifier m)
+{
+	return auto_sortedByModifier(map,m,true);
+}
+
+item[int] auto_sortedByModifier(int[item] map, modifier m, boolean high_to_low)
+{
+	item[int] ranked_list;
+	foreach entry in map
+	{
+		ranked_list[count(ranked_list)] = entry;
+	}
+	// Sort
+	float sign = high_to_low ? -1 : 1;
+	sort ranked_list by sign * numeric_modifier(value,m);
+	return ranked_list;
+}
+
+item[int] auto_sortedByModifier(boolean[item] map, modifier m)
+{
+	return auto_sortedByModifier(map,m,true);
+}
+
+item[int] auto_sortedByModifier(boolean[item] map, modifier m, boolean high_to_low)
+{
+	int[item] int_map;
+	foreach entry in map
+	{
+		int_map[entry]++;
+	}
+	return auto_sortedByModifier(int_map,m,high_to_low);
+}
+
+effect[int] auto_sortedByModifier(int[effect] map, modifier m)
+{
+	return auto_sortedByModifier(map,m,true);
+}
+
+effect[int] auto_sortedByModifier(int[effect] map, modifier m, boolean high_to_low)
+{
+	effect[int] ranked_list;
+	foreach entry in map
+	{
+		ranked_list[count(ranked_list)] = entry;
+	}
+	// Sort
+	float sign = high_to_low ? -1 : 1;
+	sort ranked_list by sign * numeric_modifier(value,m);
+	return ranked_list;
+}
+
+effect[int] auto_sortedByModifier(boolean[effect] map, modifier m)
+{
+	return auto_sortedByModifier(map,m,true);
+}
+
+effect[int] auto_sortedByModifier(boolean[effect] map, modifier m, boolean high_to_low)
+{
+	int[effect] int_map;
+	foreach entry in map
+	{
+		int_map[entry]++;
+	}
+	return auto_sortedByModifier(int_map,m,high_to_low);
+}
+
 //end of location[int]

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1580,6 +1580,17 @@ effect[int] effectList();
 int[int] intList();
 item[int] itemList();
 
+// Handy sorts of lists
+item[int] auto_sortedByModifier(int[item]     list, modifier m);
+item[int] auto_sortedByModifier(int[item]     list, modifier m, boolean high_to_low);
+item[int] auto_sortedByModifier(boolean[item] list, modifier m);
+item[int] auto_sortedByModifier(boolean[item] list, modifier m, boolean high_to_low);
+
+effect[int] auto_sortedByModifier(int[effect]     list, modifier m);
+effect[int] auto_sortedByModifier(int[effect]     list, modifier m, boolean high_to_low);
+effect[int] auto_sortedByModifier(boolean[effect] list, modifier m);
+effect[int] auto_sortedByModifier(boolean[effect] list, modifier m, boolean high_to_low);
+
 ########################################################################################################
 //Defined in autoscend/autoscend_migration.ash
 string autoscend_current_version();


### PR DESCRIPTION
# Description

This adds some useful sorting functions that take unsorted Mafia maps of items and effects, and returns them as lists sorted by a numeric modifier.

These functions are used in several upcoming PRs, I thought it was easier to get them in separately rather than having multiple re-merges.

## How Has This Been Tested?

Many runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
