### PR TITLE
Force NC to start war if have Cane/Cartogrpahy. Do it ASAP if we have all requirements.

### DIFF
--- a/BUILD/task_order/default.dat
+++ b/BUILD/task_order/default.dat
@@ -19,6 +19,8 @@ LX_lowkeySummer
 L11_aridDesert	L11_hasUltrahydrated
 # Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
 L11_shenStartQuest
+# If we have everything to start the war instantly, just do it so we can start flyering.
+L12_opportunisticWarStart
 # Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
 finishBuildingSmutOrcBridge
 # Call quest handlers based on current state if applicable

--- a/RELEASE/data/autoscend_task_order.txt
+++ b/RELEASE/data/autoscend_task_order.txt
@@ -253,6 +253,103 @@ Avatar of Jarlsberg	54	L13_towerAscent
 Avatar of Jarlsberg	55	auto_softBlockHandler
 Avatar of Jarlsberg	56	LX_attemptPowerLevel
 
+default	0	LX_freeCombatsTask
+default	1	woods_questStart
+default	2	LX_unlockPirateRealm
+default	3	catBurglarHeist
+default	4	auto_breakfastCounterVisit
+default	5	chateauPainting
+default	6	LX_setWorkshed
+default	7	LX_galaktikSubQuest
+default	8	L9_leafletQuest
+default	9	L5_findKnob
+default	10	L12_sonofaPrefix
+default	11	LX_burnDelay
+default	12	LX_summonMonster
+# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
+default	13	LM_edTheUndying
+default	14	LX_bugbearInvasion
+default	15	LX_lowkeySummer
+# make sure we don't waste turns of Ultrahydrated doing something else.
+default	16	L11_aridDesert	L11_hasUltrahydrated
+# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+default	17	L11_shenStartQuest
+# If we have everything to start the war instantly, just do it so we can start flyering.
+default	18	L12_opportunisticWarStart
+# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+default	19	finishBuildingSmutOrcBridge
+# Call quest handlers based on current state if applicable
+default	20	auto_earlyRoutingHandling
+# Guild access.
+default	21	LX_guildUnlock
+#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
+default	22	LX_unlockDesert
+default	23	LX_lockPicking
+default	24	LX_fatLootToken
+#	Get the Steel Organ if the user wants it (needs L6 quest complete)
+default	25	LX_steelOrgan
+# open up delay zones.
+default	26	LX_spookyravenManorFirstFloor
+# open up zones where we want to force non-combats.
+# Open up underground zones so they are available for Breathitin.
+default	27	L5_getEncryptionKey
+default	28	L5_findKnob
+#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
+default	29	L12_islandWar
+# Start the macguffin quest
+default	30	L11_blackMarket
+default	31	L11_forgedDocuments
+default	32	L11_mcmuffinDiary
+default	33	L11_getBeehive
+# open the hidden city up (delay zones)
+default	34	L2_mosquito
+default	35	LX_unlockHiddenTemple
+default	36	L6_dakotaFanning
+default	37	L11_unlockHiddenCity
+# Murder pygmies for the ancient amulet.
+default	38	L11_hiddenCityZones
+default	39	L11_hiddenCity
+# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
+default	40	LX_spookyravenManorSecondFloor
+default	41	L11_mauriceSpookyraven
+# Lay the smack down on those Jerk Copperhead twins
+default	42	L11_talismanOfNam
+# Open up the top of the beanstalk.
+default	43	L10_plantThatBean
+# Clean up the plains
+default	44	L10_rainOnThePlains
+# Get Black Angus his pizza
+default	45	L9_chasmBuild
+default	46	L9_highLandlord
+#  Kill Groar because *we* are the monsters.
+default	47	L8_trapperQuest
+# Kill the undead? Is this an oxymoron?
+default	48	L7_crypt
+# Cleanse the taint.
+default	49	L6_friarsGetParts
+# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
+default	50	L11_palindome
+default	51	L11_aridDesert
+default	52	L11_unlockPyramid
+default	53	L11_unlockEd
+default	54	L11_defeatEd
+#	Finish off the Goblin King.
+default	55	L5_slayTheGoblinKing
+# Show the Boss bat who's boss.
+default	56	L4_batCave
+# Fix that dripping tap.
+default	57	L3_tavern
+# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
+default	58	L2_mosquito
+# There's an extra task in KoE
+default	59	LX_koeInvaderHandler
+# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
+default	60	L13_towerAscent
+# release the hounds!
+default	61	auto_softBlockHandler
+# if all else fails, powerlevel like there's no tomorrow.
+default	62	LX_attemptPowerLevel
+
 Legacy of Loathing	0	LX_freeCombatsTask
 Legacy of Loathing	1	woods_questStart
 Legacy of Loathing	2	LX_unlockPirateRealm
@@ -576,99 +673,4 @@ Zombie Slayer	53	L3_tavern
 Zombie Slayer	54	L13_towerAscent
 Zombie Slayer	55	auto_softBlockHandler
 Zombie Slayer	56	LX_attemptPowerLevel
-
-default	0	LX_freeCombatsTask
-default	1	woods_questStart
-default	2	LX_unlockPirateRealm
-default	3	catBurglarHeist
-default	4	auto_breakfastCounterVisit
-default	5	chateauPainting
-default	6	LX_setWorkshed
-default	7	LX_galaktikSubQuest
-default	8	L9_leafletQuest
-default	9	L5_findKnob
-default	10	L12_sonofaPrefix
-default	11	LX_burnDelay
-default	12	LX_summonMonster
-# path handling which should be in it's own task order but pre-dates task order functionality (tech debt FTW).
-default	13	LM_edTheUndying
-default	14	LX_bugbearInvasion
-default	15	LX_lowkeySummer
-# make sure we don't waste turns of Ultrahydrated doing something else.
-default	16	L11_aridDesert	L11_hasUltrahydrated
-# Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
-default	17	L11_shenStartQuest
-# Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
-default	18	finishBuildingSmutOrcBridge
-# Call quest handlers based on current state if applicable
-default	19	auto_earlyRoutingHandling
-# Guild access.
-default	20	LX_guildUnlock
-#	Desert access, Daily Dungeon and other early random stuff that we don't want to miss.
-default	21	LX_unlockDesert
-default	22	LX_lockPicking
-default	23	LX_fatLootToken
-#	Get the Steel Organ if the user wants it (needs L6 quest complete)
-default	24	LX_steelOrgan
-# open up delay zones.
-default	25	LX_spookyravenManorFirstFloor
-# open up zones where we want to force non-combats.
-# Open up underground zones so they are available for Breathitin.
-default	26	L5_getEncryptionKey
-default	27	L5_findKnob
-#	Do the War early. Access to the Orchard is useful for booze/potions and maybe we can make use of the green smoke bombs?
-default	28	L12_islandWar
-# Start the macguffin quest
-default	29	L11_blackMarket
-default	30	L11_forgedDocuments
-default	31	L11_mcmuffinDiary
-default	32	L11_getBeehive
-# open the hidden city up (delay zones)
-default	33	L2_mosquito
-default	34	LX_unlockHiddenTemple
-default	35	L6_dakotaFanning
-default	36	L11_unlockHiddenCity
-# Murder pygmies for the ancient amulet.
-default	37	L11_hiddenCityZones
-default	38	L11_hiddenCity
-# Dance with lady spookyraven so we can go murder her undead husband and take the Eye of Ed
-default	39	LX_spookyravenManorSecondFloor
-default	40	L11_mauriceSpookyraven
-# Lay the smack down on those Jerk Copperhead twins
-default	41	L11_talismanOfNam
-# Open up the top of the beanstalk.
-default	42	L10_plantThatBean
-# Clean up the plains
-default	43	L10_rainOnThePlains
-# Get Black Angus his pizza
-default	44	L9_chasmBuild
-default	45	L9_highLandlord
-#  Kill Groar because *we* are the monsters.
-default	46	L8_trapperQuest
-# Kill the undead? Is this an oxymoron?
-default	47	L7_crypt
-# Cleanse the taint.
-default	48	L6_friarsGetParts
-# Finish the other Macguffin zones so we can beat Ed to death repeatedly and waste all his Ka coins.
-default	49	L11_palindome
-default	50	L11_aridDesert
-default	51	L11_unlockPyramid
-default	52	L11_unlockEd
-default	53	L11_defeatEd
-#	Finish off the Goblin King.
-default	54	L5_slayTheGoblinKing
-# Show the Boss bat who's boss.
-default	55	L4_batCave
-# Fix that dripping tap.
-default	56	L3_tavern
-# Basic fetch quest is the first thing the council demand of you. Is this 2002 or what?
-default	57	L2_mosquito
-# There's an extra task in KoE
-default	58	LX_koeInvaderHandler
-# "win" the contests, navigate the maze, unlock the door, climb the tower, commit sorceresscide.
-default	59	L13_towerAscent
-# release the hounds!
-default	60	auto_softBlockHandler
-# if all else fails, powerlevel like there's no tomorrow.
-default	61	LX_attemptPowerLevel
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1242,6 +1242,8 @@ boolean L12_farm();
 boolean L12_clearBattlefield();
 boolean L12_finalizeWar();
 boolean L12_islandWar();
+boolean L12_opportunisticWarStart();
+boolean L12_singleNCForWarStart();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_13.ash

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -797,7 +797,7 @@ boolean L12_startWar()
 	// wear the appropriate war outfit based on auto_hippyInstead
 	equipWarOutfit();
 	
-	if (auto_haveCCSC())
+	if (auto_haveCCSC() && !have_skill($skill[Comprehensive Cartography]))
 	{
 		autoForceEquip($item[candy cane sword cane]);
 	}

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -797,10 +797,19 @@ boolean L12_startWar()
 	// wear the appropriate war outfit based on auto_hippyInstead
 	equipWarOutfit();
 	
+	if (auto_haveCCSC())
+	{
+		autoForceEquip($item[candy cane sword cane]);
+	}
+	
 	// start the war when siding with frat boys
 	if(!get_property("auto_hippyInstead").to_boolean())
 	{
 		auto_log_info("Must save the ferret!!", "blue");
+		if (L12_singleNCForWarStart())
+		{
+			boolean NCForced = auto_forceNextNoncombat($location[Wartime Hippy Camp]);
+		}
 		autoAdv(1, $location[Wartime Hippy Camp]);
 		
 		//if war started, accept flyer quest for fratboys.
@@ -808,13 +817,17 @@ boolean L12_startWar()
 		//move this to dedicated function that can start it for both sides as appropriate
 		if(internalQuestStatus("questL12War") == 1)
 		{
-			visit_url("bigisland.php?place=concert&pwd");	
+			visit_url("bigisland.php?place=concert&pwd");
 		}
 	}
 	// start the war when siding with hippies
 	else
 	{
 		auto_log_info("Must save the goldfish!!", "blue");
+		if (L12_singleNCForWarStart())
+		{
+			boolean NCForced = auto_forceNextNoncombat($location[Wartime Frat House]);
+		}
 		autoAdv(1, $location[Wartime Frat House]);
 	}
 		
@@ -2401,4 +2414,28 @@ boolean L12_islandWar()
 		return true;
 	}
 	return false;
+}
+
+boolean L12_opportunisticWarStart()
+{
+	// If we have all the resources to start the war in one turn, do that.
+	if(internalQuestStatus("questL12War") != 0) { return false; }
+	if(!haveWarOutfit(true))                    { return false; }
+	if(!L12_singleNCForWarStart())              { return false; }
+	if(remainingNCForcesToday() == 0)           { return false; }
+	// Dinghy the island if we can.
+	if (get_property("lastIslandUnlock").to_int() != my_ascensions())
+	{
+		if (available_amount($item[Pirate dinghy])>0)
+		{
+			use($item[Pirate dinghy]);
+		}
+	}
+	if (get_property("lastIslandUnlock").to_int() != my_ascensions()) { return false; }
+	return L12_startWar();
+}
+
+boolean L12_singleNCForWarStart()
+{
+	return (auto_haveCCSC() || have_skill($skill[Comprehensive Cartography]));
 }


### PR DESCRIPTION
# Description

The war needs an NC to be started, but 3 NCs are available. Fortunately, there are two IOTMs that mean a forced NC will always give you the ability to start the war. If you have either, now force an NC to start the war.

Additionally, we now have a way to instantly unlock the island (pirate dinghy). Once we have and can wear the war outfit, and are level 12, unlock the island and use a force to start the war in one turn so we can start flyering immediately. This has been added to only the default task_order so far.

(also, for some reason the task order build has put default in a different place than it was in the repo, I just let it move it - if other people are getting inconsistent ordering we should fix it, should be one line in assemble.sh to sort eg alphabetically).

![d1_ncs](https://github.com/user-attachments/assets/d1818d97-c2bf-4e9b-a258-f883f3c4df16)

Example of the NC forces from a d1 standard HC (also including the friars delay NC force PR, separate)

## How Has This Been Tested?

Shiny character HC standard, works properly. Two non-shiny characters saw no effects.

Yet to be tested on shiny character in pathed.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
