### PR TITLE
Set of minor changes

### DIFF
--- a/BUILD/monsters/sniff.dat
+++ b/BUILD/monsters/sniff.dat
@@ -11,7 +11,6 @@ Tomb Rat
 Bob Racecar	!sniffed:Racecar Bob
 Racecar Bob	!sniffed:Bob Racecar
 Government Scientist	class:Ed the Undying
-Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
 War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
 War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
 Naughty Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Sorority Nurse
@@ -19,7 +18,7 @@ Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
 Possessed Wine Rack
 Blue Oyster cultist
 Dirty Old Lihc	prop:cyrptNicheEvilness>17
-Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
+Possibility Giant	loc:The Castle in the Clouds in the Sky \(Ground Floor\);prop:auto_hippyInstead=true;prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
 bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
 elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
 spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -162,45 +162,44 @@ sniff	9	Tomb Rat
 sniff	10	Bob Racecar	!sniffed:Racecar Bob
 sniff	11	Racecar Bob	!sniffed:Bob Racecar
 sniff	12	Government Scientist	class:Ed the Undying
-sniff	13	Green Ops Soldier	!path:Kingdom of Exploathing;prop:hippiesDefeated>399
-sniff	14	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
-sniff	15	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
-sniff	16	Naughty Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Sorority Nurse
-sniff	17	Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
-sniff	18	Possessed Wine Rack
-sniff	19	Blue Oyster cultist
-sniff	20	Dirty Old Lihc	prop:cyrptNicheEvilness>17
-sniff	21	Possibility Giant	loc:The Castle in the Clouds in the Sky (Ground Floor);prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
-sniff	22	bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
-sniff	23	elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
-sniff	24	spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
-sniff	25	Serialbus	item:bus pass<4
-sniff	26	CH Imp	item:imp air<4
-sniff	27	Camel's Toe	!sniffed:Skinflute
-sniff	28	Skinflute	!sniffed:Camel's Toe
-sniff	29	Red Butler	prop:_glarkCableUses<5;item:glark cable<5
+sniff	13	War Hippy Naturopathic Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Homeopath
+sniff	14	War Hippy Homeopath	path:Kingdom of Exploathing;item:filthy poultice<5;!sniffed:War Hippy Naturopathic Homeopath
+sniff	15	Naughty Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Sorority Nurse
+sniff	16	Sorority Nurse	path:G-Lover;item:gauze garter<5;!sniffed:Naughty Sorority Nurse
+sniff	17	Possessed Wine Rack
+sniff	18	Blue Oyster cultist
+sniff	19	Dirty Old Lihc	prop:cyrptNicheEvilness>17
+sniff	20	Possibility Giant	loc:The Castle in the Clouds in the Sky (Ground Floor);prop:auto_hippyInstead=true;prop:auto_skipL12Farm=false;prop:chaosButterflyThrown=false;item:chaos butterfly<1;!path:Bees Hate You;!path:Pocket Familiars;!path:G-Lover;!itemdropcapped:20=chaos butterfly
+sniff	21	bearpig topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:spider (duck?) topiary animal
+sniff	22	elephant (meatcar?) topiary animal	!familiar:Melodramedary;!sniffed:bearpig topiary animal;!sniffed:spider (duck?) topiary animal
+sniff	23	spider (duck?) topiary animal	!familiar:Melodramedary;!sniffed:elephant (meatcar?) topiary animal;!sniffed:bearpig topiary animal
+sniff	24	Serialbus	item:bus pass<4
+sniff	25	CH Imp	item:imp air<4
+sniff	26	Camel's Toe	!sniffed:Skinflute
+sniff	27	Skinflute	!sniffed:Camel's Toe
+sniff	28	Red Butler	prop:_glarkCableUses<5;item:glark cable<5
 # Unlocking Knob Menagerie
-sniff	30	Knob Goblin Very Mad Scientist	loc:Cobb's Knob Laboratory;item:Cobb's Knob Menagerie key<1;turnsspent:Cobb's Knob Laboratory>7
+sniff	29	Knob Goblin Very Mad Scientist	loc:Cobb's Knob Laboratory;item:Cobb's Knob Menagerie key<1;turnsspent:Cobb's Knob Laboratory>7
 # Pirate quest F'c'le's last missing item
-sniff	31	cleanly pirate	loc:The F'c'le;item:rigging shampoo==0;item:ball polish>0;item:mizzenmast mop>0;!itemdropcapped:30=rigging shampoo
-sniff	32	creamy pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish==0;item:mizzenmast mop>0;!itemdropcapped:30=ball polish
-sniff	33	curmudgeonly pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish>0;item:mizzenmast mop==0;!itemdropcapped:30=mizzenmast mop
+sniff	30	cleanly pirate	loc:The F'c'le;item:rigging shampoo==0;item:ball polish>0;item:mizzenmast mop>0;!itemdropcapped:30=rigging shampoo
+sniff	31	creamy pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish==0;item:mizzenmast mop>0;!itemdropcapped:30=ball polish
+sniff	32	curmudgeonly pirate	loc:The F'c'le;item:rigging shampoo>0;item:ball polish>0;item:mizzenmast mop==0;!itemdropcapped:30=mizzenmast mop
 # Bugbear Invasion Wanderers
-sniff	34	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
-sniff	35	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
-sniff	36	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
-sniff	37	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
-sniff	38	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
-sniff	39	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
-sniff	40	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
-sniff	41	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
-sniff	42	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
+sniff	33	scavenger bugbear	path:Bugbear Invasion;!loc:Waste Processing;!prop:statusWasteProcessing=unlocked;!prop:statusWasteProcessing=open;!prop:statusWasteProcessing=cleared
+sniff	34	hypodermic bugbear	path:Bugbear Invasion;!loc:Medbay;!prop:statusMedbay=unlocked;!prop:statusMedbay=open;!prop:statusMedbay=cleared
+sniff	35	batbugbear	path:Bugbear Invasion;!loc:Sonar;!prop:statusSonar=unlocked;!prop:statusSonar=open;!prop:statusSonar=cleared;prop:questL04Bat=finished
+sniff	36	bugbear scientist	path:Bugbear Invasion;!loc:Science Lab;!prop:statusScienceLab=unlocked;!prop:statusScienceLab=open;!prop:statusScienceLab=cleared
+sniff	37	bugaboo	path:Bugbear Invasion;!loc:Morgue;!prop:statusMorgue=unlocked;!prop:statusMorgue=open;!prop:statusMorgue=cleared;prop:questL07Cyrptic=finished
+sniff	38	Black Ops Bugbear	path:Bugbear Invasion;!loc:Special Ops;!prop:statusSpecialOps=unlocked;!prop:statusSpecialOps=open;!prop:statusSpecialOps=cleared;prop:questL08Trapper=finished
+sniff	39	Battlesuit Bugbear Type	path:Bugbear Invasion;!loc:Engineering;!prop:statusEngineering=unlocked;!prop:statusEngineering=open;!prop:statusEngineering=cleared;prop:questL10Garbage=finished
+sniff	40	ancient unspeakable bugbear	path:Bugbear Invasion;!loc:Navigation;!prop:statusNavigation=unlocked;!prop:statusNavigation=open;!prop:statusNavigation=cleared;prop:questL11Manor=finished
+sniff	41	trendy bugbear chef	path:Bugbear Invasion;!loc:Galley;!prop:statusGalley=unlocked;!prop:statusGalley=open;!prop:statusGalley=cleared;prop:questL12War=finished
 # Bugbear Invasion Mothership
-sniff	43	creepy eye-stalk tentacle monster	path:Bugbear Invasion
-sniff	44	anesthesiologist bugbear	path:Bugbear Invasion
-sniff	45	bugbear mortician	path:Bugbear Invasion
-sniff	46	N-space Virtual Assistant	path:Bugbear Invasion
-sniff	47	angry cavebugbear	path:Bugbear Invasion
+sniff	42	creepy eye-stalk tentacle monster	path:Bugbear Invasion
+sniff	43	anesthesiologist bugbear	path:Bugbear Invasion
+sniff	44	bugbear mortician	path:Bugbear Invasion
+sniff	45	N-space Virtual Assistant	path:Bugbear Invasion
+sniff	46	angry cavebugbear	path:Bugbear Invasion
 
 # Gotta get that wig
 yellowray	0	Burly Sidekick	item:Mohawk Wig<1;!skill:Comprehensive Cartography;!itemdropcapped:10=Mohawk wig

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -427,12 +427,16 @@ boolean autoEat(int howMany, item toEat, boolean silent)
 		}
 		if(item_amount($item[mini kiwi aioli]) > 0 || (item_amount($item[mini kiwi]) >= 5 && item_amount($item[mini kiwi aioli]) == 0)) //use mini kiwi aioli if we got one from the mini kiwi
 		{
-			if(item_amount($item[mini kiwi aioli]) == 0)
+			// Kiwi aioli is per-fullness, only eat it on foods size 4+
+			if (toEat.fullness > 3)
 			{
-				create(1, $item[mini kiwi aioli]); //create the aioli to actually use it
+				if(item_amount($item[mini kiwi aioli]) == 0)
+				{
+					create(1, $item[mini kiwi aioli]); //create the aioli to actually use it
+				}
+				use(1, $item[mini kiwi aioli]);
+				handleTracker("Used "+$item[mini kiwi aioli]+" for "+toEat, "auto_otherstuff");
 			}
-			use(1, $item[mini kiwi aioli]);
-			handleTracker("Used " + $item[mini kiwi aioli], "auto_otherstuff");
 		}
 		if(have_effect($effect[Ready to Eat]) > 0)
 		{

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2072,6 +2072,15 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests)
 	}
 	else
 	{
+		// Simplifies restoration massively, make that our first choice
+		if (have_skill($skill[Cannelloni Cocoon]))
+		{
+			int coc_tries = 0;
+			while (goal-my_hp() > 20 && coc_tries++ < 3)
+			{
+				use_skill($skill[Cannelloni Cocoon]);
+			}
+		}
 		__restore("hp", goal, meat_reserve, useFreeRests);
 	}
 

--- a/RELEASE/scripts/autoscend/auto_routing.ash
+++ b/RELEASE/scripts/autoscend/auto_routing.ash
@@ -120,7 +120,8 @@ boolean auto_reserveUndergroundAdventures()
 		return false;
 	}
 	if (get_workshed() != $item[cold medicine cabinet] && auto_is_valid($item[cold medicine cabinet]) && item_amount($item[cold medicine cabinet]) > 0 &&
-	!get_property("_workshedItemUsed").to_boolean() && (LX_getDesiredWorkshed() == $item[cold medicine cabinet] || LX_getDesiredWorkshed() == $item[none]))
+	!get_property("_workshedItemUsed").to_boolean() && (LX_getDesiredWorkshed() == $item[cold medicine cabinet] || LX_getDesiredWorkshed() == $item[none]) &&
+	have_campground())
 	{
 		auto_log_debug("Reserving underground adventures as we will be switching to the CMC.");
 		// Don't have the CMC installed yet but we can still switch today and want to switch to it so save underground zones until then.

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1959,12 +1959,6 @@ boolean LX_summonMonster()
 		if(summonMonster($monster[Astronomer])) return true;
 	}
 
-	// summon grops to start copy chain. Goal is to copy into delay zones and get war progress at same time. Bonus if we get smoke bombs
-	if(!summonedMonsterToday($monster[Green Ops Soldier]) && get_property("hippiesDefeated").to_int() > 399 && get_property("hippiesDefeated").to_int() < 1000 && !in_koe() && auto_backupUsesLeft() > 0)
-	{
-		if(summonMonster($monster[Green Ops Soldier])) return true;
-	}
-
 	// summon additional monsters in heavy rains with rain man when available
 	if(have_skill($skill[Rain Man]) && my_rain() >= 50)
 	{


### PR DESCRIPTION
# Description

* Only use mini kiwi aioli if food is large enough since it is flat adv/full
* No longer summon/sniff GrOps
* Don't route for CMC in paths with no campground/workshed
* Only use advanced HP restore options if cocoon isn't an option

## How Has This Been Tested?

Several HC runs across shiny standard/ed, nonshiny standard and softcore LoL.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
