### PR TITLE
fix: include first item in preferences in stacking

### DIFF
--- a/RELEASE/relay/relay_autoscend.ash
+++ b/RELEASE/relay/relay_autoscend.ash
@@ -73,7 +73,7 @@ void handleSetting(string type, int x)
 void generateTrackingData(string tracked, string print_between, boolean stacked)
 {
 	int day = 0;
-	string[int] tracking = split_string(get_property(tracked), ",");
+	string[int] tracking = split_string(get_property(tracked), ", ");
 	if(get_property(tracked) == "")
 	{
 		return;


### PR DESCRIPTION
# Description

Splitting on "," meant that every item after the first had a starting space, which meant that the first entry wouldn't get stacked with those after it. This was most obvious on genie wishes / magical sausages.

## How Has This Been Tested?

Checked in browser.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
