### PR TITLE
Less meat wishes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -1532,21 +1532,30 @@ float provideMeat(int amt, location loc, boolean doEverything, boolean speculati
 		{
 			boolean success = true;
 			int specwishes = 0;
-			foreach eff in $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
-			Braaaaaains, //200% meat, -50% item
-			Let's Go Shopping!,  //150% meat, 75% item, -300% myst
-			Always Be Collecting, //100% meat, 50% item
-			Incredibly Well Lit, //100% meat, 50% item
-			A View to Some Meat, //100% meat
-			Cravin' for a Ravin', //100% meat
-			Low on the Hog, //100% meat
-			Leisurely Amblin', //100% meat
-			Trufflin', //100% meat
-			Here's Some More Mud in Your Eye, //100% meat
-			Eau d' Clochard, //100% meat
-			Flapper Dancin', //100% meat
-			Fishing for Meat, //100% meat
-			Preternatural Greed] //100% meat
+			boolean[effect] wish_to_try = (in_avantGuard()? // Avant guard only has 6 turns for nuns, so needs tonnes of buffs
+			  $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
+			    Braaaaaains, //200% meat, -50% item
+			    // no Sinuses for Miles here in AG, get it from an inhaler
+			    Let's Go Shopping!,  //150% meat, 75% item, -300% myst
+			    Always Be Collecting, //100% meat, 50% item
+			    Incredibly Well Lit, //100% meat, 50% item
+			    A View to Some Meat, //100% meat\
+			    Cravin' for a Ravin', //100% meat
+			    Low on the Hog, //100% meat
+			    Leisurely Amblin', //100% meat
+			    Trufflin', //100% meat
+			    Here's Some More Mud in Your Eye, //100% meat
+			    Eau d' Clochard, //100% meat
+			    Flapper Dancin', //100% meat
+			    Fishing for Meat, //100% meat
+			    Preternatural Greed //100% meat
+			  ] : // Regular probably doesn't need more than 600% from wishes
+			  $effects[Frosty, //200% meat, 100% item, 25 ML, 100% init
+			    Braaaaaains, //200% meat, -50% item
+			    Sinuses for miles, //200% meat
+			    //~ Let's Go Shopping!  //150% meat, 75% item, -300% myst
+			  ]);
+			foreach eff in wish_to_try
 			{
 				if(eff == $effect[Frosty] && in_wereprof()) continue; //skip frosty in wereprof
 				if(have_effect(eff) == 0)

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1726,7 +1726,9 @@ boolean L12_themtharHills()
 	{
 		auto_log_info("Themthar Nuns!", "blue");
 	}
-
+	
+	handleFamiliar("meat");
+	
 	//can only do this in Avant Guard in 6 turns in HC or 8 turns in Normal. Need the August Scepter. If going turbo, can't get enough waffles so don't even bother with this
 	set_property("auto_delayWar", false);
 	if(in_avantGuard() && auto_haveAugustScepter() && !(auto_turbo()))
@@ -1774,11 +1776,14 @@ boolean L12_themtharHills()
 			}
 		}
 	}
-
+	
+	// Outside of AG, if we have 3+ effect wishes we'll be wishing for Sinuses for Miles instead
+	boolean considerCloverForInhaler = in_avantGuard() || auto_totalEffectWishesAvailable() < 3;
+	
 	// Target 1000 + 400% = 5000 meat per brigand. Of course we want more, but don\'t bother unless we can get this.
 	float meat_need = 400.00;
 	//count inhaler if we have one or if we have a clover to obtain one and can use one
-	if((item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0 || cloversAvailable() > 0) && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]))
+	if((item_amount($item[Mick\'s IcyVapoHotness Inhaler]) > 0) || (cloversAvailable() > 0 && considerCloverForInhaler))
 	{
 		meat_need = meat_need - 200;
 	}
@@ -1840,11 +1845,14 @@ boolean L12_themtharHills()
 			auto_log_info("The min should be enough! Doing it!!", "purple");
 		}
 	}
-
-	if(have_effect($effect[Sinuses For Miles]) <= 0 && item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]) && cloversAvailable() > 0 && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]))
+	
+	if (considerCloverForInhaler)
 	{
-		//use clover to get inhaler
-		return autoLuckyAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
+		if(have_effect($effect[Sinuses For Miles]) <= 0 && item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]) && cloversAvailable() > 0 && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]))
+		{
+			//use clover to get inhaler
+			return autoLuckyAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);
+		}
 	}
 
 	provideMeat(1800, true, false); // Do as much as possible to get meat drops

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1791,7 +1791,8 @@ boolean L12_themtharHills()
 	}
 	
 	// Outside of AG, if we have 3+ effect wishes we'll be wishing for Sinuses for Miles instead
-	boolean considerCloverForInhaler = in_avantGuard() || auto_totalEffectWishesAvailable() < 3;
+	boolean considerCloverForInhaler = (in_avantGuard() || auto_totalEffectWishesAvailable() < 3) && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]);
+	considerCloverForInhaler = considerCloverForInhaler && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]);
 	
 	// Target 1000 + 400% = 5000 meat per brigand. Of course we want more, but don\'t bother unless we can get this.
 	float meat_need = 400.00;
@@ -1861,7 +1862,7 @@ boolean L12_themtharHills()
 	
 	if (considerCloverForInhaler)
 	{
-		if(have_effect($effect[Sinuses For Miles]) <= 0 && item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && auto_is_valid($item[Mick\'s IcyVapoHotness Inhaler]) && cloversAvailable() > 0 && zone_isAvailable($location[The Castle in the Clouds in the Sky (Top Floor)]))
+		if(have_effect($effect[Sinuses For Miles]) <= 0 && item_amount($item[Mick\'s IcyVapoHotness Inhaler]) < 1 && cloversAvailable() > 0)
 		{
 			//use clover to get inhaler
 			return autoLuckyAdv($location[The Castle in the Clouds in the Sky (Top Floor)]);


### PR DESCRIPTION
# Description

A lot of wishes were added for meat in Avant Guard to allow the nuns to be completed in 6 turns. This wound up being total overkill in standard (I had all 8 daily standard wishes deployed on nuns once).

This PR leaves all the AG wishes in place, but only wishes for +200% meat effects if not in AG.

## How Has This Been Tested?

Lots of HC runs in/out of standard with shiny and non-shiny characters.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
