### PR TITLE
Low Key Summer Modernisation

### DIFF
--- a/BUILD/assemble.sh
+++ b/BUILD/assemble.sh
@@ -11,7 +11,7 @@ for DIR in ./*/; do
 	cat $DIR/header.txt >> $OUT
 	SAVEIFS=$IFS
 	IFS=$(echo -en "\n\b")
-	for FILENAME in ${DIR}*.dat; do
+  for FILENAME in $(ls ${DIR}*.dat | sort -i); do
 		SLOT=${FILENAME::-4}
 		SLOT=${SLOT##*/}
 		NUM=0

--- a/BUILD/monsters/freerun.dat
+++ b/BUILD/monsters/freerun.dat
@@ -42,3 +42,42 @@ Mob Penguin Capo
 ninja snowman (chopsticks)
 ninja snowman janitor
 ninja snowman weaponmaster
+# low key summer
+fluffy bunny
+factory-irregular skeleton
+novelty tropical skeleton
+remaindered skeleton
+swarm of skulls
+cooler wino
+dire pigeon
+malt liquor golem
+sewer snake with a sewer snake in it
+angry piñata
+handsome mariachi
+irate mariachi
+mariachi calavera
+raging bull
+Snow Queen
+upgraded ram
+baguette lady
+cr&ecirc;ep
+dinner troll
+gingerbread murderer
+Carnivorous Moxie Weed
+Grass Elemental
+Weremoose
+anglerbush
+confused goth music student
+man-eating plant
+skeletal cat
+skeletal hamster
+skeletal monkey
+creepy doll
+possessed toy chest
+spooky music box
+1335 HaXx0r
+Anime Smiley
+Flaming Troll
+Lamz0r N00b
+me4t begZ0r
+Spam Witch

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -110,6 +110,45 @@ freerun	40	Mob Penguin Capo
 freerun	41	ninja snowman (chopsticks)
 freerun	42	ninja snowman janitor
 freerun	43	ninja snowman weaponmaster
+# low key summer
+freerun	44	fluffy bunny
+freerun	45	factory-irregular skeleton
+freerun	46	novelty tropical skeleton
+freerun	47	remaindered skeleton
+freerun	48	swarm of skulls
+freerun	49	cooler wino
+freerun	50	dire pigeon
+freerun	51	malt liquor golem
+freerun	52	sewer snake with a sewer snake in it
+freerun	53	angry piñata
+freerun	54	handsome mariachi
+freerun	55	irate mariachi
+freerun	56	mariachi calavera
+freerun	57	raging bull
+freerun	58	Snow Queen
+freerun	59	upgraded ram
+freerun	60	baguette lady
+freerun	61	cr&ecirc;ep
+freerun	62	dinner troll
+freerun	63	gingerbread murderer
+freerun	64	Carnivorous Moxie Weed
+freerun	65	Grass Elemental
+freerun	66	Weremoose
+freerun	67	anglerbush
+freerun	68	confused goth music student
+freerun	69	man-eating plant
+freerun	70	skeletal cat
+freerun	71	skeletal hamster
+freerun	72	skeletal monkey
+freerun	73	creepy doll
+freerun	74	possessed toy chest
+freerun	75	spooky music box
+freerun	76	1335 HaXx0r
+freerun	77	Anime Smiley
+freerun	78	Flaming Troll
+freerun	79	Lamz0r N00b
+freerun	80	me4t begZ0r
+freerun	81	Spam Witch
 
 replace	0	Banshee Librarian	item:Killing Jar>0
 replace	1	Beefy Bodyguard Bat	loc:The Boss Bat's Lair;turnsspent:The Boss Bat's Lair>=4;!path:Heavy Rains;!path:Actually Ed the Undying;!path:Pocket Familiars;!path:Dark Gyffte;!path:Path of the Plumber;!pathid:41;!path:Wildfire;!path:Fall of the Dinosaurs;!path:Avatar of Shadows Over Loathing;!path:Legacy of Loathing;!path:WereProfessor

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1074,6 +1074,10 @@ boolean dailyEvents()
 	auto_birdOfTheDay();
 	while(auto_doPrecinct());
 	handleBarrelFullOfBarrels(true);
+	
+	// Hit bastille, then council in case we levelled up (and unlocked getaway camp)
+	cheeseWarMachine(0, 0, 0, 0);
+	council();
 
 	auto_campawayGrabBuffs();
 	kgb_getMartini();

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -1256,3 +1256,44 @@ boolean is_watch(item it)
 	//watches are accessories that conflict with each other. you can only equip one watch total.
 	return boolean_modifier(it, $modifier[Nonstackable Watch]);
 }
+
+int[item] auto_getAllEquipabble()
+{
+	return auto_getAllEquipabble($slot[none]);
+}
+
+int[item] auto_getAllEquipabble(slot s)
+{
+	boolean ignore_slot = s==$slot[none];
+	s = (s==$slot[acc2] || s==$slot[acc3]?$slot[acc1]:s);// all accessories checked against slot 1
+	int[item] valid_and_equippable;
+	foreach it,n in get_inventory()
+	{
+		slot it_s = to_slot(it);
+		if(can_equip(it) && auto_is_valid(it) && (s==it_s || ignore_slot))
+		{
+			valid_and_equippable[it] = n;
+		}
+	}
+	// Add equipped
+	boolean[slot] my_slots;
+	if (ignore_slot)
+	{
+		my_slots = $slots[hat, weapon, off-hand, back, shirt, pants, acc1, acc2, acc3, familiar];
+	}
+	else
+	{
+		my_slots[s] = true;
+		if (s==$slot[acc1])
+		{
+			my_slots[$slot[acc2]] = true;
+			my_slots[$slot[acc3]] = true;
+		}
+	}
+	foreach my_slot in my_slots
+	{
+		item it = equipped_item(my_slot);
+		valid_and_equippable[it]++;
+	}
+	return valid_and_equippable;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1492,6 +1492,8 @@ void equipRollover(boolean silent);
 boolean auto_forceEquipSword(boolean speculative);
 boolean auto_forceEquipSword();
 boolean is_watch(item it);
+int[item] auto_getAllEquipabble();
+int[item] auto_getAllEquipabble(slot s);
 
 ########################################################################################################
 //Defined in autoscend/auto_familiar.ash

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -482,10 +482,8 @@ boolean LX_lowkeySummer() {
 
 		// Check our meat accessories, grab +meat keys before attempting Themthar Hills if they'll help.
 		int n_meat_drop_acc_50plus = 0;
-		foreach it,n in auto_getAllEquipabble($slot[acc1])
-		{
-			if (numeric_modifier(it,$modifier[meat drop])>50)
-			{
+		foreach it,n in auto_getAllEquipabble($slot[acc1]) {
+			if (numeric_modifier(it,$modifier[meat drop])>=45 || it==$item[backup camera]) { // backup camera isn't always meat 
 				n_meat_drop_acc_50plus += n;
 			}
 		}

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -383,6 +383,29 @@ boolean L13_sorceressDoorLowKey()
 boolean LX_lowkeySummer() {
 
 	if (!in_lowkeysummer()) { return false; }
+	
+	// Copied out of task order default.dat
+	if (LX_freeCombatsTask        ()) { return true; }
+	if (woods_questStart          ()) { return true; }
+	if (LX_unlockPirateRealm      ()) { return true; }
+	if (catBurglarHeist           ()) { return true; }
+	if (auto_breakfastCounterVisit()) { return true; }
+	if (chateauPainting           ()) { return true; }
+	if (LX_setWorkshed            ()) { return true; }
+	if (LX_galaktikSubQuest       ()) { return true; }
+	if (L9_leafletQuest           ()) { return true; }
+	if (L5_findKnob               ()) { return true; }
+	if (L12_sonofaPrefix          ()) { return true; }
+	if (LX_burnDelay              ()) { return true; }
+	if (LX_summonMonster          ()) { return true; }
+	// Lock in the Shen zones as soon as we can as it (potentially) unlocks a bunch of stuff.
+	if (L11_shenStartQuest()) { return true; }
+	// If we have everything to start the war instantly, just do it so we can start flyering.
+	if (L12_opportunisticWarStart()) { return true; }
+	// Build the Bridge when we have enough parts as we may want to spend daily resources at the peaks.
+	if (finishBuildingSmutOrcBridge()) { return true; }
+	// Call quest handlers based on current state if applicable
+	if (auto_earlyRoutingHandling()) { return true; }
 
 	// Guild access
 	if (LX_guildUnlock()) { return true; }

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -480,8 +480,13 @@ boolean LX_lowkeySummer() {
 			}
 		}
 
-		// Get the +meat keys before attempting Themthar Hills.
-		if (possessEquipment($item[Knob treasury key]) && possessEquipment($item[Kekekey])) {
+		// Check our meat accessories, grab +meat keys before attempting Themthar Hills if they'll help.
+		int n_meat_drop_acc_50plus = 0;
+		foreach it,n in auto_getAllEquipabble($slot[acc1])
+		{
+			n_meat_drop_acc_50plus += n;
+		}
+		if (n_meat_drop_acc_50plus>=2) {
 			if (L12_themtharHills()) { return true; }
 		} else if(!get_property("auto_skipNuns").to_boolean() && (get_property("hippiesDefeated").to_int() >= 192 || get_property("auto_hippyInstead").to_boolean())) {
 			// about to do nuns. Make sure The Valley is open so we can get the Kekekey.

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -484,7 +484,10 @@ boolean LX_lowkeySummer() {
 		int n_meat_drop_acc_50plus = 0;
 		foreach it,n in auto_getAllEquipabble($slot[acc1])
 		{
-			n_meat_drop_acc_50plus += n;
+			if (numeric_modifier(it,$modifier[meat drop])>50)
+			{
+				n_meat_drop_acc_50plus += n;
+			}
 		}
 		if (n_meat_drop_acc_50plus>=2) {
 			if (L12_themtharHills()) { return true; }

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -416,20 +416,22 @@ boolean LX_lowkeySummer() {
 	// Cobb's Knob unlocks a lot of zones which contain generally useful keys for all classes (-combat, +meat, +adv).
 	// Also the +20% to all Muscle Gains key unlocks here.
 	if (L5_getEncryptionKey() || L5_findKnob()) { return true; }
-
-	if (my_primestat() == $stat[Mysticality] && possessEquipment($item[Key sausage])) {
-		// Myst classes want access to Pandamonium Slums to find the demonic key (+20% to all Mysticality Gains).
-		// Get the -combat key first.
-		if(!possessEquipment($item[Demonic key]) && my_buffedstat($stat[moxie]) < monster_attack($monster[Hellion])) {
-			//starting the level 6 quest as early as possible can be dangerous?
-			buffMaintain($effect[Vital]);
+	
+	if (my_level() < 12) {
+		if (my_primestat() == $stat[Mysticality] && possessEquipment($item[Key sausage])) {
+			// Myst classes want access to Pandamonium Slums to find the demonic key (+20% to all Mysticality Gains).
+			// Get the -combat key first.
+			if(!possessEquipment($item[Demonic key]) && my_buffedstat($stat[moxie]) < monster_attack($monster[Hellion])) {
+				//starting the level 6 quest as early as possible can be dangerous?
+				buffMaintain($effect[Vital]);
+			}
+			if (L6_friarsGetParts()) { return true; }
 		}
-		if (L6_friarsGetParts()) { return true; }
-	}
-	else if (my_primestat() == $stat[Muscle] && item_amount($item[Cobb\'s Knob Lab Key]) == 0) {
-		// Mus classes want access to the laboratory to find the Knob labinet key (+20% to all Muscle Gains).
-		// Have already gone after Key sausage and Knob treasury key by now, if still missing lab key give priority to the Knob
-		if (L5_slayTheGoblinKing()) { return true; }
+		else if (my_primestat() == $stat[Muscle] && item_amount($item[Cobb\'s Knob Lab Key]) == 0) {
+			// Mus classes want access to the laboratory to find the Knob labinet key (+20% to all Muscle Gains).
+			// Have already gone after Key sausage and Knob treasury key by now, if still missing lab key give priority to the Knob
+			if (L5_slayTheGoblinKing()) { return true; }
+		}
 	}
 
 	// Island access for all classes. also farm the +20% to all Moxie Gains key
@@ -498,7 +500,7 @@ boolean LX_lowkeySummer() {
 		}
 
 		// Do the rest of the war. Should have the +item key already before we start the war.
-		if (L12_gremlins() || L12_filthworms() || L12_orchardFinalize() || L12_farm() || L12_finalizeWar()) { return true; }
+		if (L12_gremlins() || L12_filthworms() || L12_orchardFinalize() || L12_farm() || L12_clearBattlefield() || L12_finalizeWar()) { return true; }
 	}
 
 	// Start the macguffin quest as we need it to unlock Belowdecks.

--- a/RELEASE/scripts/autoscend/paths/low_key_summer.ash
+++ b/RELEASE/scripts/autoscend/paths/low_key_summer.ash
@@ -462,12 +462,14 @@ boolean LX_lowkeySummer() {
 		// Don't start the war unless we've acquired the key from Belowdecks first as it gives +item.	
 		// TODO these aren't the full L12 tasks, could filthworms earlier here if Yellow Ray available
 		if (possessEquipment($item[Treasure Chest key])) {
-			if (L12_preOutfit() || L12_getOutfit() || L12_startWar() || L12_flyerFinish()) { return true; }
+			if (L12_preOutfit() || L12_getOutfit() || L12_startWar()) { return true; }
 		} else {
 			// Make sure Belowdecks is open so we can get the key.
 			if (LX_pirateQuest()) { return true; }
 		}
-
+		
+		L12_flyerFinish(); // Finish flyers whenever possible.
+		
 		// Get the +combat key before attempting Sonofa Beach.
 		if (possessEquipment($item[Music Box Key])) {
 			if (L12_sonofaBeach() || L12_sonofaFinish()) { return true; }

--- a/RELEASE/scripts/autoscend/quests/level_05.ash
+++ b/RELEASE/scripts/autoscend/quests/level_05.ash
@@ -17,7 +17,8 @@ boolean L5_getEncryptionKey()
 	}
 
 	// want to fight goblin king quickly in legacy of loathing to get another replica mr a
-	if(!in_lol() && canBurnDelay($location[The Outskirts of Cobb\'s Knob]))
+	// In LKS, important keys are gated behind here, and we have tonnes of delay
+	if(!(in_lol()||in_lowkeysummer()) && canBurnDelay($location[The Outskirts of Cobb\'s Knob]))
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

A lot of extra tasks and efficiencies have been added since LKS was optimised in autoscend. This updates the script to handle a few of them.

* Copy/pastes the early tasks from the default task order.
* Adds free runs for LKS only zones.
* Only wait for keys before the nuns (2x 50% meat keys) if they're needed (there's tonnes of alternatives now: backup camera, yamtility belt, feather boa).
* Don't wait for delay zones to complete Knob Outskirts in LKS (broke LKS for muscle classes)
* Only get the +exp keys early if we need the XP

Additionally, there are two more general changes:
* Changes assemble.sh to sort filenames case insensitive. This was how most of the repo was set up, but sometimes caused issues when people sorted filename-sensitive making the order different in the RELEASE data files, and commits unreadable.
* Hit the bastille batallion earlier so we can get the +25% exp buff from getaway campsite before doing mouthwash. Will affect most unrestricted paths.

## How Has This Been Tested?

3 shiny HC LKS runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
