### PR TITLE
use floundry fish from Bonus Adventures from Hell if our clan hasn't got them

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/clan.ash
+++ b/RELEASE/scripts/autoscend/iotms/clan.ash
@@ -683,13 +683,29 @@ boolean auto_floundryAction()
 	{
 		return false;
 	}
+	
+	// Handle whether we can jump to BAFH
+	int orig_clan_id = get_clan_id();
+	boolean in_bafh = orig_clan_id == getBAFHID();
+	boolean bafh_available = isWhitelistedToBAFH() && canReturnToCurrentClan(); // bafh probably has it fully stocked
+	
 	if(!get_property("_floundryItemGot").to_boolean() && (auto_get_clan_lounge() contains $item[Clan Floundry]) && !inAftercore())
 	{
 		if(get_property("auto_floundryChoice") != "")
 		{
 			string[int] floundryChoice = split_string(get_property("auto_floundryChoice"), ";");
 			item myFloundry = trim(floundryChoice[min(count(floundryChoice), my_daycount()) - 1]).to_item();
-			if(auto_floundryAction(myFloundry))
+			boolean success = auto_floundryAction(myFloundry);
+			if(!success)
+			{
+				if (bafh_available)
+				{
+					changeClan(); // Jump to BAFH
+					success = auto_floundryAction(myFloundry);
+					changeClan(orig_clan_id); // go home
+				}
+			}
+			if (success)
 			{
 				if(($items[Bass Clarinet, Codpiece, Fish Hatchet] contains myFloundry) && !get_property("_floundryItemUsed").to_boolean() && (item_amount(myFloundry) > 0))
 				{


### PR DESCRIPTION
# Description

Floundry needs fish as fuel. BAFH is always stocked. If a floundry fish is request but our own clan doesn't have sufficient fish, go and grab the fish from BAFH.

## How Has This Been Tested?

Couple of runs of HC unrestricted using a character with a VIP key.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
