### PR TITLE
fix: in hardcore, when an avatar class, return after reading

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3149,7 +3149,7 @@ boolean L11_palindome()
 					pullXWhenHaveY($item[Stunt Nuts], 1, 0);
 				}
 			}
-			if(in_hardcore() && isGuildClass())
+			if(in_hardcore())
 			{
 				return true;
 			}


### PR DESCRIPTION
# Description

Fix Palindome for hardcore avatars. Previously, running autoscend again after it aborted worked, so I think this is the right move.

It might be questionable whether certain avatar paths can get +100% item drop, and so whether they should brute force the palindome.

## How Has This Been Tested?

Couple of AoSoL runs, WereProf, Dark Gyffte

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
