### PR TITLE
fix: even if the cubeling is the best fam, we might not use it

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -645,9 +645,7 @@ boolean autoChooseFamiliar(location place)
 	famChoice = auto_forceEagle(); // force Patriotic Eagle if we have a >0 combats until we can screech again
 
 	//Gelatinous Cubeling drops items that save turns in the daily dungeon
-	if(famChoice == $familiar[none] &&
-	wantCubeling() &&
-	lookupFamiliarDatafile("item") != $familiar[Gelatinous Cubeling]) // don't farm the drops if this is the best +item familiar we have. We will get them regardless.
+	if(famChoice == $familiar[none] && wantCubeling())
 	{
 		famChoice = $familiar[Gelatinous Cubeling];
 	}


### PR DESCRIPTION
# Description

Even if the Cubeling is the best item familiar we have, we might not use it enough to get the items to run the DD.

## How Has This Been Tested?

I don't have an account in a position to test this.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
