### PR TITLE
If using Douse on monster, do not YR (or especially cast envy) before

### DIFF
--- a/BUILD/monsters/yellowray.dat
+++ b/BUILD/monsters/yellowray.dat
@@ -41,9 +41,9 @@ zombie hippy	!outfit:Filthy Hippy Disguise
 War Hippy Spy	!outfit:War Hippy Fatigues;!itemdropcapped:30=round purple sunglasses;prop:auto_hippyInstead=true
 War Hippy Airborne Commander	!outfit:War Hippy Fatigues;prop:auto_hippyInstead=true
 # And we want filthworm glands, but not if we're gonna hugpocket them
-larval filthworm	!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm hatchling scent gland
-filthworm drone	!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm drone scent gland
-filthworm royal guard	!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm royal guard scent gland
+larval filthworm	item:filthworm hatchling scent gland<1;!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm hatchling scent gland
+filthworm drone	item:filthworm drone scent gland<1;!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm drone scent gland
+filthworm royal guard	item:filthworm royal guard scent gland<1;!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm royal guard scent gland
 Knight (Snake)	class:Ed the Undying
 bearpig topiary animal	familiar:Melodramedary;!itemdropcapped:15=rusty hedge trimmers
 elephant (meatcar?) topiary animal	familiar:Melodramedary;!itemdropcapped:15=rusty hedge trimmers

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -283,9 +283,9 @@ yellowray	31	zombie hippy	!outfit:Filthy Hippy Disguise
 yellowray	32	War Hippy Spy	!outfit:War Hippy Fatigues;!itemdropcapped:30=round purple sunglasses;prop:auto_hippyInstead=true
 yellowray	33	War Hippy Airborne Commander	!outfit:War Hippy Fatigues;prop:auto_hippyInstead=true
 # And we want filthworm glands, but not if we're gonna hugpocket them
-yellowray	34	larval filthworm	!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm hatchling scent gland
-yellowray	35	filthworm drone	!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm drone scent gland
-yellowray	36	filthworm royal guard	!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm royal guard scent gland
+yellowray	34	larval filthworm	item:filthworm hatchling scent gland<1;!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm hatchling scent gland
+yellowray	35	filthworm drone	item:filthworm drone scent gland<1;!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm drone scent gland
+yellowray	36	filthworm royal guard	item:filthworm royal guard scent gland<1;!familiar:XO Skeleton;!class:Ed the Undying;!itemdropcapped:10=filthworm royal guard scent gland
 yellowray	37	Knight (Snake)	class:Ed the Undying
 yellowray	38	bearpig topiary animal	familiar:Melodramedary;!itemdropcapped:15=rusty hedge trimmers
 yellowray	39	elephant (meatcar?) topiary animal	familiar:Melodramedary;!itemdropcapped:15=rusty hedge trimmers

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -76,7 +76,13 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 	}
 	
 	//yellowray instantly kills the enemy and makes them drop all items they can drop.
-	if(!combat_status_check("yellowray") && auto_wantToYellowRay(enemy, my_location()))
+	// don't yellow ray if we'll be dousing
+	skill douse = $skill[douse foe];
+	boolean isDouseTarget = wantToDouse(enemy) && round < 22; // dousing can have a low chance of success, so only do it up to round 21, then yellow
+	boolean douseAvailable = canUse(douse, false) && auto_dousesRemaining()>0;
+	boolean willDouse = isDouseTarget && douseAvailable;
+	
+	if(!combat_status_check("yellowray") && auto_wantToYellowRay(enemy, my_location()) && !willDouse)
 	{
 		string combatAction = yellowRayCombatString(enemy, true, $monsters[bearpig topiary animal, elephant (meatcar?) topiary animal, spider (duck?) topiary animal, Knight (Snake)] contains enemy);
 		if(combatAction != "")


### PR DESCRIPTION
# Description

We now use the FLUDA douse pickpocket on the Filthworms. At the moment this works fine in standard except log entries, but in unrestricted where we have eg, Feel Envy or other forced drops it will use these before trying to douse. So with an envy, you use both the envy and the douse to get the same item.

This adds a condition to the YR so it tries dousing first, and only YR/Envies if it gets to round limit for dousing.

Fixes # (issue)

## How Has This Been Tested?

3 shiny HC runs, inc 2 unrestricted.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
