### PR TITLE
Pull a range from storage if we didn't buy it

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1364,6 +1364,11 @@ boolean ovenHandle()
 	if(!get_property("auto_haveoven").to_boolean() && (my_meat() >= (npc_price($item[Dramatic&trade; range]) + 1000)) && isGeneralStoreAvailable())
 	{
 		auto_buyUpTo(1, $item[Dramatic&trade; range]);
+		if(storage_amount($item[Dramatic&trade; range]) > 0)
+		{
+			//pull it from storage if we didn't get 1 when we tried to buy it
+			pullXWhenHaveY($item[Dramatic&trade; range], 1, 0);
+		}
 		use(1, $item[Dramatic&trade; range]);
 		set_property("auto_haveoven", true);
 	}


### PR DESCRIPTION
# Description

Fronobulax reported this issue on the Mafia forums where he didn't acquire a range as expceted when trying to create fancy foods. This should fix that.

## How Has This Been Tested?

Untested. Waiting on frono's input

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
