### PR TITLE
Pass famChoice through if we don't need to force the eagle

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -642,7 +642,7 @@ boolean autoChooseFamiliar(location place)
 		famChoice = lookupFamiliarDatafile("init");
 	}
 
-	famChoice = auto_forceEagle(); // force Patriotic Eagle if we have a >0 combats until we can screech again
+	famChoice = auto_forceEagle(famChoice); // force Patriotic Eagle if we have a >0 combats until we can screech again
 
 	//Gelatinous Cubeling drops items that save turns in the daily dungeon
 	if(famChoice == $familiar[none] &&

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -546,7 +546,7 @@ boolean auto_canCircadianRhythm();
 boolean auto_circadianRhythmTarget(monster target);
 boolean auto_circadianRhythmTarget(phylum target);
 boolean auto_haveEagle();
-familiar auto_forceEagle();
+familiar auto_forceEagle(familiar famChoice);
 boolean auto_haveJillOfAllTrades();
 void auto_handleJillOfAllTrades();
 boolean auto_haveBurningLeaves();

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -918,7 +918,7 @@ boolean auto_haveEagle()
 	return false;
 }
 
-familiar auto_forceEagle()
+familiar auto_forceEagle(familiar famChoice)
 {
 	//Force the Patriotic Eagle if we used a banish recently and can't use one until we burn 11 combats with the Eagle
 	if(auto_haveEagle() && get_property("screechCombats").to_int() > 0 && !auto_queueIgnore())
@@ -926,7 +926,7 @@ familiar auto_forceEagle()
 		auto_log_info("Forcing Patriotic Eagle");
 		return $familiar[Patriotic Eagle];
 	}
-	return $familiar[none];
+	return famChoice;
 }
 
 boolean auto_haveBurningLeaves()


### PR DESCRIPTION
# Description

If we didn't need to force the Patriotic Eagle, we would return $familiar[none]. This returns whatever was previously picked instead.

## How Has This Been Tested?

Untested, but should work

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
