### PR TITLE
feat: extract having good fam equipment from tiny gold medal summon code

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -918,3 +918,16 @@ void preAdvUpdateFamiliar(location place)
 		mummifyFamiliar();
 	}
 }
+
+boolean auto_needsGoodFamiliarEquipment() {
+	if (possessEquipment($item[Astral pet sweater])) {
+		return false;
+	}
+	if (auto_hasStillSuit()) {
+		return false;
+	}
+	if (auto_haveCupidBow()) {
+		return false;
+	}
+	return true;
+}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -616,6 +616,7 @@ boolean auto_equipAllMcHugeLarge();
 boolean auto_openMcLargeHugeSkis();
 int auto_McLargeHugeForcesLeft();
 int auto_McLargeHugeSniffsLeft();
+boolean auto_haveCupidBow();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash
@@ -1520,6 +1521,7 @@ boolean autoChooseFamiliar(location place);
 boolean haveSpleenFamiliar();
 boolean wantCubeling();
 void preAdvUpdateFamiliar(location place);
+boolean auto_needsGoodFamiliarEquipment();
 
 ########################################################################################################
 //Defined in autoscend/auto_list.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -621,7 +621,7 @@ void auto_scepterSkills()
 			use_familiar(findRockFamiliarInTerrarium());
 			use_skill($skill[Aug. 28th: Race Your Mouse Day!]); //Fam equipment to lower weight of attack familiar or Burly bodyguard (Avant Guard) for Gremlins
 		}
-		else if((!auto_hasStillSuit() && item_amount($item[Astral pet sweater]) == 0) || in_small())
+		else if(auto_needsGoodFamiliarEquipment() || in_small())
 		{
 			if(!is100FamRun())
 			{

--- a/RELEASE/scripts/autoscend/iotms/mr2025.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2025.ash
@@ -75,3 +75,9 @@ int auto_McLargeHugeSniffsLeft()
 	int used = get_property("_mcHugeLargeSlashUses").to_int();
 	return 3-used;
 }
+
+boolean auto_haveCupidBow()
+{
+	item bow = $item[toy cupid bow];
+	return (auto_is_valid(bow) && possessEquipment(bow));
+}


### PR DESCRIPTION
# Description

Don't summon a tiny gold medal if we have astral pet sweater, stillsuit or cupid bow (or are in small, following existing code).

Cupid bow code extracted from #1577. 

## How Has This Been Tested?

Not yet.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
