### PR TITLE
feat: improve eagle banish clearing

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1449,7 +1449,7 @@ boolean adventureFailureHandler()
 		}
 	}
 
-	if(last_monster() == $monster[Crate] && !(get_property("screechDelay").to_boolean()) && (in_wereprof() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave in Wereprof for Smashed Scientific Equipment
+	if(last_monster() == $monster[Crate] && get_property("screechDelay") != "" && (in_wereprof() && !($location[Noob Cave].turns_spent < 8))) //want 7 turns of Noob Cave in Wereprof for Smashed Scientific Equipment
 	{
 		if(get_property("auto_newbieOverride").to_boolean())
 		{

--- a/RELEASE/scripts/autoscend/paths/bugbear_invasion.ash
+++ b/RELEASE/scripts/autoscend/paths/bugbear_invasion.ash
@@ -100,7 +100,7 @@ boolean bugbear_UnlockMothership(location loc)
 
 	if (is_banished($phylum[beast]))
 	{
-		set_property("screechDelay", true);
+		set_property("screechDelay", "beast");
 		return false; // Can't fight bugbears if beasts are banished
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -54,7 +54,7 @@ boolean L10_airship()
 
 	if (is_banished($phylum[dude]) && get_property("screechCombats").to_int() > 0 && !possessEquipment($item[amulet of extreme plot significance]))
 	{
-		set_property("screechDelay", true);
+		set_property("screechDelay", "dude");
 		return false; //Probably should delay the Airship to try for a Quiet Healer
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -459,7 +459,7 @@ boolean LX_unlockManorSecondFloor() {
 	if (is_banished($phylum[construct]) && get_property("screechCombats").to_int() > 0 &&
 	(item_amount($item[killing jar]) > 0 && ((get_property("gnasirProgress").to_int() & 4) != 4)))
 	{
-		set_property("screechDelay", true);
+		set_property("screechDelay", "construct");
 		return false;
 	}
 
@@ -825,7 +825,7 @@ boolean L11_blackMarket()
 
 	if (is_banished($phylum[beast]) && get_property("screechCombats").to_int() > 0)
 	{
-		set_property("screechDelay", true);
+		set_property("screechDelay", "beast");
 		return false; // Can't get the reassembled blackbird if beasts are banished
 	}
 	
@@ -2454,7 +2454,7 @@ boolean L11_mauriceSpookyraven()
 	{
 		if (is_banished($phylum[construct]) && get_property("screechCombats").to_int() > 0)
 		{
-			set_property("screechDelay", true);
+			set_property("screechDelay", "construct");
 			return false; //No sense in trying to go to the Wine Cellar if constructs (Wine Racks) are banished
 		}
 
@@ -2477,7 +2477,7 @@ boolean L11_mauriceSpookyraven()
 	{
 		if (is_banished($phylum[undead]) && get_property("screechCombats").to_int() > 0)
 		{
-			set_property("screechDelay", true);
+			set_property("screechDelay", "undead");
 			return false; //No sense in trying to go to the Laundry Room if undead (Cabinet of Dr. Limpieza) are banished
 		}
 
@@ -2804,7 +2804,7 @@ boolean L11_shenCopperhead()
 
 	if (is_banished($phylum[dude]) && get_property("screechCombats").to_int() > 0)
 	{
-		set_property("screechDelay", true);
+		set_property("screechDelay", "dude");
 		return false; //Probably should delay the Copperhead Club because dudes are important here
 	}
 
@@ -2971,7 +2971,7 @@ boolean L11_palindome()
 
 	if(is_banished($phylum[dude]) && get_property("screechCombats").to_int() > 0)
 	{
-		set_property("screechDelay", true);
+		set_property("screechDelay", "dude");
 		return false; //If new phylum banishers come out, this should be updated.
 	}
 
@@ -3054,7 +3054,7 @@ boolean L11_palindome()
 		//Can't do Whitey's Grove if beasts are banished
 		if(is_banished($phylum[beast]) && get_property("screechCombats").to_int() > 0)
 		{
-			set_property("screechDelay", true);
+			set_property("screechDelay", "beast");
 			return false; //If new phylum banishers come out, this should be updated.
 		}
 		providePlusCombat(15, $location[Whitey's Grove], false);

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -1108,11 +1108,11 @@ boolean LX_dronesOut()
 boolean LX_lastChance()
 {
 	//miscellaneous calls that aren't powerlevelling but need to be done at some point based on certain conditions
-	if(get_property("screechDelay").to_boolean())
+	if(get_property("screechDelay") != "")
 	{
 		location banishLoc;
 		auto_log_warning("Patriotic Eagle's screech banished something we need and we can't adventure anywhere else");
-		while(get_property("screechCombats").to_int() > 0 && my_adventures() > 2 && phylumBanishTurnsRemaining() > 0)
+		while((get_property("screechCombats").to_int() > 0 || banishLoc == $location[none]) && my_adventures() > 2 && is_banished(get_property("screechDelay").to_phylum()))
 		{
 			handleFamiliar($familiar[Patriotic Eagle]); //force eagle to be used
 			if(LX_getDigitalKey() || LX_getStarKey())
@@ -1149,8 +1149,10 @@ boolean LX_lastChance()
 			auto_log_warning("Couldn't clear screech delay without running out of adventures");
 			return false;
 		}
-		autoAdv(banishLoc); //adventure here to banish goblins or constructs and be able to progress other quests
-		set_property("screechDelay", false);
+		if (is_banished(get_property("screechDelay").to_phylum())) {
+			autoAdv(banishLoc); //adventure here to banish goblins or constructs and be able to progress other quests
+		}
+		set_property("screechDelay", "");
 		return true;
 	}
 	// Need the digital key and star key so if we have nothing to do before the L13 quest, might as well do them here


### PR DESCRIPTION
# Description

Enter the `screechCombat` eagle block if banish location is unset.

Set which phylum we're trying to unbanish so we can confirm it didn't run out.

## How Has This Been Tested?

Fist run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
