### PR TITLE
Make auto_consume respect auto_advToReserve

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1985,7 +1985,7 @@ boolean auto_chewAdventures()
 	//tries to chew a size 4 familiar spleen item that gives adventures. All are IOTM derivatives with 1.875 adv/size
 	boolean liver_check = my_inebriety() < inebriety_limit() && !in_kolhs();	//kolhs has special drinking. liver often unfilled
 	if(liver_check || my_fullness() < fullness_limit()
-		|| ((my_adventures() > 1+auto_advToReserve()) && !almostRollover()))
+		|| (my_adventures() > max(10,1+auto_advToReserve()) && !almostRollover()))
 	{
 		return false;	//1.875 A/S is bad. only chew if 1 adv remains
 	}
@@ -2206,7 +2206,7 @@ void consumeStuff()
 
 	boolean edSpleenCheck = (isActuallyEd() && my_level() < 11 && spleen_left() > 0); // Ed should fill spleen first
 	
-	if (my_adventures() < 10 && fullness_left() > 0 && is_boris())
+	if (my_adventures() < max(10,1+auto_advToReserve()) && fullness_left() > 0 && is_boris())
 	{
 		borisDemandSandwich(true);
 	}
@@ -2229,8 +2229,8 @@ void consumeStuff()
 		}
 	}
 
-	// If adventures low, or it's almost Rollover, we need to consume
-	if ((my_adventures() < 10 && !edSpleenCheck) || (almostRollover() && needToConsumeForEmergencyRollover()))
+	// If adventures at our reserve amount, or it's almost Rollover, we need to consume
+	if ((my_adventures() < max(10,1+auto_advToReserve()) && !edSpleenCheck) || (almostRollover() && needToConsumeForEmergencyRollover()))
 	{
 		// always unequip stooper as only useful for roll over
 		if (my_familiar() == $familiar[Stooper] && to_familiar(get_property("auto_100familiar")) != $familiar[Stooper] 


### PR DESCRIPTION
# Description

Previously, auto_consume would consume once the user got to less than 10 adv (other than chewing spleen). This changes that to be either 10 or 1+how much the user wants to reserve at the end of the day, whichever is greater.

## How Has This Been Tested?

Set auto_advToReserve to my current adventure count and it triggered the consume code. Unsetting it it runs like normal.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
