### PR TITLE
feat: add a pref to banish phyla

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -1,3 +1,4 @@
+auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.
 auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
 auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
 auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.

--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -1,4 +1,3 @@
-auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.
 auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
 auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
 auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.

--- a/BUILD/settings/post.dat
+++ b/BUILD/settings/post.dat
@@ -5,3 +5,4 @@ auto_holeinthesky	boolean	Open the Hole in the Sky in this ascension?
 auto_hippyInstead	boolean	Fight on the side of the hippies instead of the Frat Warriors in this ascension?
 auto_ignoreFlyer	boolean	Do not do the flyer quest in this ascension? recommended to set true if fighting for the hippies.
 auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this ascension?
+auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -9,55 +9,56 @@ action	2	auto_paranoia	integer	If quest tracking is broken enable this. It deter
 action	3	auto_inv_paranoia	boolean	If item drop tracking is broken enable this. It will refresh inventory every loop.
 action	4	auto_newbieOverride	boolean	If true will override newbie block once then set itself to false. Newbie block is enabled used when you fight a crate (please report crate fighting) or when you spent too many adventures in a zone
 
-any	0	auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
-any	1	auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
-any	2	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
-any	3	auto_powerLevelTimer	integer	Delay in seconds before each time we spend an adv powerleveling. default is 10 sec. lowest valid value is 1.
-any	4	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
-any	5	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
-any	6	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
-any	7	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
-any	8	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	9	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	10	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	11	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
-any	12	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
-any	13	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	14	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
-any	15	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	16	auto_dontConsumeLegendPizzas	boolean	When false, will craft or pull and eat Cookbookbat Legend Pizzas. Does nothing if auto_limitConsume is true;
-any	17	auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
-any	18	auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
-any	19	auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
-any	20	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	21	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	22	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	23	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	24	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	25	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	26	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	27	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	28	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	29	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	30	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	31	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	32	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
-any	33	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	34	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
-any	35	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	36	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	37	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle. Setting to -1 will cause the lowest possible ML to be equipped, including going negative if possible - this can cause non-optimal gear to be equipped.
-any	38	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	39	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	40	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 3 (debug).
-any	41	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
-any	42	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	43	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	44	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP? This may also let autoscend collect low-effort PVP items.
-any	45	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
-any	46	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
-any	47	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
-any	48	auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?
+any	0	auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.
+any	1	auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
+any	2	auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
+any	3	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
+any	4	auto_powerLevelTimer	integer	Delay in seconds before each time we spend an adv powerleveling. default is 10 sec. lowest valid value is 1.
+any	5	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
+any	6	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
+any	7	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
+any	8	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
+any	9	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
+any	10	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	11	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	12	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
+any	13	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
+any	14	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	15	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
+any	16	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	17	auto_dontConsumeLegendPizzas	boolean	When false, will craft or pull and eat Cookbookbat Legend Pizzas. Does nothing if auto_limitConsume is true;
+any	18	auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
+any	19	auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
+any	20	auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
+any	21	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	22	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	23	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	24	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	25	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	26	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	27	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	28	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	29	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	30	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	31	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	32	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	33	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
+any	34	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	35	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
+any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	37	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	38	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle. Setting to -1 will cause the lowest possible ML to be equipped, including going negative if possible - this can cause non-optimal gear to be equipped.
+any	39	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	40	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	41	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 3 (debug).
+any	42	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
+any	43	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	44	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	45	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP? This may also let autoscend collect low-effort PVP items.
+any	46	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+any	47	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
+any	48	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
+any	49	auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -9,56 +9,55 @@ action	2	auto_paranoia	integer	If quest tracking is broken enable this. It deter
 action	3	auto_inv_paranoia	boolean	If item drop tracking is broken enable this. It will refresh inventory every loop.
 action	4	auto_newbieOverride	boolean	If true will override newbie block once then set itself to false. Newbie block is enabled used when you fight a crate (please report crate fighting) or when you spent too many adventures in a zone
 
-any	0	auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.
-any	1	auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
-any	2	auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
-any	3	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
-any	4	auto_powerLevelTimer	integer	Delay in seconds before each time we spend an adv powerleveling. default is 10 sec. lowest valid value is 1.
-any	5	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
-any	6	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
-any	7	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
-any	8	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
-any	9	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
-any	10	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
-any	11	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
-any	12	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
-any	13	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
-any	14	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
-any	15	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
-any	16	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
-any	17	auto_dontConsumeLegendPizzas	boolean	When false, will craft or pull and eat Cookbookbat Legend Pizzas. Does nothing if auto_limitConsume is true;
-any	18	auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
-any	19	auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
-any	20	auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
-any	21	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
-any	22	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
-any	23	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
-any	24	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
-any	25	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
-any	26	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
-any	27	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
-any	28	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
-any	29	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
-any	30	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
-any	31	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
-any	32	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
-any	33	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
-any	34	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	35	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
-any	36	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
-any	37	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	38	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle. Setting to -1 will cause the lowest possible ML to be equipped, including going negative if possible - this can cause non-optimal gear to be equipped.
-any	39	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	40	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	41	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 3 (debug).
-any	42	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
-any	43	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
-any	44	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
-any	45	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP? This may also let autoscend collect low-effort PVP items.
-any	46	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
-any	47	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
-any	48	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
-any	49	auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?
+any	0	auto_skipGuzzlrCocktailSet	boolean	If true will not accept and abandon a Platinum Guzzlr quest for the cocktail set.
+any	1	auto_mushroomGardenGrowth	integer	Picks the mushroom when growth reaches the given value (or higher). Defaults to 1 to pick every day, capped at 11.
+any	2	auto_delayTimer	integer	Sets the delay before each action, default is 1 second(s). It is not recommended to reduce this below 1.
+any	3	auto_powerLevelTimer	integer	Delay in seconds before each time we spend an adv powerleveling. default is 10 sec. lowest valid value is 1.
+any	4	auto_stayInRun	boolean	If true, we stop when the King can be freed but do not free the King. Paths with a choice at liberation time will always stayInRun regardless of this setting.
+any	5	auto_confidence	boolean	If true, we'll get the confidence buff instead of breaking the mirror. Good if your combat suite isn't very fleshed out yet, since it makes the Naughty Sorceress dramatically easier.
+any	6	auto_teaChoice	string	When using the tea tree, grab this 'tea'. Must use a string that acceptable to Mafia's 'teatree' command (Use ; to separate by daycount, leave blank to skip a day).
+any	7	auto_floundryChoice	string	Force floundry usage. Must use the item name (Use ; to separate by daycount, leave blank to skip a day).
+any	8	auto_extrudeChoice	string	: separated by day, ; separated by order. Use food, booze. Defaults to booze for any empty fields.
+any	9	auto_blacklistFamiliar	string	A semi-colon separated string of familiar names that we do not want to use. They still may get used but this will minimize their usage.
+any	10	auto_ashtonLimit	integer	If set, makes sure you save X of an item before feeding it to the Asdon Martin (ignores Soda Bread).
+any	11	auto_limitConsume	boolean	When true will not eat or drink anything automatically.
+any	12	auto_skipNightcap	boolean	When true will not get overdrunk at the end of the day
+any	13	auto_consumeMinAdvPerFill	float	The minimum adventures per fill to consider for a consumable before eating or drinking it. Defaults to 0.0 and will consume whatever is available if necessary.
+any	14	auto_consumePullDesirability	float	This value is used as a rough estimate of how much a pull is "worth" when the consumption algorithm is considering using pulls. Higher values will make it more conservative and vice-versa. Defaults to 5.0.
+any	15	auto_dontConsumeKeyLimePies	boolean	When false, will pull and eat key lime pies if we require keys. Does nothing if auto_limitConsume is true;
+any	16	auto_dontConsumeLegendPizzas	boolean	When false, will craft or pull and eat Cookbookbat Legend Pizzas. Does nothing if auto_limitConsume is true;
+any	17	auto_bedtime_pulls_skip	boolean	If true will not automatically pull any items at the end of day.
+any	18	auto_bedtime_pulls_pvp_multi	float	Set the value of X for the formula for pull of rollover equipment. desireability = 1*rollover adventures + X*rollover PVP fights (if hippy stone is unlocked).
+any	19	auto_bedtime_pulls_min_desirability	float	During bedtime we pull and wear equipment that gives extra adventures and optionally PVP fights on rollover. This variable determines the minimum allowed score improvement compared to current equipment before we consider pulling it.
+any	20	auto_maximize_baseline	string	The string to use as the baseline for the maximizer when deciding gear. If this is blank or "default", it will use a generated maximizer statement that takes your current situation in to account somewhat.
+any	21	auto_equipment_override_hat	string	A semicolon separated list of overrides for the hat slot.
+any	22	auto_equipment_override_back	string	A semicolon separated list of overrides for the back slot.
+any	23	auto_equipment_override_shirt	string	A semicolon separated list of overrides for the shirt slot.
+any	24	auto_equipment_override_weapon	string	A semicolon separated list of overrides for the weapon slot.
+any	25	auto_equipment_override_off-hand	string	A semicolon separated list of overrides for the off-hand slot.
+any	26	auto_equipment_override_pants	string	A semicolon separated list of overrides for the pants slot.
+any	27	auto_equipment_override_acc	string	A semicolon separated list of overrides for the acc slots.
+any	28	auto_hideAdultery	boolean	When true, automatically deletes Zatara Consults from Kmails during end of day cleanup.
+any	29	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to get Ascension relevant rewards.
+any	30	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
+any	31	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
+any	32	auto_considerGalaktik	boolean	When true autoscend may automatically enable galaktik quest for this run if it decides it is needed.
+any	33	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+any	34	auto_skipUnlockGuild	boolean	When true, don't unlock the guild.
+any	35	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	36	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	37	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle. Setting to -1 will cause the lowest possible ML to be equipped, including going negative if possible - this can cause non-optimal gear to be equipped.
+any	38	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	39	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	40	auto_log_level	int	valid choices: 0 = error. 1 = warning. 2 = info. 3 = debug. Sets the level of logging which autoscend will output to gCLI and session log. Defaults to 3 (debug).
+any	41	auto_log_level_restore	int	valid choices: 0 = no extra debugging. 1 = log the stages and their results 2 = log restorer data dump. Sets the level of extra debug logging which autoscend restore code will output to gCLI and session log. Defaults to 0. Note that this is just for extra debugging.
+any	42	auto_restoreUseBloodBond	boolean	Whether to use extra hp to cast blood bond. Blood bond has a recurring HP drain, set to false if you are worried about getting killed or wasting resources healing. Defaults to false.
+any	43	auto_forceFatLootToken	boolean	force grabbing the fat loot tokens from daily dungeon and fantasy realm every day even if you already have enough for this run. This is mainly for new accounts who want to get the cubeling and/or skillbooks.
+any	44	auto_pvpEnable	boolean	Break the hippy stone to unlock PvP? This may also let autoscend collect low-effort PVP items.
+any	45	auto_towerBreak	string	Where should we break in the tower? (e.g. wall of skin, wall of bones, shadow, ns). Blank by default.
+any	46	auto_ignoreRestoreFailure	boolean	if true we will always ignore failure to restore MP or HP and just continue playing
+any	47	auto_workshed	string	What workshed item should we initialize with? If blank or invalid, we will change workshed based on priorities. There are some shorthands or you can use the full name of the workshed item. Some worksheds are not implemented so unless you are certain you want to deviate, use auto.
+any	48	auto_stopMinutesToRollover	int	How many minutes before rollover do we need to start getting ready for bed?
 
 post	0	auto_getSteelOrgan	boolean	Get Steel Organ in this ascension?
 post	1	auto_getBeehive	boolean	Get Beehive in this ascension?
@@ -67,6 +66,7 @@ post	3	auto_holeinthesky	boolean	Open the Hole in the Sky in this ascension?
 post	4	auto_hippyInstead	boolean	Fight on the side of the hippies instead of the Frat Warriors in this ascension?
 post	5	auto_ignoreFlyer	boolean	Do not do the flyer quest in this ascension? recommended to set true if fighting for the hippies.
 post	6	auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this ascension?
+post	7	auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.
 
 pre	0	auto_getSteelOrgan_initialize	boolean	When we initialize an ascension this will be copied to auto_getSteelOrgan
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -189,6 +189,7 @@ void initializeSettings() {
 	set_property("auto_debuffAsdonDelay", 0);
 	set_property("auto_disableAdventureHandling", false);
 	set_property("auto_doCombatCopy", "no");
+	set_property("auto_dontPhylumBanish", false);
 	set_property("auto_drunken", "");
 	set_property("auto_eaten", "");
 	set_property("auto_familiarChoice", "");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -757,6 +757,9 @@ boolean auto_wantToBanish(monster enemy, location loc)
 
 boolean auto_wantToBanish(phylum enemyphylum, location loc)
 {
+	if (get_property("auto_dontPhylumBanish").to_boolean()) {
+		return false;
+	}
 	location locCache = my_location();
 	set_location(loc);
 	boolean [phylum] phylumToBanish = auto_getPhylum("banish");

--- a/RELEASE/scripts/autoscend/paths/bugbear_invasion.ash
+++ b/RELEASE/scripts/autoscend/paths/bugbear_invasion.ash
@@ -13,6 +13,8 @@ void bugbear_InitializeSettings()
 		set_property("auto_holeinthesky", false);
 		set_property("auto_getStarKey", false);
 		set_property("nsTowerDoorKeysUsed", "Boris's key,Jarlsberg's key,Sneaky Pete's key,Richard's star key,skeleton key,digital key");
+		// banishing beasts / constructs can screw up bugbear hunting
+		set_property("auto_dontPhylumBanish", true);
 	}
 }
 

--- a/RELEASE/scripts/autoscend/paths/wereprofessor.ash
+++ b/RELEASE/scripts/autoscend/paths/wereprofessor.ash
@@ -10,6 +10,8 @@ void wereprof_initializeSettings()
 		return;
 	}
 	set_property("auto_wandOfNagamar", false);		//wand not used in this path
+	// if we banish a phylum while werewolf, we can't undo it while wereprofessor
+	set_property("auto_dontPhylumBanish", true);
 	cli_execute('wereprofessor research');			//parse the research bench
 }
 


### PR DESCRIPTION
# Description

Banishing phyla is high variance and can mess up the routing. Let the user turn it off. 

## How Has This Been Tested?

Bugbear, werewolf.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
