### PR TITLE
Disallow Patriotic Screech in some paths. Some QT optimizations

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -407,7 +407,7 @@ boolean auto_pre_adventure()
 				adjustForYellowRayIfPossible(mon);
 				zoneHasWantedMonsters = true;
 			}
-			if(auto_wantToBanish(monster_phylum(mon), place) && !auto_famKill($familiar[Patriotic Eagle], place))
+			if(auto_wantToBanish(monster_phylum(mon), place))
 			{
 				// attempt to prepare for banishing, but if we can not try free running
 				adjustForBanishIfPossible(monster_phylum(mon), place);

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -577,7 +577,7 @@ string banisherCombatString(phylum enemyPhylum, location loc, boolean inCombat)
 	if(inCombat)
 		auto_log_info("Finding a phylum banisher to use on " + enemyPhylum + " at " + loc, "green");
 
-	if(inCombat ? (my_familiar() == $familiar[Patriotic Eagle] && get_property("screechCombats").to_int() == 0) : (auto_have_familiar($familiar[Patriotic Eagle]) && (get_property("screechCombats").to_int() == 0)))
+	if(inCombat ? (my_familiar() == $familiar[Patriotic Eagle] && get_property("screechCombats").to_int() == 0) : (!in_avantGuard() && pathAllowsChangingFamiliar() && !auto_famKill($familiar[Patriotic Eagle], loc) && auto_have_familiar($familiar[Patriotic Eagle]) && (get_property("screechCombats").to_int() == 0)))
 	{
 		return "skill" + $skill[%fn\, Release the Patriotic Screech!];
 	}

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -59,17 +59,22 @@ boolean LX_quantumTerrarium()
 			}
 			break;
 		case $familiar[Reassembled blackbird]:
-			if(my_level() > 10 && !(internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 1 || black_market_available()))
+			if(!(internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 1 || black_market_available()))
 			{
 				return L11_blackMarket();
 			}
 			break;
 		case $familiar[Reconstituted crow]:
-			if(my_level() > 10 && !(internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 1 || black_market_available()))
+			if(!(internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 1 || black_market_available()))
 			{
 				return L11_blackMarket();
 			}
 			break;
+		case $familiar[Melodramedary]:
+			if(!(internalQuestStatus("questL11Desert") != 0 || get_property("desertExploration").to_int() >= 100))
+			{
+				return L11_aridDesert();
+			}
 		default:
 			break;
 	}

--- a/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
+++ b/RELEASE/scripts/autoscend/paths/quantum_terrarium.ash
@@ -58,6 +58,18 @@ boolean LX_quantumTerrarium()
 				}
 			}
 			break;
+		case $familiar[Reassembled blackbird]:
+			if(my_level() > 10 && !(internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 1 || black_market_available()))
+			{
+				return L11_blackMarket();
+			}
+			break;
+		case $familiar[Reconstituted crow]:
+			if(my_level() > 10 && !(internalQuestStatus("questL11Black") < 0 || internalQuestStatus("questL11Black") > 1 || black_market_available()))
+			{
+				return L11_blackMarket();
+			}
+			break;
 		default:
 			break;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1344,7 +1344,14 @@ boolean L11_aridDesert()
 
 		if (dbr.fam != $familiar[none])
 		{
-			handleFamiliar(dbr.fam);
+			if(in_quantumTerrarium())
+			{
+				qt_FamiliarSwap(dbr.fam);
+			}
+			else
+			{
+				handleFamiliar(dbr.fam);
+			}
 		}
 		if (dbr.weapon != $item[none])
 		{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -828,6 +828,16 @@ boolean L11_blackMarket()
 		set_property("screechDelay", true);
 		return false; // Can't get the reassembled blackbird if beasts are banished
 	}
+	
+	if(in_quantumTerrarium())
+	{
+		//swap to the blackbird or crow if we can
+		if(!($familiars[Reassembled Blackbird, Reconstituted Crow] contains my_familiar()))
+		{
+			qt_FamiliarSwap($familiar[Reassembled Blackbird]);
+			qt_FamiliarSwap($familiar[Reconstituted Crow]);
+		}
+	}
 
 	if ($location[The Black Forest].turns_spent > 12 && !in_avantGuard())
 	{


### PR DESCRIPTION
# Description

This should fix some of the reported issues with Eagle being used inappropriately in Avant Guard and Quantum Terrarium.

Also, in QT:
* Forces reassembled blackbird or reconstituted crow when going to the black forest
* If they are the randomly chosen fam, go to the black forest if still needed
* Forces melodramadery or LHM when adventuring in the desert
* If the melodramadery is randomly, go to the desert if still needed

## How Has This Been Tested?

Almost a full QT run. The melodramadery and blackbird changes weren't tested as they were caught mid-run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
