### PR TITLE
dont gravel first astronomers

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -44,7 +44,7 @@ boolean wantToThrowGravel(location loc, monster enemy)
 	if (isFreeMonster(enemy, loc)) { return false; } // don't use gravel against inherently free fights
 	// prevent overuse after breaking ronin or in casual
 	if(can_interact()) return false;
-	
+	//don't gravel first astronomer we encounter in an ascension. 
 	if(enemy == $monster[Astronomer] && item_amount($item[star chart]) < 1 && item_amount($item[Richard's star key]) < 1)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -44,7 +44,11 @@ boolean wantToThrowGravel(location loc, monster enemy)
 	if (isFreeMonster(enemy, loc)) { return false; } // don't use gravel against inherently free fights
 	// prevent overuse after breaking ronin or in casual
 	if(can_interact()) return false;
-
+	
+	if(enemy == $monster[Astronomer] && item_amount($item[star chart]) < 1 && item_amount($item[Richard's star key]) < 1)
+	{
+		return false;
+	}
 	// only want certain enemies to free-kill in Avant Guard
 	if(in_avantGuard())
 	{


### PR DESCRIPTION
# Description
Dont use gravel against the first astronomer we encounter in an ascension - prevention added in as initial implementation to fix issue wherein this happens in avant guard run against a bodyguard astronomer, and then autoscend tries to timespin up an astronomer but cant because of how avant guard works

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

It hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [X] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
