### PR TITLE
Update auto_combat_default_stage5.ash

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -293,6 +293,11 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 				costMinor = mp_cost($skill[Utensil Twist]);
 			}
 		}
+		if((in_glover() || attackMinor == "attack with weapon") && canUse($skill[Saucegeyser], false))
+        	{
+            		attackMinor = useSkill($skill[Saucegeyser], false);
+            		costMinor = mp_cost($skill[Saucegeyser]);
+        	}
 		break;
 	case $class[Sauceror]:
 		if(canUse($skill[Saucegeyser], false))


### PR DESCRIPTION
Add G-lover path, skill Saucegeyser. Code provided by Malibu Stacey

# Description

I was running G-Lover and needed to use Saucegeyser as the attack. As a pastamancer it was running "attack with weapon" instead of Saucegeyser which it should be using. This adds the combat support for Saucegeyser as a pastamancer in G-Lover

## How Has This Been Tested?

I ran the rest of my adventures via autoscend and it finally used Saucegeyser instead of "Attack with weapon"