### PR TITLE
fix: do not try to adventure with no familiar in AG

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -286,8 +286,8 @@ boolean fantasyRealmToken()
 		return false;
 	}
 
-	// If we're not allowed to adventure without a familiar due to being in a 100% familiar run.
-	if(is100FamRun())
+	// If we're not allowed to adventure without a familiar due to being in a 100% familiar run or Avant Guard
+	if(is100FamRun() || in_avantGuard())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

In Avant Guard, we need the bodyguard, so we can't fight bandits with no familiar.

Fixes # (issue)

## How Has This Been Tested?

Worked to get past that point.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
