### PR TITLE
fix: various wotsf issues, delay airship with banished dudes

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage5.ash
@@ -960,6 +960,17 @@ string auto_combatDefaultStage5(int round, monster enemy, string text)
 		}
 	}
 
+	// Wu Tang the Betrayer is immune to spells and normal attacks, but not Fist skills or Spectral Snapper
+	if (enemy == $monster[Wu Tang the Betrayer]) {
+		foreach sk in $skills[Spectral Snapper, Stinkpalm, Drunken Baby Style, Zendo Kobushi Kancho, Chilled Monkey Brain Technique, Knuckle Sandwich, Seven-Finger Strike, Flying Fire Fist] {
+			if(canUse(sk, false))
+			{
+				return useSkill(sk, false);
+			}
+		}
+		abort("Wu Tang the Betrayer is immune to spells and normal attacks, and I do not know how to kill him");
+	}
+
 	if((my_location() == $location[The X-32-F Combat Training Snowman]) && contains_text(text, "Cattle Prod") && (my_mp() >= costMajor))
 	{
 		return attackMajor;

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -52,6 +52,12 @@ boolean L10_airship()
 		return false;
 	}
 
+	if (is_banished($phylum[dude]) && get_property("screechCombats").to_int() > 0 && !possessEquipment($item[amulet of extreme plot significance]))
+	{
+		set_property("screechDelay", true);
+		return false; //Probably should delay the Airship to try for a Quiet Healer
+	}
+
 	auto_log_info("The Penultimate Fantasy Airship - unlocking Castle.", "blue");
 	if((my_mp() > 60) || considerGrimstoneGolem(true))
 	{
@@ -147,7 +153,7 @@ boolean L10_basement()
 			return false;
 		}
 	}
-	else if(possessEquipment($item[Titanium Assault Umbrella]) && !auto_can_equip($item[Titanium Assault Umbrella]))
+	else if(possessEquipment($item[Titanium Assault Umbrella]) && !in_wotsf() && !is_boris() && !auto_can_equip($item[Titanium Assault Umbrella]))
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -925,7 +925,7 @@ boolean L11_forgedDocuments()
 	{
 		return false;
 	}
-	if (my_meat() < npc_price($item[Forged Identification Documents]))
+	if (!in_wotsf() && my_meat() < npc_price($item[Forged Identification Documents]))
 	{
 		if(isAboutToPowerlevel())
 		{


### PR DESCRIPTION
# Description

Extract the non-eagle changes from #1592.

Various changes from a WotSF run.

Don't try to do the airship while Healers are phylum banished.

Don't avoid adventuring in the Castle Basement with an umbrella you can't equip.

Don't require enough meat to buy the forged identification documents when you won't need to buy them.

Fight Wu Tang a bit better.

Fixes # (issue)

## How Has This Been Tested?

Fist run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
