### PR TITLE
fix: don't even try nuns on day 1 AG

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1741,11 +1741,21 @@ boolean L12_themtharHills()
 	}
 	
 	handleFamiliar("meat");
-	
-	//can only do this in Avant Guard in 6 turns in HC or 8 turns in Normal. Need the August Scepter. If going turbo, can't get enough waffles so don't even bother with this
+
+	//can only do this in Avant Guard in 6 turns in HC or 8 turns in Normal. Need the August Scepter. If day 1, can't get enough waffles so don't even bother with this
 	set_property("auto_delayWar", false);
-	if(in_avantGuard() && auto_haveAugustScepter() && !(auto_turbo()))
+	if(in_avantGuard())
 	{
+		if (!auto_haveAugustScepter()) {
+			// no scepter = no waffles = impossible
+			// macrometeorite / replace enemy use different code and don't work for this
+			set_property("auto_skipNuns", "true");
+			return false;
+		}
+		if (my_daycount() == 1) {
+			// don't have enough waffles yet
+			return false;
+		}
 		auto_log_info("Checking how much meat drop we can get");
 		if((in_hardcore() && item_amount($item[waffle]) <= 6 && $location[The Themthar Hills].turns_spent + item_amount($item[waffle]) > 6) ||
 		(item_amount($item[waffle]) <= 8 && $location[The Themthar Hills].turns_spent + item_amount($item[waffle]) > 8))


### PR DESCRIPTION
# Description

If we don't have the scepter, we can't try nuns at all.

On day 1, we definitely won't have enough waffles, so again don't try.

Fixes # (issue)

## How Has This Been Tested?

Avant Guard, day 1, stopped at the nuns.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
