### PR TITLE
Allow Plumber to use McDuffel to climb the Peak

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -496,6 +496,11 @@ boolean L8_trapperExtreme()
 	if(auto_haveMcHugeLargeSkis())
 	{
 		auto_equipAllMcHugeLarge();
+		// plumber literally wont let you adventure if you have no way to fight in plumber.
+			if(in_plumber())
+			{
+				equip($slot[acc3], $item[work boots]);
+			}
 	}
 	// we should equip the extreme outfit if we have it
 	else if(possessOutfit("eXtreme Cold-Weather Gear", true)) // own and can equip
@@ -831,11 +836,6 @@ boolean L8_trapperPeak()
 			equip($slot[off-hand], $item[McHugeLarge left pole]);
 			equip($slot[acc1]    , $item[McHugeLarge left ski]);
 			equip($slot[acc2]    , $item[McHugeLarge right ski]);
-			// plumber literally wont let you adventure if you have no way to fight in plumber.
-			if(in_plumber())
-			{
-				equip($slot[acc3], $item[work boots]);
-			}
 			visit_url("place.php?whichplace=mclargehuge&action=cloudypeak");
 			return true;
 		}

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -831,6 +831,11 @@ boolean L8_trapperPeak()
 			equip($slot[off-hand], $item[McHugeLarge left pole]);
 			equip($slot[acc1]    , $item[McHugeLarge left ski]);
 			equip($slot[acc2]    , $item[McHugeLarge right ski]);
+			// plumber literally wont let you adventure if you have no way to fight in plumber.
+			if(in_plumber())
+			{
+				equip($slot[acc3], $item[work boots]);
+			}
 			visit_url("place.php?whichplace=mclargehuge&action=cloudypeak");
 			return true;
 		}


### PR DESCRIPTION
# Description

Ensure Plumber is wearing work boots when trying to use the McDuffel equipment to get the NonCombat(s) - Plumber autostops you from going into a zone if you dont have a way to actually fight due to not wearing one of the plumber equips.

Fixes # (issue)

## How Has This Been Tested?

It Hasn't

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [X] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
