### PR TITLE
More conditions to prevent halting while dousing shadow bricks

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_header.ash
@@ -59,6 +59,7 @@ boolean wantToForceDrop(monster enemy);
 boolean wantToDouse(monster enemy);
 int maxRoundsToDouse(monster enemy);
 boolean canSurviveShootGhost(monster enemy, int shots);
+int auto_remainingMildEvilUses();
 
 #####################################################
 //defined in /autoscend/combat/auto_combat_awol.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -1202,6 +1202,9 @@ int maxRoundsToDouse(monster enemy)
 	if (canUse(flyer) && get_property("flyeredML").to_int() < 10000) { rounds -= 1; }
 	// Or pants removal
 	if (canUse($skill[tear away your pants!])) { rounds -= 1; }
+	if (canUse($skill[perpetrate mild evil] )) { rounds -= auto_remainingMildEvilUses(); }// We'll be mild eviling any monsters we douse most likely
+	if (canUse($skill[swoop like a bat]     )) { rounds -= 1; } // swoopin' em too
+	if (canUse($skill[Fire Extinguisher: Polar Vortex])) { rounds -= auto_fireExtinguisherCharges(); }// and extingo
 	
 	return rounds;
 }
@@ -1253,4 +1256,10 @@ boolean canSurviveShootGhost(monster enemy, int shots) {
 			damage = my_maxhp() * 0.3;
 	}
 	return my_hp() > damage * shots;
+}
+
+int auto_remainingMildEvilUses()
+{
+	if (!have_skill($skill[perpetrate mild evil])) { return 0; }
+	return 3-get_property("_mildEvilPerpetrated").to_int();
 }


### PR DESCRIPTION
# Description

We use "Douse Your Foe" to get shadow bricks from shadow slabs. We only use it so many times, then move to other skills. When you have lots of other sources of combat actions, this can cause us to hit our round limit and require the player to kill manually.

This PR makes the max number of douses lower if you are going to use other pickpockets afterwards.

Fixes # (issue)

## How Has This Been Tested?

Couple of zooto SC runs, sepos in Discord also tested one day.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
