### PR TITLE
Use Peace Turkey for NCs, pea soup as free runaway, more condo spleen

### DIFF
--- a/BUILD/monsters/banish.dat
+++ b/BUILD/monsters/banish.dat
@@ -14,6 +14,7 @@ Gluttonous Ghuol	class:Vampyre
 Gluttonous Ghuol	prop:auto_turbo==true
 Knob Goblin Harem Guard
 Knob Goblin Madam	item:Knob Goblin Perfume>0
+Irritating Series of Random Encounters
 Mad Wino	!class:Ed the Undying
 MagiMechTech MechaMech	class:Ed the Undying
 Mob Penguin Capo	class:Ed the Undying

--- a/RELEASE/data/autoscend_monsters.txt
+++ b/RELEASE/data/autoscend_monsters.txt
@@ -18,44 +18,45 @@ banish	12	Gluttonous Ghuol	class:Vampyre
 banish	13	Gluttonous Ghuol	prop:auto_turbo==true
 banish	14	Knob Goblin Harem Guard
 banish	15	Knob Goblin Madam	item:Knob Goblin Perfume>0
-banish	16	Mad Wino	!class:Ed the Undying
-banish	17	MagiMechTech MechaMech	class:Ed the Undying
-banish	18	Mob Penguin Capo	class:Ed the Undying
-banish	19	Mismatched Twins
-banish	20	Natural Spider
-banish	21	Plaid Ghost
-banish	22	Possessed Laundry Press
-banish	23	Procrastination Giant
-banish	24	Protagonist	!class:Ed the Undying;!familiar:Red-Nosed Snapper
-banish	25	Pygmy Headhunter
-banish	26	Pygmy Janitor	tavern:true
-banish	27	Pygmy Orderlies
-banish	28	Pygmy Witch Lawyer
-banish	29	Pygmy Witch Nurse
-banish	30	Red Herring
-banish	31	Red Snapper
-banish	32	Sabre-Toothed Goat
-banish	33	Senile Lihc	loc:The Defiled Niche;prop:cyrptNicheEvilness>14
-banish	34	Slick Lihc	loc:The Defiled Niche;prop:cyrptNicheEvilness>14
-banish	35	Skeletal Sommelier
-banish	36	Spooky mummy	class:Ed the Undying
-banish	37	Spooky vampire	class:Ed the Undying
-banish	38	Steam Elemental
-banish	39	Taco Cat
-banish	40	Tan Gnat
-banish	41	Tomb Asp
-banish	42	Tomb Servant
-banish	43	Triffid	class:Ed the Undying
-banish	44	Wardr&ouml;b Nightstand
-banish	45	Warehouse Janitor
-banish	46	party skelteon	loc:The Defiled Nook;prop:cyrptNookEvilness>14
-banish	47	basic lihc	loc:The Defiled Niche;prop:cyrptNicheEvilness>14
+banish	16	Irritating Series of Random Encounters
+banish	17	Mad Wino	!class:Ed the Undying
+banish	18	MagiMechTech MechaMech	class:Ed the Undying
+banish	19	Mob Penguin Capo	class:Ed the Undying
+banish	20	Mismatched Twins
+banish	21	Natural Spider
+banish	22	Plaid Ghost
+banish	23	Possessed Laundry Press
+banish	24	Procrastination Giant
+banish	25	Protagonist	!class:Ed the Undying;!familiar:Red-Nosed Snapper
+banish	26	Pygmy Headhunter
+banish	27	Pygmy Janitor	tavern:true
+banish	28	Pygmy Orderlies
+banish	29	Pygmy Witch Lawyer
+banish	30	Pygmy Witch Nurse
+banish	31	Red Herring
+banish	32	Red Snapper
+banish	33	Sabre-Toothed Goat
+banish	34	Senile Lihc	loc:The Defiled Niche;prop:cyrptNicheEvilness>14
+banish	35	Slick Lihc	loc:The Defiled Niche;prop:cyrptNicheEvilness>14
+banish	36	Skeletal Sommelier
+banish	37	Spooky mummy	class:Ed the Undying
+banish	38	Spooky vampire	class:Ed the Undying
+banish	39	Steam Elemental
+banish	40	Taco Cat
+banish	41	Tan Gnat
+banish	42	Tomb Asp
+banish	43	Tomb Servant
+banish	44	Triffid	class:Ed the Undying
+banish	45	Wardr&ouml;b Nightstand
+banish	46	Warehouse Janitor
+banish	47	party skelteon	loc:The Defiled Nook;prop:cyrptNookEvilness>14
+banish	48	basic lihc	loc:The Defiled Niche;prop:cyrptNicheEvilness>14
 # Bugbear Invasion Mothership
-banish	48	scavenger bugbear	path:Bugbear Invasion;loc:Waste Processing;!sniffed:scavenger bugbear
-banish	49	bugaboo	path:Bugbear Invasion;loc:Morgue;!sniffed:bugaboo
-banish	50	Battlesuit Bugbear Type	path:Bugbear Invasion:loc:Engineering;!sniffed:Battlesuit Bugbear Type
-banish	51	ancient unspeakable bugbear	path:Bugbear Invasion;loc:Navigation;!sniffed:ancient unspeakable bugbear
-banish	52	trendy bugbear chef	path:Bugbear Invasion;loc:Galley;loc:Gallery;!sniffed:trendy bugbear chef
+banish	49	scavenger bugbear	path:Bugbear Invasion;loc:Waste Processing;!sniffed:scavenger bugbear
+banish	50	bugaboo	path:Bugbear Invasion;loc:Morgue;!sniffed:bugaboo
+banish	51	Battlesuit Bugbear Type	path:Bugbear Invasion:loc:Engineering;!sniffed:Battlesuit Bugbear Type
+banish	52	ancient unspeakable bugbear	path:Bugbear Invasion;loc:Navigation;!sniffed:ancient unspeakable bugbear
+banish	53	trendy bugbear chef	path:Bugbear Invasion;loc:Galley;loc:Gallery;!sniffed:trendy bugbear chef
 
 copy	0	Pygmy Bowler	prop:hiddenBowlingAlleyProgress<4
 copy	1	Bob Racecar

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1160,11 +1160,12 @@ boolean dailyEvents()
 
 	if(item_amount($item[Clan VIP Lounge Key]) > 0)
 	{
-		if(!get_property("_olympicSwimmingPoolItemFound").to_boolean() && is_unrestricted($item[Olympic-sized Clan Crate]))
+		int[item] furn = auto_get_clan_lounge();
+		if(furn contains $item[Olympic-sized Clan crate] && !get_property("_olympicSwimmingPoolItemFound").to_boolean() && is_unrestricted($item[Olympic-sized Clan Crate]))
 		{
 			cli_execute("swim item");
 		}
-		if(!get_property("_lookingGlass").to_boolean() && is_unrestricted($item[Clan Looking Glass]))
+		if(furn contains $item[Clan looking glass] && !get_property("_lookingGlass").to_boolean() && is_unrestricted($item[Clan Looking Glass]))
 		{
 			string temp = visit_url("clan_viplounge.php?action=lookingglass");
 		}
@@ -1174,7 +1175,7 @@ boolean dailyEvents()
 			cli_execute("clan_viplounge.php?action=klaw");
 			cli_execute("clan_viplounge.php?action=klaw");
 		}
-		if(!get_property("_crimboTree").to_boolean() && is_unrestricted($item[Crimbough]))
+		if(furn contains $item[Crimbough] && furn[$item[Crimbough]]==5 && !get_property("_crimboTree").to_boolean() && is_unrestricted($item[Crimbough]))
 		{
 			cli_execute("crimbotree get");
 		}

--- a/RELEASE/scripts/autoscend/auto_bedtime.ash
+++ b/RELEASE/scripts/autoscend/auto_bedtime.ash
@@ -69,6 +69,29 @@ void bedtime_still()
 	}
 }
 
+boolean bedtime_spleen()
+{
+	boolean[item] to_try = $items[Breathitin&trade;, Extrovermectin&trade;,
+	  scoop of pre-workout powder, phosphor traces, Homebodyl&trade;, energized spores];
+
+	boolean done = false;
+	while (spleen_left() > 0 && !done)
+	{
+		boolean consumed_this_loop = false;
+		foreach it in to_try
+		{
+			if (canChew(it) && available_amount(it) > 0 && it.spleen <= spleen_left())
+			{
+				autoChew(1,it);
+				consumed_this_loop = true;
+				break;
+			}
+		}
+		if (!consumed_this_loop) { done = true; }
+	}
+	return spleen_left()==0;
+}
+
 int pullsNeeded(string data)
 {
 	if(inAftercore())
@@ -1330,7 +1353,9 @@ boolean doBedtime()
 			auto_log_info("Using the spinning wheel in your workshed", "blue");
 			visit_url("campground.php?action=spinningwheel");
 		}
-		
+
+		bedtime_spleen();
+
 		bedtime_pulls();
 		pullsNeeded("evaluate");
 

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -192,7 +192,7 @@ boolean auto_run_choice(int choice, string page)
 			{
 				run_choice(6); // advance immateria quest
 			}
-			else if (options contains 5)
+			else if (options contains 5 && L10_needUmbrella())
 			{
 				run_choice(5); // get titanium umbrella, metallic A, SGEEA and a penultimate fantasy chest
 			}

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -205,9 +205,6 @@ boolean auto_pre_adventure()
 	}
 	auto_log_info("Starting preadventure script...", "green");
 	auto_log_debug("Adventuring at " +place, "green");
-	
-	preAdvUpdateFamiliar(place);
-	ed_handleAdventureServant(place);
 
 	if (item_amount($item[Handful of split pea soup]) == 0 && creatable_amount($item[Handful of split pea soup]) > 0)
 	{
@@ -374,6 +371,10 @@ boolean auto_pre_adventure()
 	if (combatModifier._boolean && !auto_queueIgnore()) {
 		acquireCombatMods(combatModifier._int, true);
 	}
+
+	// Update our familiar after combat modifiers (which can set the familiar), but before Crystal Ball (familiar equip)
+	preAdvUpdateFamiliar(place);
+	ed_handleAdventureServant(place);
 
 	boolean considerCrystalBallBonus = false;
 	if(auto_haveCrystalBall())

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -209,6 +209,11 @@ boolean auto_pre_adventure()
 	preAdvUpdateFamiliar(place);
 	ed_handleAdventureServant(place);
 
+	if (item_amount($item[Handful of split pea soup]) == 0 && creatable_amount($item[Handful of split pea soup]) > 0)
+	{
+		return create(1, $item[Handful of split pea soup]);
+	}
+
 	if(get_floundry_locations() contains place)
 	{
 		buffMaintain($effect[Baited Hook]);

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -361,8 +361,7 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 		Inky Camouflage,
 		Celestial Camouflage,
 		Feeling Lonely,
-		Feeling Sneaky,
-		Hippy Antimilitarism
+		Feeling Sneaky
 	])) {
 		return result();
 	}

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -233,6 +233,23 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 		return result();
 	}
 
+	// First let's do the peace turkey, only if we haven't already picked a familiar
+	if (!speculative && get_property("auto_familiarChoice").to_familiar()==$familiar[none])
+	{
+		foreach fam in $familiars[Peace Turkey]
+		{
+			if(canChangeToFamiliar(fam))
+			{
+				use_familiar(fam);
+				handleFamiliar(fam);
+				if(pass()){
+					return result();
+				}
+				break;
+			}
+		}
+	}
+
 
 	// first lets do stuff that is "free" (as in has no MP cost, item use or can be freely removed/toggled)
 
@@ -376,16 +393,19 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 		return result();
 	}
 
-	if (!speculative)
+	// If we haven't picked a familiar by now consider the disgeist
+	if (!speculative && get_property("auto_familiarChoice").to_familiar()==$familiar[none])
 	{
-		foreach fam in $familiars[Peace Turkey, Disgeist]
+		foreach fam in $familiars[disgeist]
 		{
 			if(canChangeToFamiliar(fam))
 			{
+				use_familiar(fam);
 				handleFamiliar(fam);
 				if(pass()){
 					return result();
 				}
+				break;
 			}
 		}
 	}

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -848,6 +848,10 @@ boolean adjustForBanish(string combat_string)
 	{
 		return create(1, $item[Handful of split pea soup]);
 	}
+	if(combat_string == "skill "+$skill[Punch Out Your Foe] && auto_punchOutsLeft() == 0 && available_amount($item[scoop of pre-workout powder]) > 0 && spleen_left() > 3)
+	{
+		return autoChew(1, $item[scoop of pre-workout powder]);
+	}
 	return true;
 }
 
@@ -1068,6 +1072,13 @@ string freeRunCombatString(monster enemy, location loc, boolean inCombat)
 	if((inCombat ? auto_have_skill($skill[Bowl a Curveball]) : item_amount($item[Cosmic Bowling Ball]) > 0) && auto_is_valid($skill[Bowl a Curveball]))
 	{
 		return "skill " + $skill[Bowl a Curveball];
+	}
+
+	// We have a lot of banishes - we can use handful of split pea soup as runaway, but not our last
+	int potential_split_pea_soup = available_amount($item[whirled peas])/2 + available_amount($item[handful of split pea soup]);
+	if(potential_split_pea_soup > 1 && auto_is_valid($item[handful of split pea soup]))
+	{
+		return "item " + $item[handful of split pea soup];
 	}
 
 	//Non-standard free-runs

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1458,6 +1458,7 @@ boolean autoAdvBypass(string url, string option);
 ########################################################################################################
 //Defined in autoscend/auto_bedtime.ash
 void bedtime_still();
+boolean bedtime_spleen();
 int pullsNeeded(string data);
 float rollover_value(item it);
 float rollover_improvement(item it, slot sl);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -636,6 +636,8 @@ boolean auto_haveLeprecondo();
 boolean auto_haveDiscoveredLeprecondoFurniture(int furn);
 boolean auto_setLeprecondo();
 boolean auto_useLeprecondoDrops();
+int auto_punchOutsLeft();
+int auto_afterimagesLeft();
 
 ########################################################################################################
 //Defined in autoscend/paths/actually_ed_the_undying.ash

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1219,6 +1219,7 @@ boolean L10_topFloor();
 void castleTopFloorChoiceHandler(int choice);
 boolean L10_holeInTheSkyUnlock();
 boolean L10_rainOnThePlains();
+boolean L10_needUmbrella();
 
 ########################################################################################################
 //Defined in autoscend/quests/level_11.ash

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -774,11 +774,6 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 		return "skill " + $skill[Snokebomb];
 	}
 	
-	if(auto_have_skill($skill[Punch Out Your Foe]) && auto_is_valid($skill[Punch Out Your Foe]) && (my_mp() >= mp_cost($skill[Punch Out Your Foe])) && (!(used contains "punch out your foe")) && useFree)
-	{
-		return "skill " + $skill[Punch Out Your Foe];
-	}
-	
 	if((item_amount($item[stuffed yam stinkbomb]) > 0) && (!(used contains "stuffed yam stinkbomb")) && auto_is_valid($item[stuffed yam stinkbomb]))
 	{
 		return "item " + $item[stuffed yam stinkbomb];
@@ -787,6 +782,12 @@ string banisherCombatString(monster enemy, location loc, boolean inCombat)
 	if(inCombat ? item_amount($item[Handful of split pea soup]) > 0 && (!(used contains "Handful of split pea soup")) && auto_is_valid($item[Handful of split pea soup]) && useFree : (item_amount($item[Handful of split pea soup]) > 0 || item_amount($item[Whirled peas]) >= 2))
 	{
 		return "item " + $item[Handful of split pea soup];
+	}
+
+	if(inCombat ? (auto_have_skill($skill[Punch Out Your Foe]) && auto_is_valid($skill[Punch Out Your Foe]) && (my_mp() >= mp_cost($skill[Punch Out Your Foe])) && (!(used contains "punch out your foe")) && useFree)
+	    : auto_is_valid($skill[Punch Out Your Foe]) && (auto_have_skill($skill[Punch Out Your Foe]) || (available_amount($item[scoop of pre-workout powder]) > 0 && spleen_left() > 3) ))
+	{
+		return "skill " + $skill[Punch Out Your Foe];
 	}
 
 	if(auto_have_skill($skill[[28021]Punt]) && (my_mp() > mp_cost($skill[[28021]Punt])) && !(used contains "Punt"))

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -1085,7 +1085,7 @@ boolean auto_handleCCSC()
 	 The Shore, Inc. Travel Agency - 2 Scrips and all stats
 	 The Defiled Cranny - -11 evilness
 	 The eXtreme Slope - If we can't do ninja snowmen for some reason, gives us 2 pieces of equipment in one NC
-	 The Penultimate Fantasy Airship - Get an umbrella for basement, metallic A for wand, SGEEA, and Fantasy Chest for even more items
+	 The Penultimate Fantasy Airship - Get an umbrella for basement, only if we don't have one.
 	 The Black Forest - +8 exploration
 	 The Copperhead Club - Gives us a priceless diamond, saving 4950-5000 meat
 	 The Hidden Apartment Building - +1 cursed level, Doesn't leave NC
@@ -1104,7 +1104,7 @@ boolean auto_handleCCSC()
 	   || (place == $location[The Hidden Apartment Building] && !get_property("candyCaneSwordApartmentBuilding").to_boolean())
 	   || (place == $location[An Overgrown Shrine (Northeast)] && !get_property("_candyCaneSwordOvergrownShrine").to_boolean() && get_property("hiddenOfficeProgress").to_int() > 0)
 	   || (place == $location[The Overgrown Lot] && !get_property("_candyCaneSwordOvergrownLot").to_boolean())
-	   || (place == $location[The Penultimate Fantasy Airship] && (!possessEquipment($item[Amulet of Extreme Plot Significance]) || !possessEquipment($item[unbreakable umbrella]) || !possessEquipment($item[Titanium Assault Umbrella])))
+	   || (place == $location[The Penultimate Fantasy Airship] && L10_needUmbrella())
 	   || ((place == $location[Wartime Frat House] && possessOutfit("War Hippy Fatigues")) || (place == $location[Wartime Hippy Camp] && possessOutfit("Frat Warrior Fatigues")))
 	   || ($locations[The Sleazy Back Alley, A Mob of Zeppelin Protesters, The Daily Dungeon]) contains place)
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2025.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2025.ash
@@ -178,3 +178,13 @@ boolean auto_useLeprecondoDrops()
 	}
 	return true;
 }
+
+int auto_punchOutsLeft()
+{
+	return to_int(get_property("preworkoutPowderUses"));
+}
+
+int auto_afterimagesLeft()
+{
+	return to_int(get_property("phosphorTracesUses"));
+}

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -423,3 +423,14 @@ boolean L10_rainOnThePlains()
 	}
 	return false;
 }
+
+boolean L10_needUmbrella()
+{
+	foreach it in $items[titanium assault umbrella, unbreakable umbrella]
+	{
+		if (auto_is_valid(it) && available_amount(it)>0) {
+			return false;
+		}
+	}
+	return true;
+}


### PR DESCRIPTION
# Description

Using the Peace Turkey as a -combat modifier has been sitting in the provider for ages but didn't actually work. This fixes that.

Additionally:
* Always craft split pea soup before combat, whether we're using it as a banish or not.
* If it leaves us with at least one split pea soup, allow it to be used as a banish
* Stop candy-caning the airship as much (before it expected it could get an amulet for the cane sword, it can't)
* Since we no longer phylum banish it, irritating series of random encounters is just a regular banish now
* Consume pre-workout powder if we need it to banish.
* At bedtime, fill up our spleen if possible with CMC drops, condo drops and then energised spores from SIT.

Fixes # (issue)

## How Has This Been Tested?

1.5 zooto runs. The completed one was my fastest auto run by 10 turns, and I have a lot.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
