### PR TITLE
Use new mafia variable to check for douse foe success

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28448;	// update mafia for early condo support
+since r28468;	// douse success variable
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -173,7 +173,7 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 		}
 	}
 
-	if(wantToDouse(enemy) && round <= maxRoundsToDouse(enemy)) // dousing can have a low chance of success, so only do it for a while
+	if(wantToDouse(enemy) && round <= maxRoundsToDouse(enemy) && !(get_property("_douseFoeSuccess").to_boolean())) // dousing can have a low chance of success, so only do it for a while
 	{
 		skill douse = $skill[douse foe];
 		boolean douseAvailable = canUse(douse, false) && auto_dousesRemaining()>0;


### PR DESCRIPTION
# Description

We use douse foe to get shadow bricks from slabs, but previously had no way to tell if it had worked so just kept dousing until we were short on turns for other combat actions.

Ryo added a new Mafia variable to tell us that it's succeeded, so let's use that now.

## How Has This Been Tested?

One day's shadow rifting, worked perfectly.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
