### PR TITLE
Actually use user_confirms in Turbo

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2225,9 +2225,9 @@ void main(string... input)
 				return;
 			case "turbo":
 			// gotta go faaaaaast. Doing a double confirm because of the nature of this parameter.
-				user_confirm("This will get expensive for you. This should only be used if you are trying to go for a 1-day and don't care about expenses. Do you really want to do this? Will default to 'No' in 15 seconds.", 15000, false);
+				if(user_confirm("This will get expensive for you. This should only be used if you are trying to go for a 1-day and don't care about expenses. Do you really want to do this? Will default to 'No' in 15 seconds.", 15000, false))
 				{
-					user_confirm("This will use UMSBs and Spice Melanges if you have them. If you are ok with this, you have 15 seconds to hit 'Yes'", 15000, false);
+					if(user_confirm("This will use UMSBs and Spice Melanges if you have them. If you are ok with this, you have 15 seconds to hit 'Yes'", 15000, false))
 					{
 						set_property("auto_turbo", "true");
 						auto_log_info("Ka-chow! Gotta go fast.");

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -627,7 +627,7 @@ int handlePulls(int day)
 			{
 				if(storage_amount(it) > 0 && auto_is_valid(it) && !pulledToday(it))
 				{
-					user_confirm("Pulling a " + it + ". If you are ok with this, you have 15 seconds to hit 'Yes'", 15000, false);
+					if(user_confirm("Pulling a " + it + ". If you are ok with this, you have 15 seconds to hit 'Yes'", 15000, false))
 					{
 						pullXWhenHaveY(it, 1, 0);
 					}


### PR DESCRIPTION
# Description

Adds ifs to each user_confirm so that they actually do things in turbo

## How Has This Been Tested?

Tested each user_confirm (except the one in auto_acquire) with yes's and no's and it branched as expected

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
