### PR TITLE
fix: do the leaf fight more consistently

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -1303,8 +1303,10 @@ boolean auto_fightFlamingLeaflet()
 		addBonusToMaximize($item[tearaway pants], 500); // plants give turns when you tearaway
 	}
 
-	visit_url("campground.php?preaction=leaves");
-	return autoAdvBypass("choice.php?pwd&whichchoice=1510&option=1&leaves=11",$location[Noob Cave]);
+	string[int] pages;
+	pages[0] = "campground.php?preaction=leaves";
+	pages[1] = "choice.php?pwd&whichchoice=1510&option=1&leaves=11";
+	return autoAdvBypass(0, pages, $location[Noob Cave], "");
 }
 
 boolean auto_haveCCSC()


### PR DESCRIPTION
# Description

If the pre-adventure script visited a URL, the visiting of the choice would fail as the campground leaves wasn't the most immediately visited page.

This should fix that. 

## How Has This Been Tested?

Not yet, will try tomorrow.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
