### PR TITLE
Shadow fixes

### DIFF
--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -2218,7 +2218,6 @@ boolean[location] monster_to_location(monster target)
 	case $location[The Typical Tavern Cellar]:
 	case $location[The Spooky Forest]:
 	case $location[The Hidden Temple]:
-	case $location[8-Bit Realm]:
 	case $location[The Black Forest]:
 	case $location[The Beanbat Chamber]:
 	case $location[The Bat Hole Entrance]:

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1595,7 +1595,10 @@ boolean L13_towerNSTowerShadow()
 		buffMaintain($effect[Spiky Hair]);
 	}
 	cli_execute("scripts/autoscend/auto_post_adv.ash");
-	acquireHP();
+	if (!acquireHP())
+	{
+		abort("Failed to restore max hp for shadow");
+	}
 
 	autoAdvBypass("place.php?whichplace=nstower&action=ns_09_monster5", $location[Noob Cave]);
 	return true;

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1544,16 +1544,6 @@ boolean L13_towerNSTowerShadow()
 	{
 		abort("auto_towerBreak set to abort here.");
 	}
-	if(my_maxhp() < 800)
-	{
-		buffMaintain($effect[Industrial Strength Starch]);
-		buffMaintain($effect[Truly Gritty]);
-		buffMaintain($effect[Superheroic]);
-		buffMaintain($effect[Strong Grip]);
-		buffMaintain($effect[Spiky Hair]);
-	}
-	cli_execute("scripts/autoscend/auto_post_adv.ash");
-	acquireHP();
 
 	int n_healing_items = item_amount($item[gauze garter]) + item_amount($item[filthy poultice]) + item_amount($item[red pixel potion]) + item_amount($item[scented massage oil]);
 	if(in_plumber())
@@ -1595,6 +1585,18 @@ boolean L13_towerNSTowerShadow()
 			return autoAdv($location[The Fungus Plains]);
 		}
 	}
+
+	if(my_maxhp() < 800)
+	{
+		buffMaintain($effect[Industrial Strength Starch]);
+		buffMaintain($effect[Truly Gritty]);
+		buffMaintain($effect[Superheroic]);
+		buffMaintain($effect[Strong Grip]);
+		buffMaintain($effect[Spiky Hair]);
+	}
+	cli_execute("scripts/autoscend/auto_post_adv.ash");
+	acquireHP();
+
 	autoAdvBypass("place.php?whichplace=nstower&action=ns_09_monster5", $location[Noob Cave]);
 	return true;
 }

--- a/RELEASE/scripts/autoscend/quests/level_13.ash
+++ b/RELEASE/scripts/autoscend/quests/level_13.ash
@@ -1592,7 +1592,7 @@ boolean L13_towerNSTowerShadow()
 				}
 				abort("I tried to create [red pixel potions] for the shadow and mysteriously failed");
 			}
-			return autoAdv($location[8-bit Realm]);
+			return autoAdv($location[The Fungus Plains]);
 		}
 	}
 	autoAdvBypass("place.php?whichplace=nstower&action=ns_09_monster5", $location[Noob Cave]);


### PR DESCRIPTION
# Description

- 8-bit Realm is no longer available if we need red pixel potions
- Don't buff until items are acquired
- halt if healing before shadow fails

## How Has This Been Tested?

🙃

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
