### PR TITLE
Add beeosity and get rid of most maximize statements

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -509,6 +509,10 @@ string defaultMaximizeStatement()
 		res += ",0.4hp,0.2mp 1000max";
 		res += isActuallyEd() ? ",6mp regen" : ",3mp regen";
 	}
+	if(in_bhy())
+	{
+		res += ", 1 beeosity";
+	}
 
 	//weapon handling
 	if(is_boris())

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4626,7 +4626,8 @@ void effectAblativeArmor(boolean passive_dmg_allowed)
 	//but I am labeling them seperate from buffs in case we ever need to split this function.
 	
 	//if you have something that reduces the cost of casting buffs, wear it now.
-	maximize("-mana cost, -tie", false);
+	addToMaximize("-1000mana cost, -tie");
+	equipMaximizedGear();
 	
 	//Passive damage
 	if(passive_dmg_allowed)

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -223,7 +223,8 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	{
 		auto_log_info("We're gonna slurp up some sausage, let's make sure we have enough max mp", "blue");
 		cli_execute("checkpoint");
-		maximize("mp,-tie", false);
+		addToMaximize("1000mp,-tie", false);
+		equipMaximizedGear();
 	}
 	// I could optimize this a little more by eating more sausage at once if you have enough max mp...
 	// but meh.

--- a/RELEASE/scripts/autoscend/iotms/mr2019.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2019.ash
@@ -223,7 +223,7 @@ boolean auto_sausageEatEmUp(int maxToEat)
 	{
 		auto_log_info("We're gonna slurp up some sausage, let's make sure we have enough max mp", "blue");
 		cli_execute("checkpoint");
-		addToMaximize("1000mp,-tie", false);
+		addToMaximize("1000mp,-tie");
 		equipMaximizedGear();
 	}
 	// I could optimize this a little more by eating more sausage at once if you have enough max mp...

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -639,8 +639,9 @@ void auto_scepterSkills()
 		}
 	}
 	//see how much mana cost reduction we can get (up to 3mp)
-	maximize("-mana cost", true);
-	int manaCostMaximize = numeric_modifier("Generated:_spec", "Mana Cost");
+	simMaximizeWith("-1000mana cost");
+
+	int manaCostMaximize = simValue("Mana Cost");
 	if(manaCostMaximize < 3 && canUse($skill[Aug. 30th: Beach Day!]) && !get_property("_aug30Cast").to_boolean() && get_property("_augSkillsCast").to_int()< 5)
 	{
 		use_skill($skill[Aug. 30th: Beach Day!]); //For -MP (and Rollover Adventures)

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -309,7 +309,8 @@ boolean L13_heavyrains_towerFinal()
 	
 	//Calculate melee/ranged damage. Each element is capped at 40. assume you will be able to deal 40 physical damage.
 	cli_execute("outfit Birthday Suit");			//Need to get naked so we can check our stats properly.
-	maximize("prismatic damage, +weapon, +offhand", false);
+	addToMaximize("1000prismatic damage, +weapon, +offhand");
+	equipMaximizedGear();
 
 	int hot_dmg = min(40,numeric_modifier("hot damage"));
 	int cold_dmg = min(40,numeric_modifier("cold damage"));
@@ -325,7 +326,8 @@ boolean L13_heavyrains_towerFinal()
 	boolean want_club = false;
 	if(my_class() == $class[Seal Clubber] && auto_have_skill($skill[Lunging Thrust-Smack]))
 	{
-		maximize("prismatic damage, +weapon, +offhand, +club", false);
+		addToMaximize("prismatic damage, +weapon, +offhand, +club");
+		equipMaximizedGear();
 		int club_hot_dmg = min(40,(3*numeric_modifier("hot damage")));
 		int club_cold_dmg = min(40,(3*numeric_modifier("cold damage")));
 		int club_stench_dmg = min(40,(3*numeric_modifier("stench damage")));
@@ -423,23 +425,23 @@ boolean L13_heavyrains_towerFinal()
 		executeFlavour();
 		if(spell_extra_element)
 		{
-			maximize("spell damage percent, +weapon", false);
+			addToMaximize("spell damage percent, +weapon");
 			if(item_amount($item[Rain-Doh green lantern]) > 0)
 			{
-				equip($slot[off-hand], $item[Rain-Doh green lantern]);
+				autoEquip($slot[off-hand], $item[Rain-Doh green lantern]);
 			}
 			else if(item_amount($item[meteorb]) > 0)
 			{
-				equip($slot[off-hand], $item[meteorb]);
+				autoEquip($slot[off-hand], $item[meteorb]);
 			}
 			else if(item_amount($item[snow mobile]) > 0)
 			{
-				equip($slot[off-hand], $item[snow mobile]);
+				autoEquip($slot[off-hand], $item[snow mobile]);
 			}
 		}
 		else
 		{
-			maximize("spell damage percent, +weapon, +offhand", false);
+			addToMaximize("spell damage percent, +weapon, +offhand");
 		}
 	}
 	else
@@ -447,18 +449,18 @@ boolean L13_heavyrains_towerFinal()
 		set_property("auto_rain_king_combat", "attack");
 		if(want_club)
 		{
-			maximize("prismatic damage, +weapon, +offhand, +club", false);
+			addToMaximize("prismatic damage, +weapon, +offhand, +club");
 		}
 		else
 		{
-			maximize("prismatic damage, +weapon, +offhand", false);
+			addToMaximize("prismatic damage, +weapon, +offhand");
 		}
 	}
-	
 	//Rain King strips all equipment other than weapon and offhand.
 	//Stripped equipment can only provide you with -ML which is applied before the stripping
 	auto_buyUpTo(3, $item[water wings for babies]);
-	maximize("-ml, -weapon, -offhand", false);
+	addToMaximize("-ml, -weapon, -offhand", false);
+	equipMaximizedGear();
 	
 	//Fight!
 	//auto_disableAdventureHandling because we don't want maximize, switch familiar, change buffs, or anything else that might break our specific prepwork.

--- a/RELEASE/scripts/autoscend/paths/heavy_rains.ash
+++ b/RELEASE/scripts/autoscend/paths/heavy_rains.ash
@@ -459,7 +459,7 @@ boolean L13_heavyrains_towerFinal()
 	//Rain King strips all equipment other than weapon and offhand.
 	//Stripped equipment can only provide you with -ML which is applied before the stripping
 	auto_buyUpTo(3, $item[water wings for babies]);
-	addToMaximize("-ml, -weapon, -offhand", false);
+	addToMaximize("-ml, -weapon, -offhand");
 	equipMaximizedGear();
 	
 	//Fight!

--- a/RELEASE/scripts/autoscend/paths/zootomist.ash
+++ b/RELEASE/scripts/autoscend/paths/zootomist.ash
@@ -62,7 +62,7 @@ void zoo_d2Pulls()
 	
 	// Pull enough ML for oil peak, we need a provider function here.
 	int ml_target = 100.0;
-	simMaximizeWith("monster level",true);
+	simMaximizeWith("monster level");
 	int curr_ml = numeric_modifier($modifier[monster level]);
 	
 	// Function to try pulling an ML item, if it improves our ML by at least 10 over best alternative.

--- a/RELEASE/scripts/autoscend/paths/zootomist.ash
+++ b/RELEASE/scripts/autoscend/paths/zootomist.ash
@@ -62,7 +62,7 @@ void zoo_d2Pulls()
 	
 	// Pull enough ML for oil peak, we need a provider function here.
 	int ml_target = 100.0;
-	maximize("monster level",true);
+	simMaximizeWith("monster level",true);
 	int curr_ml = numeric_modifier($modifier[monster level]);
 	
 	// Function to try pulling an ML item, if it improves our ML by at least 10 over best alternative.


### PR DESCRIPTION
# Description

Issue brought up on Discord about BHY not respecting no Bs when trying to maximize mp when eating sausage from sausage goblin. This hopefully fixes it.

Also removes most calls directly to maximizer so that we utilize our custom functions more.

## How Has This Been Tested?

Standard maximizer call in BHY adds 1 beeosity now and it functions as expected (1 item has 1 "b" in its name). Removing the beeosity clause from the statement adds a second item with a "b" in its name

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
