### PR TITLE
fix: don't equip no familiar at nuns

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1824,10 +1824,11 @@ boolean L12_themtharHills()
 		meat_need = meat_need - 100;
 	}
 
-	if(canChangeFamiliar())
+	familiar famChoice = get_property("auto_familiarChoice").to_familiar();
+	if(canChangeFamiliar() && famChoice != $familiar[none])
 	{
 		// if we're in a 100% run, this property returns "none" which will unequip our familiar and ruin a 100% run.
-		use_familiar(to_familiar(get_property("auto_familiarChoice")));
+		use_familiar(famChoice);
 	}
 	equipMaximizedGear();
 	float meatDropHave = provideMeat(1800, true, true);


### PR DESCRIPTION
# Description

Having no familiar aborts the adventuring from the "no familiar" check.

This can occur if we have no meat familiars, which can be true in Zombie Slayer.

## How Has This Been Tested?

Zombie Slayer runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
