### PR TITLE
Turbo dieting pill fix

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -639,7 +639,7 @@ int handlePulls(int day)
 			{
 				foreach it in $items[Pizza of Legend, Calzone of Legend, Deep Dish of Legend]
 				{
-					if(auto_is_valid(it) && !pulledToday(it))
+					if(canEat(it) && !pulledToday(it))
 					{
 						pullXWhenHaveY(it, 1, 0);
 					}

--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -633,7 +633,6 @@ int handlePulls(int day)
 					}
 				}
 			}
-			pullXWhenHaveY($item[Dieting Pill], 1, 0);
 			//Make sure we have the legendary pizzas if we want to/can consume them so we take full advantage of the dieting pills
 			if(!get_property("auto_dontConsumeLegendPizzas").to_boolean())
 			{
@@ -642,6 +641,11 @@ int handlePulls(int day)
 					if(canEat(it) && !pulledToday(it))
 					{
 						pullXWhenHaveY(it, 1, 0);
+					}
+					// Pull at least one early dieting pill if we've acquired a legendary pizza
+					if (item_amount(it) > 0 && !pulledToday($item[Dieting Pill]))
+					{
+						pullXWhenHaveY($item[Dieting Pill], 1, 0);
 					}
 				}
 			}

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -533,13 +533,8 @@ boolean consumeMilkOfMagnesiumIfUnused()
 	return use(1, $item[Milk of Magnesium]);
 }
 
-boolean wantDietPill(item toEat)
+float minAdvPerFull(item toEat)
 {
-	item pill = $item[Dieting Pill];
-	if(!auto_is_valid(pill) || !auto_is_valid(toEat))
-	{
-		return false;
-	}
 	int minAdv;
 	if(index_of(toEat.adventures, "-") < 0)
 	{
@@ -550,8 +545,31 @@ boolean wantDietPill(item toEat)
 		minAdv = substring(toEat.adventures, 0, index_of(toEat.adventures, "-")).to_int();
 	}
 	int size = toEat.fullness;
+	return minAdv/size;
+}
+
+float minAdvPerFullForDietPill()
+{
+	if(is_jarlsberg())
+	{
+		return minAdvPerFull($item[Ultimate Breakfast Sandwich]) - 0.01;
+	}
+	if(in_zombieSlayer())
+	{
+		return minAdvPerFull($item[boss brain]) - 0.01;
+	}
+	return 8.5;
+}
+
+boolean wantDietPill(item toEat)
+{
+	item pill = $item[Dieting Pill];
+	if(!auto_is_valid(pill) || !auto_is_valid(toEat))
+	{
+		return false;
+	}
 	//Use a dieting pill on only high adv/full foods
-	if(minAdv/size > 8.5)
+	if(minAdvPerFull(toEat) > minAdvPerFullForDietPill())
 	{
 		//Only want a dieting pill if we can use it successfully
 		if(fullness_left() > 2 * size && spleen_left() >= 3)

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -572,7 +572,7 @@ boolean wantDietPill(item toEat)
 	if(minAdvPerFull(toEat) > minAdvPerFullForDietPill())
 	{
 		//Only want a dieting pill if we can use it successfully
-		if(fullness_left() > 2 * size && spleen_left() >= 3)
+		if(fullness_left() > 2 * toEat.fullness && spleen_left() >= 3)
 		{
 			pullXWhenHaveY(pill, 1, 0);
 			if(item_amount(pill) > 0)

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -572,7 +572,7 @@ boolean wantDietPill(item toEat)
 	if(minAdvPerFull(toEat) > minAdvPerFullForDietPill())
 	{
 		//Only want a dieting pill if we can use it successfully
-		if(fullness_left() > 2 * toEat.fullness && spleen_left() >= 3)
+		if(fullness_left() >= 2 * toEat.fullness && spleen_left() >= 3)
 		{
 			pullXWhenHaveY(pill, 1, 0);
 			if(item_amount(pill) > 0)


### PR DESCRIPTION
# Description

- When running turbo, don't pull legendary pizzas if they cannot be eaten
- When running turbo, don't pull an early dieting pill unless a legendary pizza was pulled
- Allow Jarlsberg and Zombie Slayer to use dieting pills by lowering min adv per full requirements. The other classes that have food limitations have options that are at least the hard coded 8.5. Maybe this should set via a property?
- Fix fullness left check to be greater than or equal to 2 * fullness

## How Has This Been Tested?

tbd: I'll test it after rollover

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
