### PR TITLE
fix: don't hose the garage if the desert is open

### DIFF
--- a/RELEASE/scripts/autoscend/paths/wildfire.ash
+++ b/RELEASE/scripts/autoscend/paths/wildfire.ash
@@ -436,7 +436,7 @@ boolean LX_wildfire_water()
 		if(LX_wildfire_hose($location[The Hidden Temple])) return true;
 	}
 	
-	if(!inKnollSign())		//knoll sign does not need to farm components for bitchin meatcar
+	if(!isDesertAvailable() && !inKnollSign()) //knoll sign does not need to farm components for bitchin meatcar
 	{
 		if(LX_wildfire_hose($location[The Degrassi Knoll Garage])) return true;
 	}


### PR DESCRIPTION
# Description

This can happen if we started as knoll and then used the spoon to switch signs, or if we bought the bus pass or used some other way to unlock the desert. 

## How Has This Been Tested?

Wildfire run.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
