### PR TITLE
Don't use combat restore if unneeded

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage3.ash
@@ -579,12 +579,12 @@ string auto_combatDefaultStage3(int round, monster enemy, string text)
 			return useSkill($skill[Ply Reality]);
 		}
 
-		if(canUse($item[Rain-Doh indigo cup]))
+		if(canUse($item[Rain-Doh indigo cup]) && my_hp() < my_maxhp())
 		{
 			return useItem($item[Rain-Doh Indigo Cup]);
 		}
 
-		if(canUse($skill[Summon Love Mosquito]))
+		if(canUse($skill[Summon Love Mosquito]) && my_hp() < my_maxhp())
 		{
 			return useSkill($skill[Summon Love Mosquito]);
 		}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -96,7 +96,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Air Dirty Laundry]);
 	}
 
-	if (canUse($skill[Summon Love Scarabs]))
+	if (canUse($skill[Summon Love Scarabs]) && my_mp() < my_maxmp())
 	{
 		return useSkill($skill[Summon Love Scarabs]);
 	}


### PR DESCRIPTION
# Description

- Don't use Rain-Doh indigo cup if at full hp
- Don't cast Summon Love Mosquito if at full hp
- Don't cast Summon Love Scarabs as ed if at full mp

## How Has This Been Tested?

trivial

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
