### PR TITLE
fix: allow fighting the wall of bones with no familiar

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -1052,7 +1052,7 @@ void main()
 	try
 	{
 		ret = auto_pre_adventure();
-		if (pathHasFamiliar() && my_familiar()==$familiar[none] && !isFantasyRealm(my_location())) {
+		if (pathHasFamiliar() && canChangeFamiliar() && my_familiar()==$familiar[none] && !isFantasyRealm(my_location())) {
 			abort("Trying to adventure with no familiar.");
 		}
 	}


### PR DESCRIPTION
# Description

In Legacy of Loathing (and perhaps elsewhere), you can end up at the wall of bones with no non-combat damaging familiars. Allow adventuring in this case. 

## How Has This Been Tested?

LoL run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
