### PR TITLE
fix: don't interrupt after mapping

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2020.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2020.ash
@@ -568,7 +568,6 @@ boolean auto_mapTheMonsters()
 
 monster auto_monsterToMap(location loc, string page)
 {
-	set_property("auto_interrupt", true);
 	matcher mons = create_matcher("heyscriptswhatsupwinkwink\" value=\"(\\d+)", page);
 	monster[int] monOpts;
 	int i = 0;


### PR DESCRIPTION
# Description

With #1636, after mapping the monsters autoscend aborts. Seems unlikely to be desired.

## How Has This Been Tested?

Run.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
