### PR TITLE
Update Phylum Banish Conditionals

### DIFF
--- a/BUILD/phylums/banish.dat
+++ b/BUILD/phylums/banish.dat
@@ -1,9 +1,9 @@
 dude	loc:The Black Forest
 dude	loc:Twin Peak
 dude	loc:The Red Zeppelin;item:Glark Cable>2
-dude	loc:Whitey's Grove;quest:questL11Palindome<=3
+dude	loc:Whitey's Grove;quest:questL11Palindome>=3
 beast	loc:The Hidden Park
-beast	loc:Inside the Palindome;quest:questL11Palindome<=3
+beast	loc:Inside the Palindome;quest:questL11Palindome<3
 undead	loc:The Haunted Library;item:Killing Jar>0;!prop_boolean:auto_famKill
 undead	loc:The Unquiet Garves
 undead	loc:The Haunted Boiler Room

--- a/RELEASE/data/autoscend_phylums.txt
+++ b/RELEASE/data/autoscend_phylums.txt
@@ -4,9 +4,9 @@
 # See auto_check_conditions for conditional optionsbanish	0	dude	loc:The Black Forest
 banish	1	dude	loc:Twin Peak
 banish	2	dude	loc:The Red Zeppelin;item:Glark Cable>2
-banish	3	dude	loc:Whitey's Grove;quest:questL11Palindome<=3
+banish	3	dude	loc:Whitey's Grove;quest:questL11Palindome>=3
 banish	4	beast	loc:The Hidden Park
-banish	5	beast	loc:Inside the Palindome;quest:questL11Palindome<=3
+banish	5	beast	loc:Inside the Palindome;quest:questL11Palindome<3
 banish	6	undead	loc:The Haunted Library;item:Killing Jar>0;!prop_boolean:auto_famKill
 banish	7	undead	loc:The Unquiet Garves
 banish	8	undead	loc:The Haunted Boiler Room


### PR DESCRIPTION
# Description

We were banishing dudes in Whitey's Grove only if the Mr. Alarm hadn't been met. This flips the conditional so now it will banish dudes if we have met Mr Alarm (no longer need dudes in Palindome

## How Has This Been Tested?

Untested

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
