### PR TITLE
Avoid homemade robot in Zooto

### DIFF
--- a/RELEASE/scripts/autoscend/paths/zootomist.ash
+++ b/RELEASE/scripts/autoscend/paths/zootomist.ash
@@ -392,7 +392,7 @@ familiar zoo_getBestFam(int bodyPart, boolean verbose)
 		"heal": 5,
 		"sniff": 5
 	};
-	boolean[familiar] blacklistFams = $familiars[reassembled blackbird, reconstituted crow];
+	boolean[familiar] blacklistFams = $familiars[reassembled blackbird, reconstituted crow, homemade robot];
 	foreach fam in $familiars[]
 	{
 		//comment out below line and uncomment second below line to see all unrestricted fams


### PR DESCRIPTION
# Description

Added Homemade Robot to the familiar blacklist for the Zooto path. Resolves #1644 .

## How Has This Been Tested?

Made change locally, ran script to continue Zooto run.

## Checklist:

- [ X] My code follows the style guidelines of this project.
- [ X] I have performed a self-review of my own code.
- [ X] I have commented my code, particularly in hard-to-understand areas.
- [ X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ X] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
