### PR TITLE
Hat Trick

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28514;	//  Fix peridot location choice parsing
+since r28530;	//  feat: peridot power, plurals
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -69,6 +69,7 @@ import <autoscend/paths/fall_of_the_dinosaurs.ash>
 import <autoscend/paths/g_lover.ash>
 import <autoscend/paths/gelatinous_noob.ash>
 import <autoscend/paths/grey_goo.ash>
+import <autoscend/paths/hattrick.ash>
 import <autoscend/paths/heavy_rains.ash>
 import <autoscend/paths/i_love_u_hate.ash>
 import <autoscend/paths/kingdom_of_exploathing.ash>

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28530;	//  feat: peridot power, plurals
+since r28534;	//  feat: support hats in Hat Trick
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -853,6 +853,7 @@ void initializeDay(int day)
 	glover_initializeDay(day);
 	bat_initializeDay(day);
 	jarlsberg_initializeDay(day);
+	ht_equip_hats(); //equip hats in Hat Trick
 
 	// Bulk cache mall prices
 	if(!in_hardcore() && get_property("auto_day_init").to_int() < day)
@@ -1923,6 +1924,7 @@ boolean doTasks()
 	auto_refreshQTFam();
 	lol_buyReplicas();
 	iluh_buyEquiq();
+	ht_equip_hats(); //equip hats in Hat Trick
 
 	oldPeoplePlantStuff();
 	use_barrels();

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -849,6 +849,11 @@ boolean in_ggoo();
 boolean LA_grey_goo_tasks();
 
 ########################################################################################################
+//Defined in autoscend/paths/hattrick.ash
+boolean in_hattrick();
+boolean ht_equip_hats();
+
+########################################################################################################
 //Defined in autoscend/paths/heavy_rains.ash
 boolean in_heavyrains();
 void heavyrains_initializeSettings();

--- a/RELEASE/scripts/autoscend/iotms/eudora.ash
+++ b/RELEASE/scripts/autoscend/iotms/eudora.ash
@@ -80,7 +80,7 @@ int[item] eudora_xiblaxian()
 		{
 			retval[$item[Xiblaxian xeno-detection goggles]] = min(polymer/4, crystal/2);
 		}
-		if(contains_text(canMake, "Xiblaxian stealth cowl"))
+		if(contains_text(canMake, "Xiblaxian stealth cowl") && !in_hattrick())
 		{
 			retval[$item[Xiblaxian Stealth Cowl]] = min(circuitry/4, min(polymer/9, alloy/5));
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -717,8 +717,8 @@ boolean auto_buyFireworksHat()
 		return false;
 	}
 
-	// noncombat is most valuable hat but has no effect in LAR
-	if(auto_can_equip($item[porkpie-mounted popper]) && !in_lar())
+	// noncombat is most valuable hat but has no effect in LAR and can't be removed in Hat Trick
+	if(auto_can_equip($item[porkpie-mounted popper]) && !(in_lar() || in_hattrick()))
 	{
 		float simNonCombat = providePlusNonCombat(auto_combatModCap(), $location[noob cave], true, true);
 		if(simNonCombat < auto_combatModCap())
@@ -728,8 +728,8 @@ boolean auto_buyFireworksHat()
 		}
 	}
 
-	// +combat hat is second most useful but has no effect in LAR and kills the professor
-	if(auto_can_equip($item[sombrero-mounted sparkler]) && !(in_lar() || in_wereprof()))
+	// +combat hat is second most useful but has no effect in LAR and kills the professor and can't be removed in Hat Trick
+	if(auto_can_equip($item[sombrero-mounted sparkler]) && !(in_lar() || in_wereprof() || in_hattrick()))
 	{
 		float simCombat = providePlusCombat(auto_combatModCap(), $location[noob cave], true, true);
 		if(simCombat < auto_combatModCap())

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -773,7 +773,16 @@ boolean auto_getClanPhotoBoothDefaultItems()
 	{
 		return false;
 	}
-	boolean[item] items_to_claim = $items[fake arrow-through-the-head, astronaut helmet, oversized monocle on a stick];
+	boolean[item] items_to_claim;
+	if(!in_hattrick())
+	{
+		items_to_claim = $items[fake arrow-through-the-head, astronaut helmet, oversized monocle on a stick];
+	}
+	else
+	{
+		items_to_claim = $items[feather boa, astronaut helmet, oversized monocle on a stick];
+	}
+	
 	int orig_clan_id = get_clan_id();
 	boolean in_bafh = orig_clan_id == getBAFHID();
 	boolean bafh_available = isWhitelistedToBAFH() && canReturnToCurrentClan(); // bafh has it fully stocked

--- a/RELEASE/scripts/autoscend/paths/hattrick.ash
+++ b/RELEASE/scripts/autoscend/paths/hattrick.ash
@@ -13,8 +13,8 @@ boolean ht_equip_hats()
     foreach it, i in availableHats
     {
         boolean skip;
-        //don't equip the following because they can mess us up later in the run (+/- combat and Thorns)
-        foreach bl in $items[Mer-kin sneakmask] //underwater combat rate so probably won't be used but might as well exclude
+        //don't equip the following because they can mess us up later in the run or are useful for consumption (+/- combat and Thorns)
+        foreach bl in $items[Mer-kin sneakmask, coconut shell]
         {
             if(it == bl)
             {

--- a/RELEASE/scripts/autoscend/paths/hattrick.ash
+++ b/RELEASE/scripts/autoscend/paths/hattrick.ash
@@ -1,4 +1,56 @@
-boolean in_hats()
+boolean in_hattrick()
 {
 	return my_path() == $path[Hat Trick];
+}
+
+boolean ht_equip_hats()
+{
+    if(!in_hattrick())
+    {
+        return false;
+    }
+    int[item] availableHats = auto_getAllEquipabble($slot[hat]);
+    foreach it, i in availableHats
+    {
+        boolean skip;
+        //don't equip the following because they can mess us up later in the run (+/- combat and Thorns)
+        foreach bl in $items[crown of thorns, Brogre bucket hat, Xiblaxian stealth cowl, silent beret,
+        sombrero-mounted sparkler, porkpie-mounted popper, Mer-kin sneakmask, very pointy crown,
+        marble mariachi hat, parasitic headgnawer, petrified wood whoopie panama]
+        {
+            if(it == bl)
+            {
+                skip = true;
+            }
+        }
+        //Only check to not equip these if MLSafetyLimit is not set or is not set low (-ML hats)
+        if(get_property("auto_MLSafetyLimit") == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
+        {
+            foreach bl in $items[imposing pilgrim's hat, nasty rat mask]
+            {
+                if(it == bl)
+                {
+                    skip = true;
+                }
+            }
+        }
+        //Only check to not equip these if MLSafetyLimit is set low (+ML hats)
+        if(get_property("auto_MLSafetyLimit").to_int() < 25)
+        {
+            foreach bl in $items[Boris's Helm (askew), fedora-mounted fountain, hemlock helm,
+            marble mariachi hat, Mer-kin headguard, mushroom cap, mutant crown, spiky turtle helmet,
+            Team Wrath cap, The Jokester's wig, Uncle Hobo's stocking cap, wolfskull mask]
+            {
+                if(it == bl)
+                {
+                    skip = true;
+                }
+            }
+        }
+        if(!skip && auto_can_equip(it))
+        {
+            equip(it);
+        }
+    }
+    return false;
 }

--- a/RELEASE/scripts/autoscend/paths/hattrick.ash
+++ b/RELEASE/scripts/autoscend/paths/hattrick.ash
@@ -1,0 +1,4 @@
+boolean in_hats()
+{
+	return my_path() == $path[Hat Trick];
+}

--- a/RELEASE/scripts/autoscend/paths/hattrick.ash
+++ b/RELEASE/scripts/autoscend/paths/hattrick.ash
@@ -14,37 +14,35 @@ boolean ht_equip_hats()
     {
         boolean skip;
         //don't equip the following because they can mess us up later in the run (+/- combat and Thorns)
-        foreach bl in $items[crown of thorns, Brogre bucket hat, Xiblaxian stealth cowl, silent beret,
-        sombrero-mounted sparkler, porkpie-mounted popper, Mer-kin sneakmask, very pointy crown,
-        marble mariachi hat, parasitic headgnawer, petrified wood whoopie panama]
+        foreach bl in $items[Mer-kin sneakmask] //underwater combat rate so probably won't be used but might as well exclude
         {
             if(it == bl)
             {
                 skip = true;
             }
         }
+        if(numeric_modifier(it, "Thorns") > 0)
+        {
+            skip = true;
+        }
+        if(numeric_modifier(it, "Combat Rate") != 0)
+        {
+            skip = true;
+        }
         //Only check to not equip these if MLSafetyLimit is not set or is not set low (-ML hats)
         if(get_property("auto_MLSafetyLimit") == "" || get_property("auto_MLSafetyLimit").to_int() >= 25)
         {
-            foreach bl in $items[imposing pilgrim's hat, nasty rat mask]
+            if(numeric_modifier(it, "Monster Level") < 0)
             {
-                if(it == bl)
-                {
-                    skip = true;
-                }
+                skip = true;
             }
         }
         //Only check to not equip these if MLSafetyLimit is set low (+ML hats)
         if(get_property("auto_MLSafetyLimit").to_int() < 25)
         {
-            foreach bl in $items[Boris's Helm (askew), fedora-mounted fountain, hemlock helm,
-            marble mariachi hat, Mer-kin headguard, mushroom cap, mutant crown, spiky turtle helmet,
-            Team Wrath cap, The Jokester's wig, Uncle Hobo's stocking cap, wolfskull mask]
+            if(numeric_modifier(it, "Monster Level") > 0)
             {
-                if(it == bl)
-                {
-                    skip = true;
-                }
+                skip = true;
             }
         }
         if(!skip && auto_can_equip(it))

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -51,7 +51,7 @@ void LX_handleIntroAdventures()
 			abort("You are stuck in an intro adventure which requires you to choose a path. I suggest you do so before trying to run autoscend and you may have better results.");
 		}
 
-		if ($ints[1046, 1405, 1416, 1419, 1446, 1450, 1464, 1480, 1503, 1507, 1519, 1531, 1552] contains choice)
+		if ($ints[1046, 1405, 1416, 1419, 1446, 1450, 1464, 1480, 1503, 1507, 1519, 1531, 1552, 1559] contains choice)
 		{
 			// 1046 is "Actually Ed the Undying", intro for Actually Ed the Undying (Spring 2015 challenge path).
 			// 1405 is "Let's, uh, go!", intro for Path of the Plumber (Spring 2020 challenge path).
@@ -65,7 +65,8 @@ void LX_handleIntroAdventures()
 			// 1507 is "Jumbled in the Bungle", intro for A Shrunken Adventurer am I (Fall 2023 challenge path).
 			// 1519 is "The coffee was *gasp* decaf!", intro for WereProfessor (Spring 2024 challenge path).
 			// 1531 is "A-1 Sound and the Sound's So Suardin'", intro for Avant Guard (Fall 2024 challenge path).
-			// 1552 is "Zoonopeia", intro for Z is for Zootomist (Spring 2024 challenge path).
+			// 1552 is "Zoonopeia", intro for Z is for Zootomist (Spring 2025 challenge path).
+			// 1559 is "Hat Trick!", intro for Hat Trick (Summer 2025 challenge path).
 			// yes they really phoned some of the titles of these in.
 			run_choice(1);
 		}


### PR DESCRIPTION
# Description

Adds support for Hat Trick (Summer 2025 challenge path)
Will equip any available hat that is not in a blacklist

## How Has This Been Tested?

1 normal Hat Trick run in progress

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
