### PR TITLE
Update Cola Wars Battlefield Zone Names

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28534;	//  feat: support hats in Hat Trick
+since r28545;	//  correct names for cola battlefield zones
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -1987,7 +1987,7 @@ generic_t zone_difficulty(location loc)
 boolean zone_hasLuckyAdventure(location loc)
 {
 	if ($locations[Vanya's Castle, The Fungus Plains, Megalo-City, Hero's Field, A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,
-	Battlefield (Cloaca Uniform),Battlefield (Dyspepsi Uniform),Battlefield (No Uniform),Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,
+	Cola Wars Battlefield (Cloaca Uniform),Cola Wars Battlefield (Dyspepsi Uniform),The Cola Wars Battlefield,Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,
 	Cobb's Knob Barracks,Cobb's Knob Harem,Cobb's Knob Kitchens,Cobb's Knob Laboratory,Cobb's Knob Menagerie\, Level 2,Cobb's Knob Treasury,
 	Elf Alley,Exposure Esplanade,Frat House,Frat House (Frat Disguise),Guano Junction,Hippy Camp,Hippy Camp (Hippy Disguise),Itznotyerzitz Mine,
 	Lair of the Ninja Snowmen,Lemon Party,Madness Reef,Oil Peak,Outskirts of Camp Logging Camp,Pandamonium Slums,Shop Class,South of the Border,

--- a/RELEASE/scripts/autoscend/iotms/mr2018.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2018.ash
@@ -948,7 +948,7 @@ string auto_latteDropName(location l)
 		case $location[The Sleazy Back Alley]: return "cloves";
 		case $location[The Haunted Boiler Room]: return "coal";
 		case $location[The Icy Peak]: return "cocoa";
-		case $location[Battlefield (No Uniform)]: return "diet";
+		case $location[The Cola Wars Battlefield]: return "diet";
 		case $location[Itznotyerzitz Mine]: return "dwarf";
 		case $location[The Feeding Chamber]: return "filth";
 		case $location[The Road to the White Citadel]: return "flour";


### PR DESCRIPTION
# Description

r28545 updates the Cola Wars Battlefield zone names. This fixes it

## How Has This Been Tested?

valauto doesn't break. autoscend also doesn't break when running, it did before the changes.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
