### PR TITLE
feat: various updates in Kingdom of Exploathing

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -441,8 +441,9 @@ boolean LX_burnDelay()
 
 	if (backupTargetAvailable)
 	{
-		location backupZone = solveDelayZone(isFreeMonster(get_property("lastCopyableMonster").to_monster()) && get_property("breathitinCharges").to_int() > 0);
-		if (backupZone == $location[none])
+		boolean skipOutdoorZones = isFreeMonster(get_property("lastCopyableMonster").to_monster()) && get_property("breathitinCharges").to_int() > 0;
+		location backupZone = solveDelayZone(skipOutdoorZones);
+		if (backupZone == $location[none] && skipOutdoorZones && !in_koe())
 		{
 			// if the monster is inherently free and we have Breathitin charges, fight it in the Noob Cave since we can't avoid it
 			// and we likely want to fight it. Noob Cave is available from turn 0 & is not outdoors so Breathitin won't trigger.
@@ -935,12 +936,11 @@ void initializeDay(int day)
 					{
 						auto_buyUpTo(1, $item[Toy Accordion]);
 					}
-					
-					if((in_koe()) && (item_amount($item[Antique Accordion]) == 0) && (koe_rmi_count() >= 10))
-					{
-						koe_acquire_rmi(10);
-						buy($coinmaster[Cosmic Ray\'s Bazaar], 1, $item[Antique Accordion]);
-					}
+				}
+				if((in_koe()) && (item_amount($item[Antique Accordion]) == 0) && (koe_rmi_count() >= 10))
+				{
+					koe_acquire_rmi(10);
+					buy($coinmaster[Cosmic Ray\'s Bazaar], 1, $item[Antique Accordion]);
 				}
 				acquireTotem();
 				if(!possessEquipment($item[Saucepan]))

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -685,6 +685,7 @@ boolean auto_autumnatonQuest()
 		if(auto_sendAutumnaton($location[Guano Junction])) return false;
 		if(auto_sendAutumnaton($location[The Batrat And Ratbat Burrow])) return false;
 		if(auto_sendAutumnaton($location[The Beanbat Chamber])) return false;
+		if(auto_sendAutumnaton($location[Cobb's Knob Harem])) return false;
 		if(auto_sendAutumnaton($location[Noob Cave])) return false;
 	}
 

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -468,6 +468,9 @@ int auto_swoopsRemaining()
 
 boolean auto_haveSeptEmberCenser()
 {
+	if (in_koe()) {
+		return false; // shop is inaccessible in Kingdom of Exploathing
+	}
 	if(auto_is_valid($item[Sept-Ember Censer]) && available_amount($item[Sept-Ember Censer]) > 0 )
 	{
 		return true;


### PR DESCRIPTION
# Description

Can't access the Noob Cave or Sept-Ember Censer shop, can't buy the toy accordion.

With bat wings you can end up at the tower without having adventured in any bat zones (autoscend bat wings for sonars and then lockets a screambat), so allow Harem as an alternative.

## How Has This Been Tested?

Exploathing runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
