### PR TITLE
fix: don't skip the twin peaks NC after using the oil jar

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -324,7 +324,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(1); // always advance to next option via choice 1
 			break;
 		case 606: // Lost in the Great Overlook Lodge
-			if(in_bhy() || in_glover() && item_amount($item[Jar Of Oil]) == 0)
+			if(in_bhy() || in_glover() && options contains 3 && item_amount($item[Jar Of Oil]) == 0)
 			{
 				// we can't make an oil jar to solve the quest, just adventure until the hotel is burned down
 				run_choice(6); // and flee the music NC


### PR DESCRIPTION
# Description

After using the jar of oil in G Lover, do the other choices instead of running away.

## How Has This Been Tested?

G Lover run.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
