### PR TITLE
update zone names given mafia update, removes warnings

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28545;	//  correct names for cola battlefield zones
+since r28569;	// yeti cooler outline
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -814,7 +814,7 @@ void initializeDay(int day)
 		visit_url("inv_use.php?pwd=&which=3&whichitem=6174", true);
 		visit_url("inv_use.php?pwd=&which=3&whichitem=6174&confirm=Yep.", true);
 		set_property("auto_disableAdventureHandling", true);
-		autoAdv(1, $location[Video Game Level 1]);
+		autoAdv(1, $location[[DungeonFAQ - Level 1]]);
 		set_property("auto_disableAdventureHandling", false);
 		if(item_amount($item[Dungeoneering Kit]) > 0)
 		{
@@ -1397,7 +1397,7 @@ boolean adventureFailureHandler()
 
 		if(tooManyAdventures && isActuallyEd())
 		{
-			if ($location[Hippy Camp] == place)
+			if ($location[The Hippy Camp] == place)
 			{
 				tooManyAdventures = false;
 			}

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -765,7 +765,7 @@ void finalizeMaximize(boolean speculative)
 		}
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
 		//as we go through the hidden hospital we equip surgeon gear on the pants slot, so we can end up dying if we cast advanced research
-		if(($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
+		if(($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Orcish Frat House, The Hippy Camp, The Orcish Frat House (In Disguise), The Hippy Camp (In Disguise), Next to that barrel with something burning in it,
 		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
 		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room, The Hidden Hospital] contains my_location())) nooculus = true;
 		if(!nooculus)
@@ -784,7 +784,7 @@ void finalizeMaximize(boolean speculative)
 	if(is_professor() && (possessEquipment($item[high-tension exoskeleton]) || possessEquipment($item[ultra-high-tension exoskeleton]) || possessEquipment($item[irresponsible-tension exoskeleton]))) //Want that damage avoidance
 	{
 		//exclude certain locations as professor that require specific outfits (the War, the Goblin King)
-		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), Frat House, Hippy Camp, Frat House (Frat Disguise), Hippy Camp (Hippy Disguise), Next to that barrel with something burning in it,
+		if(!($locations[The Battlefield (Frat Uniform), The Battlefield (Hippy Uniform), The Orcish Frat House, The Hippy Camp, The Orcish Frat House (In Disguise), The Hippy Camp (In Disguise), Next to that barrel with something burning in it,
 		Out by that rusted-out car, over where the old tires are, near an abandoned refrigerator, Sonofa Beach, The Themthar Hills, McMillicancuddy's Barn, McMillicancuddy's Pond, McMillicancuddy's Back 40,
 		McMillicancuddy's Other Back 40, Cobb\'s Knob Barracks, Cobb\'s Knob Harem, Throne Room] contains my_location()))
 		{

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -515,7 +515,7 @@ boolean autoChooseFamiliar(location place)
 	if ($locations[Guano Junction, The Beanbat Chamber, Cobb's Knob Harem, The Goatlet, Itznotyerzitz Mine,
 	Twin Peak, The Penultimate Fantasy Airship, The Hidden Temple, The Hidden Bowling Alley, The Haunted Wine Cellar,
 	The Haunted Laundry Room, The Copperhead Club, A Mob of Zeppelin Protesters, Whitey's Grove, The Oasis, The Middle Chamber,
-	Frat House, Hippy Camp, The Hatching Chamber,
+	The Orcish Frat House, The Hippy Camp, The Hatching Chamber,
 	The Feeding Chamber, The Royal Guard Chamber, The Hole in the Sky, Hero's Field, The Degrassi Knoll Garage, The Old Landfill,
 	The Laugh Floor, Infernal Rackets Backstage] contains place) {
 		famChoice = lookupFamiliarDatafile("item");

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -919,7 +919,7 @@ boolean auto_pre_adventure()
 		plumber_forceEquipTool();
 	}
 
-	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[Hippy Camp]) {
+	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[The Hippy Camp]) {
 		equip($slot[Pants], $item[None]);
 		put_closet(item_amount($item[Filthy Corduroys]), $item[Filthy Corduroys]);
 		if (is_wearing_outfit("Filthy Hippy Disguise")) {

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -69,8 +69,8 @@ generic_t zone_needItem(location loc)
 			value = 30.0;
 		}
 		break;
-	case $location[Frat House]:
-	case $location[Hippy Camp]:
+	case $location[The Orcish Frat House]:
+	case $location[The Hippy Camp]:
 			value = 5.0;
 		break;
 	case $location[Wartime Frat House]:
@@ -512,8 +512,8 @@ generic_t zone_combatMod(location loc)
 	int value = 0;
 	switch(loc)
 	{
-	case $location[Frat House]:
-	case $location[Hippy Camp]:
+	case $location[The Orcish Frat House]:
+	case $location[The Hippy Camp]:
 		if (my_level() >= 9) {
 			value = -85;
 		}
@@ -1297,14 +1297,14 @@ boolean zone_available(location loc)
 			retval = true;
 		}
 		break;
-	case $location[Frat House]:
-	case $location[Hippy Camp]:
+	case $location[The Orcish Frat House]:
+	case $location[The Hippy Camp]:
 		if(get_property("lastIslandUnlock").to_int() == my_ascensions())
 		{
 			retval = true;
 		}
 		break;
-	case $location[Frat House (Frat Disguise)]:
+	case $location[The Orcish Frat House (In Disguise)]:
 		if(get_property("lastIslandUnlock").to_int() == my_ascensions() && 
 		have_outfit("Frat Boy Ensemble") &&
 		internalQuestStatus("questL12War") != 0 &&	//mafia always calls location Wartime with L12 quest
@@ -1313,7 +1313,7 @@ boolean zone_available(location loc)
 			retval = true;
 		}
 		break;
-	case $location[Hippy Camp (Hippy Disguise)]:
+	case $location[The Hippy Camp (In Disguise)]:
 		if(get_property("lastIslandUnlock").to_int() == my_ascensions() && 
 		have_outfit("Filthy Hippy Disguise") &&
 		internalQuestStatus("questL12War") != 0 &&	//mafia always calls location Wartime with L12 quest
@@ -1987,9 +1987,9 @@ generic_t zone_difficulty(location loc)
 boolean zone_hasLuckyAdventure(location loc)
 {
 	if ($locations[Vanya's Castle, The Fungus Plains, Megalo-City, Hero's Field, A Maze of Sewer Tunnels,A Mob of Zeppelin Protesters,A-Boo Peak,An Octopus's Garden,Art Class,
-	Cola Wars Battlefield (Cloaca Uniform),Cola Wars Battlefield (Dyspepsi Uniform),The Cola Wars Battlefield,Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,
+	Cola Wars Battlefield (Cloaca Uniform),Cola Wars Battlefield (Dyspepsi Uniform), The Cola Wars Battlefield, Burnbarrel Blvd.,Camp Logging Camp,Chemistry Class,
 	Cobb's Knob Barracks,Cobb's Knob Harem,Cobb's Knob Kitchens,Cobb's Knob Laboratory,Cobb's Knob Menagerie\, Level 2,Cobb's Knob Treasury,
-	Elf Alley,Exposure Esplanade,Frat House,Frat House (Frat Disguise),Guano Junction,Hippy Camp,Hippy Camp (Hippy Disguise),Itznotyerzitz Mine,
+	Elf Alley,Exposure Esplanade,The Orcish Frat House,The Orcish Frat House (In Disguise),Guano Junction,The Hippy Camp,The Hippy Camp (In Disguise),Itznotyerzitz Mine,
 	Lair of the Ninja Snowmen,Lemon Party,Madness Reef,Oil Peak,Outskirts of Camp Logging Camp,Pandamonium Slums,Shop Class,South of the Border,
 	The "Fun" House,The Ancient Hobo Burial Ground,The Batrat and Ratbat Burrow,The Black Forest,The Brinier Deepers,The Briny Deeps,The Bugbear Pen,
 	The Castle in the Clouds in the Sky (Basement),The Castle in the Clouds in the Sky (Ground Floor),The Castle in the Clouds in the Sky (Top Floor),

--- a/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_ed.ash
@@ -40,7 +40,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 
 	set_property("auto_edCombatRoundCount", 1 + get_property("auto_edCombatRoundCount").to_int());
 
-	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location())
+	if ($locations[The Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest] contains my_location())
 	{
 		if (my_mp() < mp_cost($skill[Fist Of The Mummy]) && get_property("_edDefeats").to_int() < 2)
 		{
@@ -570,7 +570,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 				doLash = true;
 			}
 		}
-		if ((my_location() == $location[Hippy Camp] || my_location() == $location[Wartime Hippy Camp]) && contains_text(enemy, "hippy") && my_level() >= 12)
+		if ((my_location() == $location[The Hippy Camp] || my_location() == $location[Wartime Hippy Camp]) && contains_text(enemy, "hippy") && my_level() >= 12)
 		{
 			if(!possessEquipment($item[Filthy Knitted Dread Sack]) || !possessEquipment($item[Filthy Corduroys]))
 			{
@@ -872,7 +872,7 @@ string auto_edCombatHandler(int round, monster enemy, string text)
 		return useSkill($skill[Storm Of The Scarab], false);
 	}
 
-	if ($locations[Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest, The Batrat and Ratbat Burrow, The Boss Bat\'s Lair, Cobb\'s Knob Harem] contains my_location() && canUse($skill[Fist Of The Mummy], false))
+	if ($locations[The Hippy Camp, The Outskirts Of Cobb\'s Knob, The Spooky Forest, The Batrat and Ratbat Burrow, The Boss Bat\'s Lair, Cobb\'s Knob Harem] contains my_location() && canUse($skill[Fist Of The Mummy], false))
 	{
 		return useSkill($skill[Fist Of The Mummy], false);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_zombie_slayer.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_zombie_slayer.ash
@@ -154,7 +154,7 @@ string auto_combatZombieSlayerStage4(int round, monster enemy, string text)
 				doSmash = true;
 			}
 		}
-		if ((my_location() == $location[Hippy Camp] || my_location() == $location[Wartime Hippy Camp]) && contains_text(enemy, "hippy") && my_level() >= 12)
+		if ((my_location() == $location[The Hippy Camp] || my_location() == $location[Wartime Hippy Camp]) && contains_text(enemy, "hippy") && my_level() >= 12)
 		{
 			if(!possessEquipment($item[Filthy Knitted Dread Sack]) || !possessEquipment($item[Filthy Corduroys]))
 			{

--- a/RELEASE/scripts/autoscend/iotms/mr2013.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2013.ash
@@ -265,7 +265,7 @@ void oldPeoplePlantStuff()
 		cli_execute("florist plant Pitcher Plant");
 		cli_execute("florist plant Canned Spinach");
 	}
-	else if((my_location() == $location[Hippy Camp]) && (my_daycount() == 1))
+	else if((my_location() == $location[The Hippy Camp]) && (my_daycount() == 1))
 	{
 		cli_execute("florist plant Seltzer Watercress");
 		cli_execute("florist plant Rad-ish Radish");

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -1071,8 +1071,8 @@ boolean[location] citizenZones(string goal)
 	}
 	if(goal == "mp")
 	{
-		return $locations[The Upper Chamber, Inside the Palindome, A-boo Peak, Hippy Camp, Megalo-City, Shadow Rift, Vanya's Castle,
-		The Hatching Chamber, Wartime Hippy Camp (Frat Disguise), Frat House, The Middle Chamber, The Black Forest,	The Haunted Ballroom,
+		return $locations[The Upper Chamber, Inside the Palindome, A-boo Peak, The Hippy Camp, Megalo-City, Shadow Rift, Vanya's Castle,
+		The Hatching Chamber, Wartime Hippy Camp (Frat Disguise), The Orcish Frat House, The Middle Chamber, The Black Forest,	The Haunted Ballroom,
 		The Red Zeppelin, The Hidden Park, Twin Peak, The Smut Orc Logging Camp, The Daily Dungeon, The Spooky Forest];
 	}
 	if(goal == "spec")

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -963,7 +963,7 @@ void ed_handleAdventureServant(location loc)
 	}
 
 	// Initial Ka farming to get Spleen & Legs upgrades.
-	if ($locations[Hippy Camp, The Neverending Party, The Secret Government Laboratory, The SMOOCH Army HQ, VYKEA] contains loc && my_daycount() == 1)
+	if ($locations[The Hippy Camp, The Neverending Party, The Secret Government Laboratory, The SMOOCH Army HQ, VYKEA] contains loc && my_daycount() == 1)
 	{
 		myServant = $servant[Priest];
 	}
@@ -1177,7 +1177,7 @@ boolean L1_ed_islandFallback()
 	if (have_skill($skill[Upgraded Legs]) || item_amount($item[Ka coin]) >= 10)
 	{
 		auto_change_mcd(11);
-		boolean retVal = autoAdv($location[Hippy Camp]);
+		boolean retVal = autoAdv($location[The Hippy Camp]);
 		if (item_amount($item[Filthy Corduroys]) > 0)
 		{
 			if (closet_amount($item[Filthy Corduroys]) > 0)

--- a/RELEASE/scripts/autoscend/quests/level_03.ash
+++ b/RELEASE/scripts/autoscend/quests/level_03.ash
@@ -108,7 +108,7 @@ boolean auto_tavern()
 	}
 
 	// Consider a pull
-	foreach it in $items[crepe paper parachute cape, 17-ball, rare oboe, recording of benetton's medley of diversity]
+	foreach it in $items[17-ball, rare oboe, recording of benetton's medley of diversity]
 	{
 		if (!all_passed())
 		{

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -3,9 +3,9 @@
 Below are relevant locations for the war.
 war not started or finished with this side undefeated:
 [Frat House]
-[Frat House (Frat Disguise)]	//r26631 changed from [Frat House In Disguise]
+[The Orcish Frat House (In Disguise)]	//r26631 changed from [Frat House In Disguise]
 [Hippy Camp]
-[Hippy Camp (Hippy Disguise)]	//r26631 changed from [Hippy Camp In Disguise]
+[The Hippy Camp (In Disguise)]	//r26631 changed from [Hippy Camp In Disguise]
 
 War started:
 [Wartime Frat House]
@@ -637,7 +637,7 @@ boolean L12_getOutfit()
 	{
 		autoOutfit("Filthy Hippy Disguise");
 		//this should go to [Wartime Frat House (Hippy Disguise)] (despite war not started)
-		return autoAdv($location[Frat House]);
+		return autoAdv($location[The Orcish Frat House]);
 	}
 	
 	// if outfit could not be pulled and have a [Frat Boy Ensemble] outfit then wear it and adventure in Hippy Camp to get war outfit
@@ -645,7 +645,7 @@ boolean L12_getOutfit()
 	{
 		autoOutfit("Frat Boy Ensemble");
 		//this should go to [Wartime Hippy Camp (Frat Disguise)] (despite war not started)
-		return autoAdv($location[Hippy Camp]);
+		return autoAdv($location[The Hippy Camp]);
 	}
 	
 	if(L12_preOutfit())
@@ -730,7 +730,7 @@ boolean L12_preOutfit()
 		auto_log_info("Trying to acquire a filthy hippy outfit", "blue");
 		if(internalQuestStatus("questL12War") == -1)
 		{
-			adventure_status = autoAdv(1, $location[Hippy Camp]);
+			adventure_status = autoAdv(1, $location[The Hippy Camp]);
 		}
 		else
 		{
@@ -743,7 +743,7 @@ boolean L12_preOutfit()
 		auto_log_info("Trying to acquire a frat boy ensemble", "blue");
 		if(internalQuestStatus("questL12War") == -1)
 		{
-			adventure_status = autoAdv(1, $location[Frat House]);
+			adventure_status = autoAdv(1, $location[The Orcish Frat House]);
 		}
 		else
 		{


### PR DESCRIPTION
# Description

There's a bunch of warnings now because Mafia changed zone names. Doesn't do anything dangerous but spams the gCLI. This gets rid of those warnings.

## How Has This Been Tested?

I've run a bunch of runs with this (and a whole bunch of other stuff). Don't think it broke anything.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
