### PR TITLE
Don't try to use disco nap if we don't have the MP. Equip April Shield for more buffs

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -547,6 +547,8 @@ boolean auto_post_adventure()
 		{
 			buffMaintain($effect[Disco Fever], 40, 1, 10);
 		}
+		item[int] preShield = auto_saveEquipped();
+		auto_equipAprilShieldBuff(); //get secondary buffs provided by shield when the trivial class skills are used
 		buffMaintain($effect[Saucemastery], 25, 1, 4);
 		buffMaintain($effect[Pasta Oneness], 25, 1, 4);
 
@@ -557,6 +559,7 @@ boolean auto_post_adventure()
 			buffMaintain($effect[Mariachi Mood], 25, 1, 4);
 			buffMaintain($effect[Disco State of Mind], 25, 1, 4);
 		}
+		auto_loadEquipped(preShield);
 	}
 	else if(my_maxmp() < 80)
 	{
@@ -615,6 +618,8 @@ boolean auto_post_adventure()
 		{
 			buffMaintain($effect[Disco Fever], 60, 1, 10);
 		}
+		item[int] preShield = auto_saveEquipped();
+		auto_equipAprilShieldBuff(); //get secondary buffs provided by shield when the trivial class skills are used
 		buffMaintain($effect[Saucemastery], 50, 3, 4);
 		buffMaintain($effect[Pasta Oneness], 50, 3, 4);
 		if(regen > 8.2)
@@ -624,6 +629,7 @@ boolean auto_post_adventure()
 			buffMaintain($effect[Mariachi Mood], 50, 3, 4);
 			buffMaintain($effect[Disco State of Mind], 50, 3, 4);
 		}
+		auto_loadEquipped(preShield);
 	}
 	else if(my_maxmp() < 170)
 	{
@@ -816,6 +822,8 @@ boolean auto_post_adventure()
 		{
 			buffMaintain($effect[Disco Fever], 120, 1, 10);
 		}
+		item[int] preShield = auto_saveEquipped();
+		auto_equipAprilShieldBuff(); //get secondary buffs provided by shield when the trivial class skills are used
 		if(my_primestat() == $stat[Muscle])
 		{
 			buffMaintain($effect[Seal Clubbing Frenzy], 200, 5, 4);
@@ -831,6 +839,7 @@ boolean auto_post_adventure()
 			buffMaintain($effect[Saucemastery], 200, 5, 4);
 			buffMaintain($effect[Pasta Oneness], 200, 5, 4);
 		}
+		auto_loadEquipped(preShield);
 		if(familiar_weight(my_familiar()) < 20)
 		{
 			buffMaintain($effect[Curiosity of Br\'er Tarrypin], 50, 1, 2);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -896,10 +896,7 @@ boolean auto_pre_adventure()
 	equipMaximizedGear();
 	auto_handleRetrocape(); // has to be done after equipMaximizedGear otherwise the maximizer reconfigures it
 	auto_handleParka(); //same as retrocape above
-	if(auto_handleCCSC() && !have_equipped($item[Candy Cane Sword Cane]))
-	{
-		autoForceEquip($item[Candy Cane Sword Cane]); // Force the candy cane sword cane if June cleaver has been buffed beyond the 1000 bonus boost
-	}
+
 	cli_execute("checkpoint clear");
 
 	//before guaranteed non combats that give stats, overrule maximized equipment to increase stat gains
@@ -917,6 +914,10 @@ boolean auto_pre_adventure()
 	{
 		equipStatgainIncreasers(my_primestat(),true);	//The Shore, Inc. Travel Agency choice 793 is configured to pick main stat or all stats
 		plumber_forceEquipTool();
+	}
+	if(auto_handleCCSC() && !have_equipped($item[Candy Cane Sword Cane]))
+	{
+		autoForceEquip($item[Candy Cane Sword Cane]); // Force the candy cane sword cane if June cleaver has been buffed beyond the 1000 bonus boost
 	}
 
 	if (isActuallyEd() && is_wearing_outfit("Filthy Hippy Disguise") && place == $location[The Hippy Camp]) {

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -523,7 +523,7 @@ __RestorationOptimization __calculate_objective_values(int hp_goal, int mp_goal,
 			restored_amount += numeric_modifier("Bonus Resting MP");
 		}
 
-		if (metadata.name == "disco nap" && auto_haveAprilShowerShield() && get_property("_aprilShowerDiscoNap").to_int() < 5)
+		if (metadata.name == "disco nap" && auto_haveAprilShowerShield() && get_property("_aprilShowerDiscoNap").to_int() < 5 && my_mp() > mp_cost($skill[disco nap]))
 		{
 			restored_amount = 100 - 20 * get_property("_aprilShowerDiscoNap").to_int();
 		}


### PR DESCRIPTION
# Description

Disco nap was trying to be cast even though we didn't have the mp for it. This should fix that.

Make sure the April Shower Thoughts Shield is equipped when casting the 1mp class skills in post_adv so that we get more buffs.

Move CCSC handler to below statgain increasers so that it doesn't get overwritten in unrestricted runs.

## How Has This Been Tested?

Multiple runs seeing:
Equips the ASTS for 1mp class skills
Saw CCSC not be overwritten by Fourth of May Cosplay Sword at Hidden Bowling Alley after I moved the CCSC handler.

Have not seen disco nap be used, but it is consistently being removed from consideration because I don't have a negative effect when it is being considered and because that will remove a negative effect, we are keeping it available until it is needed, which I have never seen it be. So, it is definitely being considered, and it accurately says that it would restore 100 mp.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
