### PR TITLE
Chest Mimic support

### DIFF
--- a/RELEASE/dependencies.txt
+++ b/RELEASE/dependencies.txt
@@ -5,3 +5,4 @@ github Ezandora/Voting-Booth
 github loathers/excavator release
 github loathers/combo release
 github C2Talon/c2t_apron master
+github C2Talon/c2t_megg master

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -2194,6 +2194,12 @@ boolean summonMonster(monster mon, boolean speculative)
 		return true;
 	}
 	// methods which can only summon monsters should be attempted first
+	if(auto_meggFight(mon, speculative))
+	{
+		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via chest mimics", "blue");
+		return true;
+	}
+	
 	if(auto_fightLocketMonster(mon, speculative))
 	{
 		auto_log_debug((speculative ? "Can" : "Did") + " summon " + mon + " via combat lover's locket", "blue");

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -634,6 +634,9 @@ boolean auto_getClanPhotoBoothEffect(effect ef);
 boolean auto_getClanPhotoBoothEffect(effect ef, int n_times);
 boolean auto_getClanPhotoBoothEffect(string ef);
 boolean auto_getClanPhotoBoothEffect(string ef, int n_times);
+boolean auto_haveChestMimic();
+boolean auto_haveMeggEgg(monster mon);
+boolean auto_meggFight(monster mon, boolean speculative);
 
 ########################################################################################################
 //Defined in autoscend/iotms/mr2025.ash

--- a/RELEASE/scripts/autoscend/iotms/mr2024.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2024.ash
@@ -1,6 +1,7 @@
 # This is meant for items that have a date of 2024
 
 import <c2t_apron.ash>// used in consumeBlackAndWhiteApronKit()
+import <c2t_megg.ash>// used in chest mimic
 
 boolean consumeBlackAndWhiteApronKit()
 {
@@ -371,8 +372,8 @@ boolean auto_MayamClaimWhatever()
 	string ring4 = "BAD_VALUE";
 	boolean failure = false;
 	
-	if      (!auto_MayamIsUsed("chair") && auto_haveCincho())   { ring1 = "chair"; }
-	// todo: add support for giving appropriate fam 100xp with fur option
+	if (!auto_MayamIsUsed("fur") && auto_haveChestMimic() && $familiar[chest mimic].experience <= 300)   { ring1 = "fur"; use_familiar($familiar[chest mimic]); }
+	else if (!auto_MayamIsUsed("chair") && auto_haveCincho())   { ring1 = "chair"; }
 	else if (!auto_MayamIsUsed("eye"))    { ring1 = "eye"; }
 	else if (!auto_MayamIsUsed("vessel")) { ring1 = "vessel"; }
 	else { failure = true; }
@@ -965,4 +966,52 @@ boolean auto_getClanPhotoBoothEffect(string ef_string, int n_times)
 	}
 	auto_log_error("Invalid effect string for photo booth "+ef_string);
 	return false;
+}
+
+boolean auto_haveChestMimic()
+{
+	if(auto_have_familiar($familiar[chest mimic]))
+	{
+		return true;
+	}
+	return false;
+}
+
+boolean auto_haveMeggEgg(monster mon)
+{
+	foreach megg_mon, i in c2t_megg_eggs()
+		{
+			if (megg_mon == mon)
+			{
+				return true;
+			}
+		}
+	return false;
+}
+
+
+boolean auto_meggFight(monster mon, boolean speculative)
+{
+	if (!auto_haveChestMimic())
+	{
+		return false;
+	}
+	if(!auto_haveMeggEgg(mon))
+	{
+		c2t_megg_preAdv();
+		c2t_megg_extract(mon);
+	}
+	if(!auto_haveMeggEgg(mon))
+	{
+		return false;
+	}
+
+	if(speculative)
+	{
+		return true;
+	}
+	
+	handleTracker(mon, $familiar[chest mimic], "auto_copies");
+
+	return c2t_megg_fight(mon);
 }


### PR DESCRIPTION
# Description

This is a PR to add simple chest mimic support.

- [] Phase 1: Add chest mimic summons as a usable summon type if it has XP.
- Phase 2: Chest mimic levelling.
- - [] Levelling using mayam calendar.
- - [] Levelling using free fights.
- - [] Levelling using low value meat areas (boss bat lair, icy peak)
- [] Phase 3: Include cyberrealm as source of free fights.

Fixes # (issue)

## How Has This Been Tested?

Testing in progress, 2 hat trick runs down with successful mimic summons.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
