### PR TITLE
Reduce Equipment Swapping While Buffing

### DIFF
--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -199,6 +199,11 @@ boolean auto_post_adventure()
 		return true;
 	}
 
+	//save some MP while buffing
+	item[int] beforeBuffs = auto_saveEquipped();
+	addToMaximize("-1000mana cost, -tie");
+	equipMaximizedGear();
+
 	if(have_effect($effect[Cunctatitis]) > 0)
 	{
 		if((my_mp() >= 12) && auto_have_skill($skill[Disco Nap]))
@@ -842,9 +847,12 @@ boolean auto_post_adventure()
 			buffMaintain($effect[Jingle Jangle Jingle], 120, 1, 2);		//familiar acts more often
 		}
 		buffMaintain($effect[A Few Extra Pounds], 200, 1, 2);
-		buffMaintain($effect[Boon of the War Snapper], 200, 1, 5);
-		buffMaintain($effect[Boon of She-Who-Was], 200, 1, 5);
-		buffMaintain($effect[Boon of the Storm Tortoise], 200, 1, 5);
+		if(my_class() == $class[Turtle Tamer])
+		{
+			buffMaintain($effect[Boon of the War Snapper], 200, 1, 5);
+			buffMaintain($effect[Boon of She-Who-Was], 200, 1, 5);
+			buffMaintain($effect[Boon of the Storm Tortoise], 200, 1, 5);
+		}
 
 		buffMaintain($effect[Ruthlessly Efficient], 50, 1, 5);
 		buffMaintain($effect[Mathematically Precise], 150, 1, 5);
@@ -1096,7 +1104,9 @@ boolean auto_post_adventure()
 			abort("We have been disavowed...");
 		}
 	}
-
+	
+	//Remove the mana cost reduction from maximize statement
+	removeFromMaximize("-1000mana cost");
 	remove_property("auto_combatDirective");
 	remove_property("auto_digitizeDirective");
 	

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -248,6 +248,11 @@ boolean auto_pre_adventure()
 		use_skill($skill[Dismiss Pasta Thrall]);
 	}
 
+	//save some MP while buffing
+	item[int] beforeBuffs = auto_saveEquipped();
+	addToMaximize("-1000mana cost, -tie");
+	equipMaximizedGear();
+
 	if(place == $location[The Smut Orc Logging Camp])
 	{
 		prepareForSmutOrcs();
@@ -890,6 +895,8 @@ boolean auto_pre_adventure()
 	{
 		januaryToteAcquire($item[Wad Of Used Tape]);
 	}
+
+	removeFromMaximize("-1000mana cost");
 
 	// EQUIP MAXIMIZED GEAR
 	auto_ghost_prep(place);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4937,12 +4937,15 @@ boolean auto_burnMP(int mpToBurn)
 
 	item[int] equipped = auto_saveEquipped();
 
+	addToMaximize("-1000mana cost, -tie");
+	equipMaximizedGear();
 	auto_equipAprilShieldBuff(); //useful additional buffs when equipped
 
 	// record starting MP
 	int startingMP = my_mp();
 	cli_execute("burn " + mpToBurn);
 	auto_loadEquipped(equipped);
+	removeFromMaximize("-1000mana cost");
 	return startingMP != my_mp();
 }
 


### PR DESCRIPTION
# Description

After adding the save/load equip functions, I noticed that there was a lot of additional time being spent equipping and then unequipping my Baywatch during the post adventure buffing sequence, basically with each buff's skill being cast. This PR reduces maximizes for -mana cost before buffing in pre-adventure, post-adventure, and during mana burning (which kind of defeats the purpose of burning mana, but it was another slowdown I saw). Also, will not try to cast Spirit Boon if not a Turtle Tamer, another slowdown

## How Has This Been Tested?

Multiple turns observing how equipment is saved with various auto_log_info statements I added during my testing (removed from final commit).

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
