### PR TITLE
Don't use a familiar that provides the opposite combat rate modification we want

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -724,7 +724,11 @@ boolean autoChooseFamiliar(location place)
 
 	//If a fam was selected that is contrary to the Combat Rate we want, deselect it. Probably won't select it in stat or regen but user should get better free-ish fams if it does
 	float famComRate = numeric_modifier(famChoice, "Combat Rate", familiar_weight(famChoice) + weight_adjustment(), familiar_equipped_equipment(famChoice));
-	if((contains_text(get_property("auto_maximize_current"), "-200Combat") && famComRate > 0) || (contains_text(get_property("auto_maximize_current"), "200Combat") && famComRate > 0))
+	if((contains_text(get_property("auto_maximize_current"), "-200Combat") && famComRate > 0))
+	{
+		famChoice = $familiar[none];
+	}
+	else if((contains_text(get_property("auto_maximize_current"), "201Combat") && famComRate < 0))
 	{
 		famChoice = $familiar[none];
 	}

--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -721,6 +721,13 @@ boolean autoChooseFamiliar(location place)
 	{
 		famChoice = lookupFamiliarDatafile("drop");
 	}
+
+	//If a fam was selected that is contrary to the Combat Rate we want, deselect it. Probably won't select it in stat or regen but user should get better free-ish fams if it does
+	float famComRate = numeric_modifier(famChoice, "Combat Rate", familiar_weight(famChoice) + weight_adjustment(), familiar_equipped_equipment(famChoice));
+	if((contains_text(get_property("auto_maximize_current"), "-200Combat") && famComRate > 0) || (contains_text(get_property("auto_maximize_current"), "200Combat") && famComRate > 0))
+	{
+		famChoice = $familiar[none];
+	}
 	
 	// Stats from combats makes runs go faster apparently.
 	if (famChoice == $familiar[none] && (my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean())) {

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -24,7 +24,7 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 	}
 
 	if (doEquips) {
-		string max = "200combat " + amt + "max";
+		string max = "201combat " + amt + "max";
 		if (speculative) {
 			simMaximizeWith(loc, max);
 		} else {

--- a/RELEASE/scripts/autoscend/auto_providers.ash
+++ b/RELEASE/scripts/autoscend/auto_providers.ash
@@ -2,6 +2,12 @@
 float providePlusCombat(int amt, location loc, boolean doEquips, boolean speculative) {
 	auto_log_info((speculative ? "Checking if we can" : "Trying to") + " provide " + amt + " positive combat rate, " + (doEquips ? "with" : "without") + " equipment", "blue");
 
+	//if the fam is important enough to add, it will be caught in preAdvUpdateFamiliar
+	if(numeric_modifier(my_familiar(), "Combat Rate", familiar_weight(my_familiar()) + weight_adjustment(), familiar_equipped_equipment(my_familiar())) < 0)
+	{
+		use_familiar($familiar[none]);
+	}
+
 	float alreadyHave = numeric_modifier("Combat Rate");
 	float need = amt - alreadyHave;
 
@@ -72,6 +78,9 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 			if (eff == $effect[Musk of the Moose] && have_effect($effect[Smooth Movements]) > 0) {
 				delta += (-1.0 * numeric_modifier($effect[Smooth Movements], "Combat Rate")); // numeric_modifer doesn't take into account uneffecting the opposite skill so we have to add it manually.
 			}
+			if(eff == $effect[Carlweather\'s Cantata Of Confrontation] && have_effect($effect[The Sonata of Sneakiness]) > 0) {
+				delta += (-1.0 * numeric_modifier($effect[The Sonata of Sneakiness], "Combat Rate"));
+			}
 		}
 		auto_log_debug("We " + (speculative ? "can gain" : "just gained") + " " + eff.to_string() + ", now we have " + result());
 	}
@@ -91,7 +100,7 @@ float providePlusCombat(int amt, location loc, boolean doEquips, boolean specula
 	// Now handle buffs that cost MP, items or other resources
 	
 	// Cheap effects
-	shrugAT($effect[Carlweather\'s Cantata Of Confrontation]);
+	if(!speculative) shrugAT($effect[Carlweather\'s Cantata Of Confrontation]);
 	if (tryEffects($effects[
 		Musk of the Moose,
 		Carlweather's Cantata of Confrontation,
@@ -195,6 +204,12 @@ boolean providePlusCombat(int amt)
 
 float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean speculative) {
 	auto_log_info((speculative ? "Checking if we can" : "Trying to") + " provide " + amt + " negative combat rate, " + (doEquips ? "with" : "without") + " equipment", "blue");
+
+	//if the fam is important enough to add, it will be caught in preAdvUpdateFamiliar
+	if(numeric_modifier(my_familiar(), "Combat Rate", familiar_weight(my_familiar()) + weight_adjustment(), familiar_equipped_equipment(my_familiar())) > 0)
+	{
+		use_familiar($familiar[none]);
+	}
 
 	// numeric_modifier will return -combat as a negative value and +combat as a positive value
 	// so we will need to invert the return values otherwise this will be wrong (since amt is supposed to be positive).
@@ -305,7 +320,7 @@ float providePlusNonCombat(int amt, location loc, boolean doEquips, boolean spec
 
 	// Now handle buffs that cost MP, items or other resources
 
-	shrugAT($effect[The Sonata of Sneakiness]);
+	if(!speculative) shrugAT($effect[The Sonata of Sneakiness]);
 	if (tryEffects($effects[
 		Shelter Of Shed,
 		Brooding,


### PR DESCRIPTION
# Description

If we manage to get all the way to the last couple of possibility for familiars and we have a familiar that is contrary to our combat rate goal, unset famChoice and let autoscend choose a stat or regen famiiliar instead. Also, unequip those familiars if they are equipped when trying to provide +/- combat. If they are important enough, they will be equipped again during pre-adventure

## How Has This Been Tested?

Manually called providers with +/- combat rate familiars equipped and it correctly unequipped them if they were opposite the combat rate we were trying to provide and kept them if the familiar was with the combat rate we wanted

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
