### PR TITLE
Check auto_combat_appearance_rates in the zone to see if we actually can do anything

### DIFF
--- a/RELEASE/scripts/autoscend/auto_familiar.ash
+++ b/RELEASE/scripts/autoscend/auto_familiar.ash
@@ -105,8 +105,9 @@ boolean auto_famKill(familiar fam, location place)
 
 	int passiveDamage = numeric_modifier("Damage Aura") + numeric_modifier("Sporadic Damage Aura ") + numeric_modifier("Thorns") + numeric_modifier("Sporadic Thorns");
 	
-	foreach mon, freq in appearance_rates(place)
+	foreach mon, freq in auto_combat_appearance_rates(place)
 	{
+		if(freq<=0) continue;
 		//Mafia doesn't output the expected damage of the familiar so going with the highest possible for most users (NPZR)
 		if(mon != $monster[none] && monster_hp(mon) < (floor(1.5 * (familiar_weight(fam) +weight_adjustment() + 3)) + passiveDamage))
 		{
@@ -812,10 +813,12 @@ void preAdvUpdateFamiliar(location place)
 		
 		item[monster] heistDesires = catBurglarHeistDesires();
 		boolean wannaHeist = false;
+		float [monster] apprates = auto_combat_appearance_rates(place, true);
 		foreach mon, it in heistDesires
 		{
 			foreach i, mmon in get_monsters(place)
 			{
+				if(apprates[mon] <= 0) continue; //won't show up because banished or req's not fulfilled
 				if(mmon == mon)
 				{
 					auto_log_debug("Using cat burglar because we want to burgle a " + it + " from " + mon);

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -814,7 +814,7 @@ boolean auto_pre_adventure()
 	}
 
 	// Path Specific Conditions
-	if(is_professor())  //WereProfessor professor doesn't like ML
+	if(is_professor() || in_plumber())  //Path of the Plumber doesn't need ML and WereProfessor professor doesn't like ML
 	{
 		doML = false;
 		removeML = true;

--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -136,8 +136,10 @@ void auto_ghost_prep(location place)
 	int m_spooky = 1;
 	int m_sleaze = 1;
 	int m_stench = 1;
+	float [monster] apprates = auto_combat_appearance_rates(place, true);
 	foreach idx, mob in get_monsters(place)
 	{
+		if(apprates[mob] <= 0) continue; //won't show up because banished or req's not fulfilled
 		if(mob.physical_resistance >= 80)
 		{
 			switch(monster_element(mob))

--- a/RELEASE/scripts/autoscend/auto_restore.ash
+++ b/RELEASE/scripts/autoscend/auto_restore.ash
@@ -2079,6 +2079,11 @@ boolean acquireHP(int goal, int meat_reserve, boolean useFreeRests)
 			retrieve_item(1, $item[super deluxe mushroom]);
 			use(1, $item[super deluxe mushroom]);
 		}
+		if(my_hp() <= 10)
+		{
+			auto_log_info("Spending a turn to heal.");
+			visit_url("place.php?whichplace=mario&action=mush_saveblock");
+		}
 	}
 	else
 	{

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -2162,7 +2162,6 @@ boolean is_ghost_in_zone(location loc)
 			if(apprates[mob] <= 0) continue; //won't show up because banished or req's not fulfilled
 			if (mob.physical_resistance >= 80)
 			{
-				auto_log_info(mob + " is physically resistant");
 				return true;
 			}
 		}

--- a/RELEASE/scripts/autoscend/auto_zone.ash
+++ b/RELEASE/scripts/autoscend/auto_zone.ash
@@ -2156,10 +2156,13 @@ boolean is_ghost_in_zone(location loc)
 		
 	default:
 		//for all other zones
+		float [monster] apprates = auto_combat_appearance_rates(loc, true);
 		foreach idx, mob in get_monsters(loc)
 		{
+			if(apprates[mob] <= 0) continue; //won't show up because banished or req's not fulfilled
 			if (mob.physical_resistance >= 80)
 			{
+				auto_log_info(mob + " is physically resistant");
 				return true;
 			}
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2022.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2022.ash
@@ -936,7 +936,7 @@ void auto_checkTrainSet()
 		}
 	}
 	int eight = 13; //monster level
-	if((monster_level_adjustment() > get_property("auto_MLSafetyLimit").to_int() && get_property("auto_MLSafetyLimit") != "") || get_property("auto_MLSafetyLimit").to_int() == -1){
+	if((monster_level_adjustment() > get_property("auto_MLSafetyLimit").to_int() && get_property("auto_MLSafetyLimit") != "") || get_property("auto_MLSafetyLimit").to_int() == -1 || in_plumber()){
 		eight = 9; //cold res, stench dmg
 	}
 	int turnsSinceTSConfigured = min(trainsetPosition - lastTrainsetConfiguration, 40);

--- a/RELEASE/scripts/autoscend/paths/casual.ash
+++ b/RELEASE/scripts/autoscend/paths/casual.ash
@@ -35,8 +35,7 @@ boolean L8_slopeCasual()
 	{
 		return false;	//does not have unrestricted mall access. we are not in casual or postronin
 	}
-	foreach it in $items[Ninja Carabiner, Ninja Crampons, Ninja Rope,		//ninja climbing gear needed to climb the slope
-	eXtreme scarf, eXtreme mittens, snowboarder pants]						//outfit ensures you can reach 5 cold res needed
+	foreach it in $items[eXtreme scarf, eXtreme mittens, snowboarder pants]						//outfit ensures you can reach 5 cold res needed
 	{
 		if(!auto_buyUpTo(1, it))	//try to buy it or verify we already own it. if fails then do as below
 		{

--- a/RELEASE/scripts/autoscend/quests/level_08.ash
+++ b/RELEASE/scripts/autoscend/quests/level_08.ash
@@ -499,7 +499,7 @@ boolean L8_trapperExtreme()
 		// plumber literally wont let you adventure if you have no way to fight in plumber.
 			if(in_plumber())
 			{
-				equip($slot[acc3], $item[work boots]);
+				autoforceEquip($slot[acc3], $item[work boots]);
 			}
 	}
 	// we should equip the extreme outfit if we have it


### PR DESCRIPTION
# Description

Use our combat_appearance_rates to exclude potential monsters from consideration in a couple of functions. Also a couple of Path of the Plumber changes to make it run significantly smoother

## How Has This Been Tested?

Checked output of apprates[mob] <= 0 and matched expected mobs to not show up in the Spooky Forest (Baiowolf & The Headless Horseman).
HC Path of the Plumber through D1:L15. (1st ever run of it so catching a few things low shiny folk might experience with it too)

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
