### PR TITLE
fix: more paths that make you illiterate

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4947,8 +4947,8 @@ boolean auto_burnMP(int mpToBurn)
 }
 
 boolean can_read_skillbook(item it) {
-	// can't read in Picky
-	if (in_picky()) {
+	// can't read in Picky, Pokefam, Class Act or Journeyman
+	if (in_picky() || in_pokefam() || my_path() == $path[Class Act] || my_path() == $path[Class Act II: A Class For Pigs] || my_path() == $path[Journeyman]) {
 		return false;
 	}
 	// all the normal classes and AoSOL classes are literate
@@ -4979,7 +4979,7 @@ int baseNCForcesToday()
 {
 	int forces = 0;
 	if (auto_havePillKeeper()) {forces = forces + 6;}
-	if (auto_haveAprilingBandHelmet() && available_amount($item[apriling band saxophone])>0) {forces = forces + 3;}
+	if (auto_haveAprilingBandHelmet() && available_amount($item[apriling band tuba])>0) {forces = forces + 3;}
 	if (auto_haveMcHugeLargeSkis()) {forces = forces + 3;}
 	if (auto_hasParka()) {forces = forces + 5;}
 	if (auto_haveCincho()) {forces = forces + 3;} // Not important to calculate this properly here.


### PR DESCRIPTION
# Description

More paths where you shouldn't get the Manual of Secret Door Detection because you can't read books.

## How Has This Been Tested?
Pokefam.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
