### PR TITLE
fix: don't try to use combat items / skills in pokefam

### DIFF
--- a/RELEASE/scripts/autoscend/auto_pre_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_pre_adv.ash
@@ -639,7 +639,7 @@ boolean auto_pre_adventure()
 	}
 
 	item dartHolster = $item[Everfull Dart Holster];
-	if (auto_haveDarts() && have_effect($effect[Everything Looks Red]) == 0 && !in_avantGuard())
+	if (auto_haveDarts() && have_effect($effect[Everything Looks Red]) == 0 && !in_avantGuard() && !in_pokefam())
 	{
 		auto_log_info("We don't have ELR so let's hit a bullseye");
 		autoEquip($slot[acc3], dartHolster);

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -923,7 +923,10 @@ boolean auto_wantToFreeRun(monster enemy, location loc)
 
 boolean canFreeRun(monster enemy, location loc)
 {
-	// are there any restrictions on free running?
+	// pokefam cannot use skills or items
+	if (in_pokefam()) {
+		return false;
+	}
 	return true;
 }
 

--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -1053,6 +1053,10 @@ string yellowRayCombatString()
 
 string replaceMonsterCombatString(monster target, boolean inCombat)
 {
+	if(in_pokefam())
+	{
+		return "";
+	}
 	if(auto_macrometeoritesAvailable() > 0 && auto_is_valid($skill[Macrometeorite]))
 	{
 		return "skill " + $skill[Macrometeorite];


### PR DESCRIPTION
# Description

Don't try to use darts, free runaways, or replacements in pokefam.

## How Has This Been Tested?

Pokefam.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
