### PR TITLE
feat: add a configurable property for estimated day count

### DIFF
--- a/BUILD/settings/post.dat
+++ b/BUILD/settings/post.dat
@@ -6,3 +6,4 @@ auto_hippyInstead	boolean	Fight on the side of the hippies instead of the Frat W
 auto_ignoreFlyer	boolean	Do not do the flyer quest in this ascension? recommended to set true if fighting for the hippies.
 auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this ascension?
 auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.
+auto_runDayCount	integer	How many days do you think your run will take? Defaults to 2.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -68,6 +68,7 @@ post	4	auto_hippyInstead	boolean	Fight on the side of the hippies instead of the
 post	5	auto_ignoreFlyer	boolean	Do not do the flyer quest in this ascension? recommended to set true if fighting for the hippies.
 post	6	auto_wandOfNagamar	boolean	Do we need to get a Wand of Nagamar in this ascension?
 post	7	auto_dontPhylumBanish	boolean	If false will banish enemy phyla. Banishing should save some turns, but can interfere with the routing, and may mess up later banishes / tracks.
+post	8	auto_runDayCount	integer	How many days do you think your run will take? Defaults to 2.
 
 pre	0	auto_getSteelOrgan_initialize	boolean	When we initialize an ascension this will be copied to auto_getSteelOrgan
 

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -195,6 +195,7 @@ void initializeSettings() {
 	set_property("auto_disableAdventureHandling", false);
 	set_property("auto_doCombatCopy", "no");
 	set_property("auto_dontPhylumBanish", false);
+	set_property("auto_runDayCount", 2);
 	set_property("auto_drunken", "");
 	set_property("auto_eaten", "");
 	set_property("auto_familiarChoice", "");

--- a/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
+++ b/RELEASE/scripts/autoscend/paths/pocket_familiars.ash
@@ -17,6 +17,8 @@ void pokefam_initializeSettings()
 		set_property("auto_ignoreFlyer", true);
 		// No Naughty Sorceress so no need for a wand.
 		set_property("auto_wandOfNagamar", false);
+		// runs are probably going to take at least 3 days, maybe 4 in hardcore
+		set_property("auto_runDayCount", 3);
 	}
 }
 

--- a/RELEASE/scripts/autoscend/quests/level_06.ash
+++ b/RELEASE/scripts/autoscend/quests/level_06.ash
@@ -65,16 +65,16 @@ boolean L6_friarsGetParts()
 	{
 		auto_log_info("Getting Dodecagram", "blue");
 		boolean NCForced = auto_forceNextNoncombat($location[The Dark Neck of the Woods]);
-		// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-		if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean()) return false;
+		// delay if we are out of NC forcers and haven't run out of things to do
+		if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean()) return false;
 		return autoAdv($location[The Dark Neck of the Woods]);
 	}
 	if(item_amount($item[eldritch butterknife]) == 0)
 	{
 		auto_log_info("Getting Eldritch Butterknife", "blue");
 		boolean NCForced = auto_forceNextNoncombat($location[The Dark Elbow of the Woods]);
-		// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-		if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean()) return false;
+		// delay if we are out of NC forcers and haven't run out of things to do
+		if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean()) return false;
 		return autoAdv($location[The Dark Elbow of the Woods]);
 	}
 	if(item_amount($item[box of birthday candles]) == 0)
@@ -87,8 +87,8 @@ boolean L6_friarsGetParts()
 		}
 		auto_log_info("Getting Box of Birthday Candles", "blue");
 		boolean NCForced = auto_forceNextNoncombat($location[The Dark Heart of the Woods]);
-		// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-		if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean()) return false;
+		// delay if we are out of NC forcers and haven't run out of things to do
+		if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean()) return false;
 		return autoAdv($location[The Dark Heart of the Woods]);
 	}
 

--- a/RELEASE/scripts/autoscend/quests/level_10.ash
+++ b/RELEASE/scripts/autoscend/quests/level_10.ash
@@ -200,8 +200,8 @@ boolean L10_basement()
 	}
 
 	boolean NCForced = auto_forceNextNoncombat($location[The Castle in the Clouds in the Sky (Basement)]);
-	// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-	if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel()) return false;
+	// delay if we are out of NC forcers and haven't run out of things to do
+	if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel()) return false;
 	if(!autoEquip($item[Amulet of Extreme Plot Significance]))
 	{
 		if(!autoEquip($item[unbreakable umbrella]))
@@ -272,8 +272,8 @@ boolean L10_topFloor()
 	}
 
 	boolean NCForced = auto_forceNextNoncombat($location[The Castle in the Clouds in the Sky (Top Floor)]);
-	// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-	if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel()) return false;
+	// delay if we are out of NC forcers and haven't run out of things to do
+	if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel()) return false;
 	autoEquip($item[Mohawk wig]);
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
 
@@ -407,8 +407,8 @@ boolean L10_holeInTheSkyUnlock()
 	
 	// set location "wrong" so that LX_ForceNC can properly direct back to this function (L10_holeInTheSkyUnlock)
 	boolean NCForced = auto_forceNextNoncombat($location[The Hole in the Sky]);
-	// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-	if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel()) return false;
+	// delay if we are out of NC forcers and haven't run out of things to do
+	if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel()) return false;
 
 	autoAdv(1, $location[The Castle in the Clouds in the Sky (Top Floor)]);
 

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -439,8 +439,8 @@ boolean LX_unlockHauntedLibrary()
 	{
 		// only force after we get the pool cue NC.
 		boolean NCForced = auto_forceNextNoncombat($location[The Haunted Billiards Room]);
-		// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-		if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel())
+		// delay if we are out of NC forcers and haven't run out of things to do
+		if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel())
 		{
 			resetMaximize();	//cancel equipping pool cue
 			return false;
@@ -714,8 +714,8 @@ boolean LX_getLadySpookyravensPowderPuff() {
 
 	if (!zone_delay($location[The Haunted Bathroom])._boolean) {
 		boolean NCForced = auto_forceNextNoncombat($location[The Haunted Bathroom]);
-		// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-		if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel()) return false;
+		// delay if we are out of NC forcers and haven't run out of things to do
+		if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel()) return false;
 	}
 	if (autoAdv($location[The Haunted Bathroom])) {
 		return true;
@@ -907,8 +907,8 @@ boolean L11_getBeehive()
 	auto_log_info("Must find a beehive!", "blue");
 
 	boolean NCForced = auto_forceNextNoncombat($location[The Black Forest]);
-	// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-	if(!NCForced && my_daycount() == 1 && !isAboutToPowerlevel()) return false;
+	// delay if we are out of NC forcers and haven't run out of things to do
+	if(!NCForced && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel()) return false;
 	boolean advSpent = autoAdv($location[The Black Forest]);
 	if(item_amount($item[beehive]) > 0)
 	{
@@ -1923,8 +1923,8 @@ boolean L11_hiddenCity()
 			if(shouldForceElevatorAction)
 			{
 				elevatorAction = auto_forceNextNoncombat($location[The Hidden Apartment Building]);
-				// delay to day 2 if we are out of NC forcers and haven't run out of things to do
-				if(!elevatorAction && my_daycount() == 1 && !isAboutToPowerlevel()) return false;
+				// delay if we are out of NC forcers and haven't run out of things to do
+				if(!elevatorAction && my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel()) return false;
 			}
 		}
 
@@ -2001,9 +2001,9 @@ boolean L11_hiddenCity()
 			{
 				workingHoliday = true;
 			}
-			else if(my_daycount() == 1 && !isAboutToPowerlevel())
+			else if(my_daycount() < get_property("auto_runDayCount").to_int() && !isAboutToPowerlevel())
 			{
-				// delay to day 2 if we are out of NC forcers and haven't run out of things to do
+				// delay if we are out of NC forcers and haven't run out of things to do
 				return false;
 			}
 		}


### PR DESCRIPTION
Delay completing zones without NC forcers where NC forcers would be useful.

## How Has This Been Tested?

Pokefam

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
