### PR TITLE
11,037 Leagues Under the Sea Support

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r28604;	// wildsun boon is once/day, allied radio accepts uppercase
+since r28646;	// Fix some issues in my sea import
 /***
 	autoscend_header.ash must be first import
 	All non-accessory scripts must be imported here
@@ -88,6 +88,7 @@ import <autoscend/paths/quantum_terrarium.ash>
 import <autoscend/paths/small.ash>
 import <autoscend/paths/the_source.ash>
 import <autoscend/paths/two_crazy_random_summer.ash>
+import <autoscend/paths/under_the_sea.ash>
 import <autoscend/paths/way_of_the_surprising_fist.ash>
 import <autoscend/paths/wereprofessor.ash>
 import <autoscend/paths/wildfire.ash>

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1054,6 +1054,10 @@ float tcrs_expectedAdvPerFill(string quality);
 boolean tcrs_maximize_with_items(string maximizerString);
 
 ########################################################################################################
+//Defined in autoscend/paths/under_the_sea.ash
+boolean in_underTheSea();
+
+########################################################################################################
 //Defined in autoscend/paths/way_of_the_surprising_fist.ash
 boolean in_wotsf();
 

--- a/RELEASE/scripts/autoscend/paths/under_the_sea.ash
+++ b/RELEASE/scripts/autoscend/paths/under_the_sea.ash
@@ -1,0 +1,4 @@
+boolean in_underTheSea()
+{
+    return my_path() == $path[11,037 Leagues Under the Sea];
+}


### PR DESCRIPTION
# Description

Adds support for the path, and also completing the Sea, if for some reason you want autoscend to do that for you.

To-Do:

- [ ] Add sea quests
- [ ] Make sushi
- [ ] Utilize new equipment

## How Has This Been Tested?

The path has been out for 13 hours...

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
