### PR TITLE
feat: don't delay the beach if junkyard not complete

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1296,13 +1296,6 @@ boolean L12_sonofaBeach()
 	{
 		return false;
 	}
-	if(!in_pokefam() && !get_property("auto_hippyInstead").to_boolean())
-	{
-		if(get_property("sidequestJunkyardCompleted") == "none")
-		{
-			return false;
-		}
-	}
 	if(auto_warEnemiesRemaining() == 0)
 	{
 		return false;


### PR DESCRIPTION
# Description

In all runs, have the option to visit the beach even if the Junkyard isn't complete.

With options like autumn-aton or digitize, perhaps you want to set up some of this early.

No other sidequests appear to do this skipping thing.

## How Has This Been Tested?

Many runs.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
