### PR TITLE
add "do we have it" check for burning leaves to avoid choice error

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -1314,6 +1314,10 @@ int auto_remainingBurningLeavesFights()
 
 boolean auto_fightFlamingLeaflet()
 {
+	if (!auto_haveBurningLeaves())
+	{
+		return false;
+	}
 	if (auto_remainingBurningLeavesFights() < 1)
 	{
 		return false;


### PR DESCRIPTION
# Description

fix for reported error in #autoscend chat re: burning leaves causing unsupported choice errors due to the nonexistence of the pile for accounts in standard.

## How Has This Been Tested?

hasn't, but i can't imagine this is an issue.

## Checklist:

i admittedly did not add comments or update the wiki but should still be OK?

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
