### PR TITLE
fix: correctly determine if Burning Leaves is in standard

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -3400,6 +3400,17 @@ boolean auto_is_valid(effect eff)
 	return glover_usable(eff.to_string());
 }
 
+boolean auto_is_valid(string str)
+{
+	// unknown entries, presumably Bookshelf skills
+	if(my_path() == $path[Trendy])
+	{
+		return is_trendy(str);
+	}
+	
+	return is_unrestricted(str);
+}
+
 void auto_log(string s, string color, int log_level)
 {
 	if(log_level > get_property("auto_log_level").to_int())

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -2062,6 +2062,7 @@ boolean auto_is_valid(item it);
 boolean auto_is_valid(familiar fam);
 boolean auto_is_valid(skill sk);
 boolean auto_is_valid(effect eff);
+boolean auto_is_valid(string str);
 void auto_log(string s, string color, int log_level);
 void auto_log_error(string s);
 void auto_log_warning(string s, string color);

--- a/RELEASE/scripts/autoscend/iotms/mr2023.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2023.ash
@@ -1211,7 +1211,7 @@ boolean auto_getCitizenZone(string goal)
 
 boolean auto_haveBurningLeaves()
 {
-	return auto_is_valid($item[A Guide to Burning Leaves]) && get_campground() contains $item[A Guide to Burning Leaves];
+	return auto_is_valid("Burning Leaves") && get_campground() contains $item[A Guide to Burning Leaves];
 }
 
 boolean auto_initBurningLeaves()


### PR DESCRIPTION
# Description

The item "A Guide to Burning Leaves" never leaves standard. Check the "Bookshelf" instead.

Closes #1692.

## How Has This Been Tested?

Discord posters have successfully run in Standard.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
