### PR TITLE
Fix bedtime

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -1109,12 +1109,17 @@ boolean LX_dronesOut()
 
 int freeCandyFightsLeft()
 {
+	// Map isn't valid
+	if(!auto_is_valid($item[Map to a candy-rich block]))
+	{
+		return 0;
+	}
 	// Map is done
 	if(get_property("_mapToACandyRichBlockUsed").to_boolean() && get_property("_auto_candyMapCompleted").to_boolean())
 	{
 		return 0;
 	}
-	if(!get_property("_mapToACandyRichBlockUsed").to_boolean() && item_amount($item[Map to a candy-rich block]) > 0 || !auto_is_valid($item[Map to a candy-rich block]))
+	if(!get_property("_mapToACandyRichBlockUsed").to_boolean() && item_amount($item[Map to a candy-rich block]) > 0)
 	{
 		return 5;
 	}


### PR DESCRIPTION
# Description

Bedtime routine didn't overdrink or do a few other things I'd expect. Cause is it thought there was more to do today due to there being trick or treating free fights left. Which isn't true because jill isn't in standard anymore

I'm confused where the valid check originally was. Am I missing/breaking something by moving it?

## How Has This Been Tested?

Bedtime thought there was free fights left, made this change, bedtime worked as expected

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
