### PR TITLE
if breaking hippy stone, do it first thing in day init

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -696,6 +696,12 @@ void initializeDay(int day)
 
 	invalidateRestoreOptionCache();
 
+	if(get_property("auto_pvpEnable").to_boolean() && !hippy_stone_broken())
+	{
+		visit_url("peevpee.php?action=smashstone&pwd&confirm=on", true);
+		visit_url("peevpee.php?place=fight");
+	}
+
 	if (get_property("auto_day_init").to_int() < day)
 	{
 		set_property("auto_powerLevelLastLevel", "0");
@@ -960,12 +966,6 @@ void initializeDay(int day)
 			handleBjornify($familiar[El Vibrato Megadrone]);
 
 			string temp = visit_url("guild.php?place=challenge");
-
-			if(get_property("auto_pvpEnable").to_boolean() && !hippy_stone_broken())
-			{
-				visit_url("peevpee.php?action=smashstone&pwd&confirm=on", true);
-				visit_url("peevpee.php?place=fight");
-			}
 
 			auto_beachCombHead("exp");
 		}


### PR DESCRIPTION
# Description

Simple PR to prevent mayam pvp fight generation from being wasted. Will also mean hippy stone gets broken when setting is set, even if for some reason you don't run autoscend on day 1.

## How Has This Been Tested?

Have not tested yet, as I just noticed the issue this run. Will test next ascension and confirm that it works (so don't merge yet). However, it does seem fairly straightforward.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
