### PR TITLE
Lower Cubeling priority when drops obtained; raise SoCP priority slightly

### DIFF
--- a/BUILD/familiars/item.dat
+++ b/BUILD/familiars/item.dat
@@ -64,7 +64,7 @@ Pair of Stomping Boots	!path:G-Lover
 Slimeling
 # More slightly special fairies
 Cooler Yeti
-Gelatinous Cubeling
+Gelatinous Cubeling	prop:cubelingProgress<12
 Steam-Powered Cheerleader
 Obtuse Angel
 Green Pixie
@@ -79,9 +79,10 @@ Bowlet
 Crimbo Elf
 # Barely special fairies
 Mechanical Songbird
+Skeleton of Crimbo Past
+Gelatinous Cubeling
 Grouper Groupie
 Peppermint Rhino
-Skeleton of Crimbo Past
 # Turtles are cute
 Syncopated Turtle
 # The original

--- a/RELEASE/data/autoscend_familiars.txt
+++ b/RELEASE/data/autoscend_familiars.txt
@@ -178,7 +178,7 @@ item	39	Pair of Stomping Boots	!path:G-Lover
 item	40	Slimeling
 # More slightly special fairies
 item	41	Cooler Yeti
-item	42	Gelatinous Cubeling
+item	42	Gelatinous Cubeling	prop:cubelingProgress<12
 item	43	Steam-Powered Cheerleader
 item	44	Obtuse Angel
 item	45	Green Pixie
@@ -193,16 +193,17 @@ item	51	Bowlet
 item	52	Crimbo Elf
 # Barely special fairies
 item	53	Mechanical Songbird
-item	54	Grouper Groupie
-item	55	Peppermint Rhino
-item	56	Skeleton of Crimbo Past
+item	54	Skeleton of Crimbo Past
+item	55	Gelatinous Cubeling
+item	56	Grouper Groupie
+item	57	Peppermint Rhino
 # Turtles are cute
-item	57	Syncopated Turtle
+item	58	Syncopated Turtle
 # The original
-item	58	Baby Gravy Fairy
+item	59	Baby Gravy Fairy
 # Mutant Fire Ant multiplier is 1.3-(0.15*grimace darkness). Too marginal because of opportunity cost compared to leveling another familiar.
 # If we level it today when it gives a good bonus, tomorrow it might drop to bad bonus and we have to start leveling another fairy.
-item	59	Mutant Fire Ant
+item	60	Mutant Fire Ant
 
 # Wanna get that jar
 meat	0	Angry Jung Man	prop:_jungDrops<1;day:1


### PR DESCRIPTION
# Description

Another data tweak. I noticed the script using my Skeleton of Crimbo Past in most adventures, getting the familiar weight up, but then switching to the Gelatinous Cubeling when item drop rate actually mattered, actually lowering the item drop % because the Cubeling had low weight and the SoCP had maximum weight already. I noticed the Cubeling had a high priority in the data files, so I restricted the high priority to only apply when we still need its drops and added a new entry to apply the rest of the time, and placed it below the Skeleton. I also raised the latter's priority a bit.

## How Has This Been Tested?

It hasn't, first because it is only a data change and secondly because I don't think this will actually solve my problem by itself. While this is an improvement in the logic, what will actually happen is the script will switch from the SoCP to a gravy fairy when it comes time to maximize item drops. What would actually fix it is taking the weight into account in some way, which I guess the script doesn't do. I know the maximizer's `switch` keyword is able to consider weight but is also supposed to be computationally expensive, which I guess is the root of the issue and the reason why autoscend needs to have familiar data files at all rather than just sticking the entire list into the maximizer as `switch` options.

Anyway, this will still help me because I can just blacklist all the fairies and the bowlet and get the SoCP as the item familiar.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [n/a] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [n/a] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
