### PR TITLE
fix: get a wand of nagamar in standard

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -750,7 +750,7 @@ void edUnderworldChoiceHandler(int choice);
 ########################################################################################################
 //Defined in autoscend/paths/adventurer_meats_world.ash
 boolean in_amw();
-boolean amw_initializeSettings();
+void amw_initializeSettings();
 boolean amw_canAfford(skill sk);
 boolean amw_buySubstat(stat st, int numberToBuy);
 int amw_advPerTrade();

--- a/RELEASE/scripts/autoscend/paths/adventurer_meats_world.ash
+++ b/RELEASE/scripts/autoscend/paths/adventurer_meats_world.ash
@@ -3,10 +3,13 @@ boolean in_amw()
 	return my_path() == $path[Adventurer Meats World];
 }
 
-boolean amw_initializeSettings()
+void amw_initializeSettings()
 {
+	if(!in_amw())
+	{
+		return;
+	}
 	set_property("auto_wandOfNagamar", false);
-	return false;
 }
 
 boolean amw_canAfford(skill sk)


### PR DESCRIPTION
# Description

Don't apply the AMW settings on all paths.

## How Has This Been Tested?

Day 1 of standard.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
