### PR TITLE
fix whiteys screech loop

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3124,7 +3124,7 @@ boolean L11_palindome()
 			equipBaseline();
 			if((item_amount($item[Bird Rib]) == 0) || (item_amount($item[Lion Oil]) == 0))
 			{
-				doWhiteys();
+				return doWhiteys();
 			}
 			else if(item_amount($item[Stunt Nuts]) == 0)
 			{

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3130,7 +3130,7 @@ boolean L11_palindome()
 			{
 				auto_log_info("We got no nuts!! :O", "Blue");
 				autoEquip($slot[acc3], $item[Talisman o\' Namsilat]);
-				autoAdv(1, $location[Inside the Palindome]);
+				return autoAdv(1, $location[Inside the Palindome]);
 			}
 			else
 			{


### PR DESCRIPTION
# Description

Autoscend screeched beasts (evil olive) in the palindome which caused issues with whitey's grove. doWhiteys() failed as expected at line 3096 in the lvl 11 file, upon checking that beasts were screeched. But L11_Palindome() would return true, causing an infinite loop.

Fixes # (issue) -- none that I could find

## How Has This Been Tested?

A portion of an unrestricted run. After this change, autoscend went to another zone to burn turns until the screech wears off.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
