### PR TITLE
fix: jarlsberg consumables, steak usage

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -626,7 +626,7 @@ boolean canDrink(item toDrink, boolean checkValidity)
 	}
 	if(is_jarlsberg() && toDrink != $item[Steel Margarita])
 	{
-		return contains_text(craft_type(toDrink), "Jarlsberg's Kitchen");
+		return count(sell_cost($coinmaster[Jarlsberg's Cosmic Kitchen], toDrink)) > 0;
 	}
 	if(in_nuclear() && (toDrink.inebriety != 1))
 	{
@@ -704,7 +704,7 @@ boolean canEat(item toEat, boolean checkValidity)
 	}
 	if(is_jarlsberg())
 	{
-		return contains_text(craft_type(toEat), "Jarlsberg's Kitchen");
+		return count(sell_cost($coinmaster[Jarlsberg's Cosmic Kitchen], toEat)) > 0;
 	}
 	if(in_nuclear() && (toEat.fullness != 1))
 	{

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -1535,7 +1535,7 @@ int freeKillSources()
 		}
 	}
 	//combat items/IOTMs/IOTM-Derived items that aren't equipment
-	foreach it in $items[groveling gravel, Replica Bat-oomerang, shadow brick]
+	foreach it in $items[power pill, groveling gravel, Replica Bat-oomerang, shadow brick]
 	{
 		if(auto_is_valid(it) && item_amount(it) > 0)
 		{

--- a/RELEASE/scripts/autoscend/combat/auto_combat_adventurer_meats_world.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_adventurer_meats_world.ash
@@ -46,7 +46,7 @@ string auto_combatMeatGolemStage5(int round, monster enemy, string text)
 	
 	// make sure high HP combats conclude in a timely fashion
 	// only if needed; these skills cost 4-10x more than a regular combat skill
-	if (canUse($skill[Steak Through the Heart], true) && round > 12)
+	if (canUse($skill[Steak Through the Heart], true) && have_combat_skill($skill[Steak Through the Heart]) && round > 12)
 	{
 		return useSkill($skill[Steak Through the Heart], true);
 	}

--- a/RELEASE/scripts/autoscend/combat/auto_combat_adventurer_meats_world.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_adventurer_meats_world.ash
@@ -46,7 +46,7 @@ string auto_combatMeatGolemStage5(int round, monster enemy, string text)
 	
 	// make sure high HP combats conclude in a timely fashion
 	// only if needed; these skills cost 4-10x more than a regular combat skill
-	if (canUse($skill[Steak Through the Heart], true) && have_combat_skill($skill[Steak Through the Heart]) && round > 12)
+	if (canUse($skill[Steak Through the Heart], true) && combat_skill_available($skill[Steak Through the Heart]) && round > 12)
 	{
 		return useSkill($skill[Steak Through the Heart], true);
 	}


### PR DESCRIPTION
# Description

Some bugs fixes.

After the concoction -> coinmaster change, we need to check for Jarlsbergian consumables in a slightly different way.

Steak Through the Heart can only be used if the monster's HP is low enough.

Power Pill is a free kill.

## How Has This Been Tested?

Not yet.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
