### PR TITLE
no bacon in koe

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -674,7 +674,9 @@ int handlePulls(int day)
 		{
 			pullXWhenHaveY($item[etched hourglass], 1, 0);
 		}
-		if(auto_is_valid($item[Infinite BACON Machine]))
+		
+		// generic pull for any path, but unusable in KoE
+		if(!in_koe() && auto_is_valid($item[Infinite BACON Machine]))
 		{
 			pullXWhenHaveY($item[Infinite BACON Machine], 1, 0);
 		}

--- a/RELEASE/scripts/autoscend/iotms/mr2021.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2021.ash
@@ -673,11 +673,6 @@ boolean auto_getBattery(item target)
 
 boolean have_fireworks_shop()
 {
-	if(in_koe())
-	{
-		// can't access fireworks shop in kindom of exploathing
-		return false;
-	}
 	if(is_werewolf())
 	{
 		return false; //can't access fireworks shop as a werewolf


### PR DESCRIPTION
BACON is unusable in Kingdom of Exploathing (KoE), however, autoscend will currently pull and use the Infinite BACON Machine to make BACON. Then it will stop running when it fails to use the BACON, and will continue to do so each time it is run until said BACON is closeted. This PR will stop autoscend from pulling the machine in KoE