### PR TITLE
feat: add zone interrupts

### DIFF
--- a/BUILD/settings_extra/action.dat
+++ b/BUILD/settings_extra/action.dat
@@ -1,3 +1,4 @@
 auto_disableAdventureHandling	boolean	When true this prevents preadventure and postadventure scripts from running. resets every loop.
 auto_disableFamiliarChanging	boolean	When true this prevents familiar changes. resets every loop.
 auto_combatDirective	string	An action to execute at the start of next combat. resets every loop.
+auto_interruptZones	string	Semicolon-separated list of zones to abort in before starting the first adventure.

--- a/RELEASE/data/autoscend_settings_extra.txt
+++ b/RELEASE/data/autoscend_settings_extra.txt
@@ -6,6 +6,7 @@
 action	0	auto_disableAdventureHandling	boolean	When true this prevents preadventure and postadventure scripts from running. resets every loop.
 action	1	auto_disableFamiliarChanging	boolean	When true this prevents familiar changes. resets every loop.
 action	2	auto_combatDirective	string	An action to execute at the start of next combat. resets every loop.
+action	3	auto_interruptZones	string	Semicolon-separated list of zones to abort in before starting the first adventure.
 
 any	0	auto_abooclover	boolean	Are we considering using a clover at A-Boo Peak?
 any	1	auto_aboopending	integer	The last turn of a pending A-Boo Clue. 0 if no clue active.

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -229,6 +229,7 @@ void initializeSettings() {
 	set_property("auto_instakill", "");
 	set_property("auto_instakillSource", "");
 	set_property("auto_instakillSuccess", false);
+	set_property("auto_interruptedZones", "");
 	set_property("auto_iotm_claim", "");
 	set_property("auto_leaflet_done", false);
 	set_property("auto_lucky", "");

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -4450,6 +4450,26 @@ void meatReserveMessage()
 	return;
 }
 
+boolean auto_interruptZoneCheck()
+{
+	string currentZone = my_location().to_string();
+	string interruptZones = get_property("auto_interruptZones");
+	buffer interruptedZones = get_property("auto_interruptedZones");
+	if (interruptZones == "" || interruptedZones.contains_text(currentZone)) {
+		return false;
+	}
+
+	foreach i, zone in interruptZones.split_string(";") {
+		if (zone.to_location() == my_location()) {
+			interruptedZones.append(currentZone + ";");
+			set_property("auto_interruptedZones", interruptedZones);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void auto_interruptCheck(boolean debug)
 {
 	if(get_property("auto_interrupt").to_boolean())
@@ -4458,6 +4478,9 @@ void auto_interruptCheck(boolean debug)
 		restoreAllSettings();
 		meatReserveMessage();
 		abort("auto_interrupt detected and aborting, auto_interrupt disabled.");
+	}
+	else if (auto_interruptZoneCheck()) {
+		abort("auto_interruptZones detected, aborting at " + my_location().to_string());
 	}
 	else if (get_property("auto_debugging").to_boolean() && debug)
 	{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -2149,6 +2149,7 @@ int zoneRank(monster mon);
 int total_items(boolean [item] items);
 boolean auto_badassBelt();
 void meatReserveMessage();
+boolean auto_interruptZoneCheck();
 void auto_interruptCheck(boolean debug);
 void auto_interruptCheck();
 element currentFlavour();


### PR DESCRIPTION
# Description

Implement `auto_interruptZones` setting to pause the run before starting adventures in specified zones, allowing a user to perform non-ascension related tasks mid-run, pursue alternate strategies, or utilize non-implemented IOTMs in the zone(s) of choice. Will continue adventuring as normal after the first interrupt in each zone.

## How Has This Been Tested?

Several standard runs with a handful of target zones performed as expected.

* Substrings can be used, but must match the desired zone uniquely, i.e. `string.to_location()` must return that `location`.
* Apostrophes in a zone name (e.g. Cobb's Knob) interfere with the settings page and cause the rest of the property value to be cut off. They can be omitted to avoid this without issues, but a given zone will otherwise still match with them present.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [X] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
