### PR TITLE
Do not delay shen zones if we've run out of tasks

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -216,7 +216,7 @@ boolean[location] shenZonesToAvoidBecauseMaybeSnake()
 
 boolean shenShouldDelayZone(location loc)
 {
-	return shenZonesToAvoidBecauseMaybeSnake()[loc];
+	return (shenZonesToAvoidBecauseMaybeSnake()[loc] && !isAboutToPowerlevel()); // don't bother with delaying a Shen zone if we've run out of stuff to do
 }
 
 int[location] getShenZonesTurnsSpent()


### PR DESCRIPTION

# Description

Requires that we aren't about to powerlevel for `shenShouldDelayZone()` to return `true`. Practically, this means that we will not delay Shen-relevant zones if we are considering powerleveling or are out of tasks.

Currently, the shen lock is a hard lock: we do not check (both in this function or where this function is called) if we've run out of stuff to do. This can result in lots of turns spent on powerleveling while e.g. the level 9 quest remains unstarted.

Fixes # (issue)

Couldn't find an issue, but reported on Discord the other day.

## How Has This Been Tested?

~~Not; will take awhile to be tested if I'm the person that needs to do it :p. But I felt that this was a simple enough change that I oughta do a PR for it anyway.~~

Update:
Tested on a shiny normal standard run and a no-shiny normal meatpath run. No changes were noticed to the default behavior in my shiny run (did not adventure in shen zones before their quest was ready). 

For the meatpath run, I deleted the code that makes autoscend level up to level 11+ before running out of things to do, guaranteeing that autoscend will stall at level 10. It delayed the appropriate zones at level 10 until running out of things to do: HITS and Smut Orcs. Autoscend also did not delay batsnakes (due to meatpath exception) and Top of the Castle (not in today or tomorrow's list of Shen locations) as expected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
