### PR TITLE
fix: zootomist cannot cast BCZ skills

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2025.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2025.ash
@@ -1011,7 +1011,8 @@ boolean auto_BCZEquipped()
 
 boolean auto_wantToBCZ(skill sk)
 {
-	if(!auto_haveBCZ() || !(canUse(sk)))
+	// zootomist doesn't have substats
+	if(!auto_haveBCZ() || !(canUse(sk)) || in_zootomist())
 	{
 		return false;
 	}


### PR DESCRIPTION
# Description

Zootomist doesn't have substats, so none of the BCZ skills can be cast.

## How Has This Been Tested?

Zoot run.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
