### PR TITLE
feat: peridot astronomer instead of skinflute

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2025.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2025.ash
@@ -292,6 +292,10 @@ boolean[monster] peridotManuallyDesiredMonsters()
 	desired_monsters[$monster[modern zmobie]] = true;
 	desired_monsters[$monster[dairy goat]] = true;
 	desired_monsters[$monster[writing desk]] = true;
+	// we sniff the two-star, two-line monster, but we want exactly one star chart
+	if (item_amount($item[Star Chart]) == 0) {
+		desired_monsters[$monster[Astronomer]] = true;
+	}
 	// Quest gremlins need IDs because there's multiple
 	desired_monsters[$monster[547]] = true; // erudite gremlin (tool) 
 	desired_monsters[$monster[549]] = true; // batwinged gremlin (tool)


### PR DESCRIPTION
# Description

Peridot astronomer for the single star chart instead of skinflute to set up star / line gathering. If we end up sniffing this monster before getting the star chart, and the user doesn't have any other way of summoning the astronomer or getting a star chart by other means, they are in a bad state.

## How Has This Been Tested?

Hasn't.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
