### PR TITLE
Even if we're forcing a familiar, we shouldn't be ignoring "auto_dontConsumeKeyLimePies"

### DIFF
--- a/RELEASE/scripts/autoscend/auto_acquire.ash
+++ b/RELEASE/scripts/autoscend/auto_acquire.ash
@@ -812,7 +812,7 @@ int handlePulls(int day)
 		{
 			pullXWhenHaveY($item[Bittycar Meatcar], 1, 0);
 		}
-		if((in_picky() || !canChangeFamiliar()) && (item_amount(wrap_item($item[Deck of Every Card])) == 0) && (fullness_left() >= 4))
+		if((in_picky() || !canChangeFamiliar()) && !get_property("auto_dontConsumeKeyLimePies").to_boolean() && (item_amount(wrap_item($item[Deck of Every Card])) == 0) && (fullness_left() >= 4))
 		{
 			if((item_amount($item[Boris\'s Key]) == 0) && canEat($item[Boris\'s Key Lime Pie]) && !contains_text(get_property("nsTowerDoorKeysUsed"), $item[Boris\'s Key]))
 			{


### PR DESCRIPTION

# Description

Currently if you set a familiar, the script will pull these pies because you "can't change familiar"

As to why it thinks I'm 100% a familiar, it's because I'm telling autoscend to level up the yeti. There's probably a better way to do this, but this aspect is a bug regardless. I don't expect the pie to be pulled.

That said, I don't expect all three pies to be pulled immediately either! But that's a whole different issue.


Please include a summary of the change. Pull requests should always be against the [main branch](https://github.com/loathers/autoscend/tree/main).

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

## How Has This Been Tested?

Nein!

## Checklist:

- [X] My code follows the style guidelines of this project.
- [Y] I have performed a self-review of my own code.
- [A] I have commented my code, particularly in hard-to-understand areas.
- [U] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [K] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
- [Q] I am bored