### PR TITLE
Handle legendary digestion

### DIFF
--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -791,7 +791,11 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(1);
 			break;
 		case 1599: // Legendary Digestion: by default use spleen, else take famxp
-			if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0){ run_choice(1); }
+			if (get_property("auto_forceCombatWithLegendaryNoodles").to_boolean()) { 
+				run_choice(2);
+				set_property("auto_forceCombatWithLegendaryNoodles", false);
+				}
+			else if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0){ run_choice(1); }
 			else { run_choice(4); }
 			break;
 		default:

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -790,6 +790,10 @@ boolean auto_run_choice(int choice, string page)
 		case 1566: //Summon a wave
 			run_choice(1);
 			break;
+		case 1599: // Legendary Digestion: by default use spleen, else take famxp
+			if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0){ run_choice(1); }
+			else { run_choice(4); }
+			break;
 		default:
 			break;
 	}

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -791,12 +791,7 @@ boolean auto_run_choice(int choice, string page)
 			run_choice(1);
 			break;
 		case 1599: // Legendary Digestion: if we aren't forcing combat, by default use spleen, else take famxp
-			if (get_property("auto_forceCombatWithLegendaryNoodles").to_boolean()) { 
-				run_choice(2);
-				set_property("auto_forceCombatWithLegendaryNoodles", false);
-				}
-			else if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0){ run_choice(1); }
-			else { run_choice(4); }
+			legendaryNoodlesChoiceHandler();
 			break;
 		default:
 			break;

--- a/RELEASE/scripts/autoscend/auto_choice_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_choice_adv.ash
@@ -790,7 +790,7 @@ boolean auto_run_choice(int choice, string page)
 		case 1566: //Summon a wave
 			run_choice(1);
 			break;
-		case 1599: // Legendary Digestion: by default use spleen, else take famxp
+		case 1599: // Legendary Digestion: if we aren't forcing combat, by default use spleen, else take famxp
 			if (get_property("auto_forceCombatWithLegendaryNoodles").to_boolean()) { 
 				run_choice(2);
 				set_property("auto_forceCombatWithLegendaryNoodles", false);

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -720,6 +720,7 @@ boolean auto_spadeDigSkeleton();
 boolean auto_wantToSpadeDigSkeleton(location loc);
 boolean[location] spadeDelayZones();
 boolean auto_burnRemainingSpadeDigs();
+void legendaryNoodlesChoiceHandler();
 
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -260,3 +260,15 @@ boolean auto_burnRemainingSpadeDigs()
 	}
 	return auto_spadeDigsRemaining()==0;
 }
+
+void legendaryNoodlesChoiceHandler() {
+	// force combats if requested
+	if (get_property("auto_forceCombatWithLegendaryNoodles").to_boolean()) { 
+			run_choice(2);
+			set_property("auto_forceCombatWithLegendaryNoodles", false);
+	}
+	// or use a spleen instead of a stomach
+	else if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0){ run_choice(1); }
+	// take famxp if nothing else
+	else { run_choice(4); }
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -262,13 +262,20 @@ boolean auto_burnRemainingSpadeDigs()
 }
 
 void legendaryNoodlesChoiceHandler() {
+	int target_choice;
 	// force combats if requested
 	if (get_property("auto_forceCombatWithLegendaryNoodles").to_boolean()) { 
-			run_choice(2);
+			target_choice = 2;
 			set_property("auto_forceCombatWithLegendaryNoodles", false);
 	}
 	// or use a spleen instead of a stomach
-	else if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0){ run_choice(1); }
+	else if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0){ target_choice = 1; }
 	// take famxp if nothing else
-	else { run_choice(4); }
+	else { target_choice = 4; }
+
+	// sometimes options 1 and 4 aren't available, so fallback to 5 (double food effects) which always is and shouldn't ever? be detrimental
+	if (available_choice_options() contains target_choice) {
+		run_choice(target_choice);
+	}
+	else {run_choice(5);}
 }


### PR DESCRIPTION
# Description

Handle the Legendary Digestion choice adventure.

Taken from #1743 

## How Has This Been Tested?

Set auto_choice_adv as my choice adv script and ate a legendary dish before starting the script. After taking the spleen option and interrupting, ate another legendary dish. Took stomach option after restarting.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
