### PR TITLE
Legendary noodle fixes: min adv per full and force combat pref reset

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1174,7 +1174,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				potentialTurnGain[it] = 2.0;
 			}
-			else if (legendaryNoodleDishes() contains it && get_property("auto_consumeMinAdvPerFill").to_int() <= 4) {
+			else if (legendaryNoodleDishes() contains it) {
 				// we have the option, after eating the dish, to consume spleen instead 1/day.
 				// which is quite good for minimizing daycount. We want that if it's available (except Ed, who has better spleen).
 				if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0 && auto_willEatLegendaryNoodles() && !isActuallyEd()) {

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1174,7 +1174,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 			{
 				potentialTurnGain[it] = 2.0;
 			}
-			else if (legendaryNoodleDishes() contains it) {
+			else if (legendaryNoodleDishes() contains it && get_property("auto_consumeMinAdvPerFill").to_int() <= 4) {
 				// we have the option, after eating the dish, to consume spleen instead 1/day.
 				// which is quite good for minimizing daycount. We want that if it's available (except Ed, who has better spleen).
 				if (!get_property("_legendaryNoodlesSpleen").to_boolean() && spleen_left() > 0 && auto_willEatLegendaryNoodles() && !isActuallyEd()) {

--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -5231,6 +5231,7 @@ boolean _auto_forceNextCombat(location loc, boolean speculative)
 		auto_forceCombatLegendaryNoodles();
 		if(!auto_haveQueuedForcedCombat())
 		{
+			set_property("auto_forceCombatWithLegendaryNoodles", false);
 			abort("Attempted to force a combat with legendary pasta noodles but was unable to.");
 		}
 		set_property("auto_forceCombatSource", "legendary noodle dish");

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -341,7 +341,7 @@ boolean canEatSomeLegNoods() {
 boolean auto_willEatLegendaryNoodles() {
 	// We exclude small because we want to be careful about maximizing the quality of our food when we only have two space, and we exclude plumber because plumber consumption is weird
 	// Min adv per full filter is set to four because we don't differentiate between the quality of the noodles when we force-eat them, and the "worst" ones average 4 per full (others are 5)
-	return canEatSomeLegNoods() && !get_property("auto_limitConsume").to_boolean() && get_property("auto_consumeMinAdvPerFill").to_int() <= 4 && !in_small() && !in_plumber();
+	return canEatSomeLegNoods() && !get_property("auto_limitConsume").to_boolean() && get_property("auto_consumeMinAdvPerFill").to_float() <= 4.0 && !in_small() && !in_plumber();
 }
 
 boolean auto_legendaryNoodlesAvailable() {

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -340,7 +340,8 @@ boolean canEatSomeLegNoods() {
 
 boolean auto_willEatLegendaryNoodles() {
 	// We exclude small because we want to be careful about maximizing the quality of our food when we only have two space, and we exclude plumber because plumber consumption is weird
-	return canEatSomeLegNoods() && !get_property("auto_limitConsume").to_boolean() && !in_small() && !in_plumber();
+	// Min adv per full filter is set to four because we don't differentiate between the quality of the noodles when we force-eat them, and the "worst" ones average 4 per full (others are 5)
+	return canEatSomeLegNoods() && !get_property("auto_limitConsume").to_boolean() && get_property("auto_consumeMinAdvPerFill").to_int() <= 4 && !in_small() && !in_plumber();
 }
 
 boolean auto_legendaryNoodlesAvailable() {

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -369,7 +369,7 @@ boolean auto_forceCombatLegendaryNoodles() {
 	else {
 		item prospective_dish = auto_findBaseLegendaryNoods();
 		if (prospective_dish != $item[none]) {
-			action = new ConsumeAction(prospective_dish, 0, 1, 5, 10, AUTO_ORGAN_STOMACH, AUTO_OBTAIN_CRAFT);
+			action = new ConsumeAction(prospective_dish, 0, 1, 4, 10, AUTO_ORGAN_STOMACH, AUTO_OBTAIN_CRAFT);
 		}
 		else { return false;}
 	}


### PR DESCRIPTION
# Description
While we wouldn't consume legendary noodles if `auto_consumeMinAdvPerFill` was set to >5 advs due to the check in `auto_autoConsumeOne`, we weren't checking `auto_consumeMinAdvPerFill` beforehand as part of `willEatLegendaryNoodes()`. This probably led to aborting because we expected to force combat. Fixed this. We still might abort for other consumption reasons, but that's intended behavior if that pref is set.

Also found a bug that we weren't resetting the `auto_forceCombatWithLegendaryNoodles` pref before aborting due to failure to force combat, so added a pref reset before the abort.

Special thanks to @libraryaddict for mentioning this to me.

## How Has This Been Tested?

A standard run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
