### PR TITLE
Support Cup of 13s as a once/day drink

### DIFF
--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1468,6 +1468,11 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 		actions[count(actions)] = new ConsumeAction(apronKit, 0, size, adv, adv, AUTO_ORGAN_STOMACH, obtainMethod);
 	}
 
+	// Add cup of 13s if we are looking to drink
+	if(type == AUTO_ORGAN_LIVER && auto_haveCupOf13s() && get_property("_cupOf13sJewels") >= 12 && auto_canMakeCupOf13sDrink()) {
+		actions[count(actions)] = new ConsumeAction($item[Cup of 13s], 0, 1, 12.0, auto_CupOf13sDesirability(), AUTO_ORGAN_LIVER, AUTO_OBTAIN_NULL);
+	}
+
 	// Step 6: Now, to load cafe consumables. This has some TCRS-specific code.
 
 	if(type == AUTO_ORGAN_LIVER && !gnomads_available()) return false;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -164,6 +164,19 @@ boolean autoDrink(int howMany, item toDrink, boolean silent)
 		handleTracker(toDrink, stillsuitAdvs + "Advs", "auto_drunken");
 		return true;
 	}
+	if(toDrink == $item[Cup of 13s])
+	{
+		if(consumeCupOf13s())
+		{
+			handleTracker("Cup of 13s", "12 Advs", "auto_drunken");
+			return true;
+		}
+		else
+		{
+			auto_log_warning("Attempted to drink from the Cup of 13s, but failed.");
+			return false;
+		}
+	}
 	if(item_amount(toDrink) < howMany && !isSpeakeasy)
 	{
 		return false;

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -1483,7 +1483,8 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 
 	// Add cup of 13s if we are looking to drink
 	if(type == AUTO_ORGAN_LIVER && auto_haveCupOf13s() && get_property("_cupOf13sJewels") >= 12 && auto_canMakeCupOf13sDrink()) {
-		actions[count(actions)] = new ConsumeAction($item[Cup of 13s], 0, 1, 12.0, auto_CupOf13sDesirability(), AUTO_ORGAN_LIVER, AUTO_OBTAIN_NULL);
+		// really, it's 12 adventures, not 11.0. But we lose one relative to the other options because ode doesn't apply
+		actions[count(actions)] = new ConsumeAction($item[Cup of 13s], 0, 1, 11.0, auto_CupOf13sDesirability(), AUTO_ORGAN_LIVER, AUTO_OBTAIN_NULL);
 	}
 
 	// Step 6: Now, to load cafe consumables. This has some TCRS-specific code.

--- a/RELEASE/scripts/autoscend/auto_consume.ash
+++ b/RELEASE/scripts/autoscend/auto_consume.ash
@@ -78,7 +78,7 @@ boolean canOde(item toDrink)
 	{
 		return false;
 	}
-	if(toDrink == $item[tiny stillsuit])
+	if(toDrink == $item[tiny stillsuit] || toDrink == $item[Cup of 13s])
 	{
 		return false;
 	}
@@ -929,7 +929,7 @@ boolean autoConsume(ConsumeAction action)
 		abort("ConsumeAction not prepped: " + to_debug_string(action));
 	}
 
-	if (action.organ == AUTO_ORGAN_LIVER && action.it != $item[tiny stillsuit])
+	if (action.organ == AUTO_ORGAN_LIVER && action.it != $item[tiny stillsuit] && action.it != $item[Cup of 13s])
 	{
 		buffMaintain($effect[Ode to Booze], 20, 1, action.size);
 	}
@@ -1483,8 +1483,7 @@ boolean loadConsumables(string _type, ConsumeAction[int] actions)
 
 	// Add cup of 13s if we are looking to drink
 	if(type == AUTO_ORGAN_LIVER && auto_haveCupOf13s() && get_property("_cupOf13sJewels") >= 12 && auto_canMakeCupOf13sDrink()) {
-		// really, it's 12 adventures, not 11.0. But we lose one relative to the other options because ode doesn't apply
-		actions[count(actions)] = new ConsumeAction($item[Cup of 13s], 0, 1, 11.0, auto_CupOf13sDesirability(), AUTO_ORGAN_LIVER, AUTO_OBTAIN_NULL);
+		actions[count(actions)] = new ConsumeAction($item[Cup of 13s], 0, 1, 12.0, auto_CupOf13sDesirability(), AUTO_ORGAN_LIVER, AUTO_OBTAIN_NULL);
 	}
 
 	// Step 6: Now, to load cafe consumables. This has some TCRS-specific code.

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -784,7 +784,7 @@ void finalizeMaximize(boolean speculative)
 		{
 			removeFromMaximize("-equip " + toEquip);
 			// quotes let us handle weird item names (cup of 13s, items with commas)
-			addToMaximize("\"+equip " + toEquip + "\"");
+			addToMaximize("\"equip " + toEquip + "\"");
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -198,9 +198,6 @@ boolean tryAddItemToMaximize(slot s, item it)
 	}
 
 	string itString = it.to_string();
-	// maximizer uses commas, so can't have a comma in an item name
-	// fortunately fuzzy matching means just stripping out the comma is fine
-	itString = itString.replace_string(",", "");
 	set_property(getMaximizeSlotPref(s), itString);
 	return true;
 }
@@ -786,7 +783,8 @@ void finalizeMaximize(boolean speculative)
 		if(toEquip != "")
 		{
 			removeFromMaximize("-equip " + toEquip);
-			addToMaximize("+equip " + toEquip);
+			// quotes let us handle weird item names (cup of 13s, items with commas)
+			addToMaximize("\"+equip " + toEquip + "\"");
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -198,6 +198,9 @@ boolean tryAddItemToMaximize(slot s, item it)
 	}
 
 	string itString = it.to_string();
+	// maximizer uses commas, so can't have a comma in an item name
+	// fortunately fuzzy matching means just stripping out the comma is fine
+	itString = itString.replace_string(",", "");
 	set_property(getMaximizeSlotPref(s), itString);
 	return true;
 }
@@ -783,8 +786,7 @@ void finalizeMaximize(boolean speculative)
 		if(toEquip != "")
 		{
 			removeFromMaximize("-equip " + toEquip);
-			// quotes let us handle weird item names (cup of 13s, items with commas)
-			addToMaximize("\"equip " + toEquip + "\"");
+			addToMaximize("+equip " + toEquip);
 		}
 	}
 

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -735,6 +735,7 @@ boolean auto_haveCupOf13s();
 item[int] auto_pickCupOf13sIngredients();
 boolean auto_canMakeCupOf13sDrink();
 float auto_CupOf13sDesirability();
+boolean auto_acquireCupOf13sIngredients(item[int] ingredients);
 
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -734,6 +734,7 @@ void legendaryNoodlesChoiceHandler();
 boolean auto_haveCupOf13s();
 item[int] auto_pickCupOf13sIngredients();
 boolean auto_canMakeCupOf13sDrink();
+float auto_CupOf13sDesirability();
 
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -736,6 +736,7 @@ item[int] auto_pickCupOf13sIngredients();
 boolean auto_canMakeCupOf13sDrink();
 float auto_CupOf13sDesirability();
 boolean auto_acquireCupOf13sIngredients(item[int] ingredients);
+boolean consumeCupOf13s();
 
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -731,6 +731,7 @@ boolean auto_willEatLegendaryNoodles();
 boolean auto_legendaryNoodlesAvailable();
 boolean auto_forceCombatLegendaryNoodles();
 void legendaryNoodlesChoiceHandler();
+boolean auto_haveCupOf13s();
 
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -732,6 +732,8 @@ boolean auto_legendaryNoodlesAvailable();
 boolean auto_forceCombatLegendaryNoodles();
 void legendaryNoodlesChoiceHandler();
 boolean auto_haveCupOf13s();
+item[int] auto_pickCupOf13sIngredients();
+boolean auto_canMakeCupOf13sDrink();
 
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/iotms/mr2025.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2025.ash
@@ -193,7 +193,8 @@ boolean auto_setLeprecondo()
 
 boolean auto_useLeprecondoDrops()
 {
-	while (available_amount($item[crafting plans])>0 && free_crafts() < 2)
+	// picked 4 as craft threshold due to cup of 13s (as implemented) sometimes wanting up to 3 crafts
+	while (available_amount($item[crafting plans])>0 && free_crafts() < 4)
 	{
 		use($item[crafting plans]);
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -508,7 +508,7 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 
 boolean consumeCupOf13s() {
 	item[int] ing = auto_pickCupOf13sIngredients();
-	auto_log_info(`Consuming a delicious drink of {ing[1]}, {ing[2]}, and {ing[3]} from our Cup of 13s.`)
+	auto_log_info(`Consuming a delicious drink of {ing[1]}, {ing[2]}, and {ing[3]} from our Cup of 13s.`);
 	if (!auto_acquireCupOf13sIngredients(ing)) {return false;}
 	int advs = my_adventures();
 	string url1 = `inventory.php?pwd=${my_hash()}&action=cupof13s`;

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -404,3 +404,10 @@ void legendaryNoodlesChoiceHandler() {
 	}
 	else {run_choice(5);}
 }
+
+boolean auto_haveCupOf13s() {
+	if(auto_is_valid($item[Cup of 13s]) && available_amount($item[Cup of 13s]) > 0 ) {
+		return true;
+	}
+	return false;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -425,7 +425,8 @@ item[int] auto_pickCupOf13sIngredients() {
 	}
 	else {spoon_alt = $item[none];}
 
-	// summon spoons if possible
+	// summon spoons if possible. We do this here because mafia doesn't track how many times we can cast generate irony
+	// Therefore we can't tell how many spoons we have available without actually generating them.
 	while (item_amount($item[spoon]) < 3 && canUse($skill[Generate Irony]) && my_mp() > 30) {
 		useSkill($skill[Generate Irony]);
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -421,7 +421,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	if (knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
 		spoon_alt = $item[dripping meat staff];
 	}
-	else if (my_meat() > 12200 && have_skill($skill[Armorcraftiness]) && isArmoryAndLeggeryStoreAvailable()) {
+	else if ((my_meat() > 12200 || (my_meat() + 5000 > meatReserve() && my_level() >= 11)) && have_skill($skill[Armorcraftiness]) && isArmoryAndLeggeryStoreAvailable()) {
 		spoon_alt = $item[meat shield];
 	}
 	// auto_canMakeCupOf13sDrink() expects that $item[none] is located in slot #3 (at least) of the return value if we were unable to pick an alternative to spoon

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -417,6 +417,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	item spoon_alt;
 	// deciding on which other item we want if spoon isn't available
 	// these items partially come from the meatsmith, but that follows armory and leggery restrictions
+	// these items can be expensive, so we have a meat threshold to probably avoid meat issues
 	if (knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
 		spoon_alt = $item[dripping meat staff];
 	}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -505,3 +505,21 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 	}
 	else {return false;}
 }
+
+boolean consumeCupOf13s() {
+	item[int] ing = auto_pickCupOf13sIngredients();
+	if (!auto_acquireCupOf13sIngredients(ing)) {return false;}
+	int advs = my_adventures();
+  	visit_url(`inventory.php?pwd=${myHash()}&action=cupof13s`);
+  	visit_url(
+    `choice.php?pwd={my_hash()}&whichchoice=1601&option=1` +
+      `&whichitem1={to_int(ing[1])}&whichitem2={to_int(ing[2])}&whichitem3={to_int(ing[3])}`,
+  	);
+
+  	if (advs == my_adventures()) {
+    	visitUrl("main.php");
+		cliExecute("refresh inventory");
+		return false;
+	}
+	return true;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -454,7 +454,8 @@ boolean auto_canMakeCupOf13sDrink() {
 
 float auto_CupOf13sDesirability() {
 	item[int] tentative_ingredients = auto_pickCupOf13sIngredients();
-	float net_adv_gain = 12.0;
+	// really, it's 12 adventures. But we lose one relative to the other options because ode doesn't apply
+	float net_adv_gain = 11.0;
 	for x from 1 to 3 {
 		if (tentative_ingredients[x] == $item[meat shield] && (free_crafts() - x < 1)) {
 			net_adv_gain -= 1;

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -451,3 +451,18 @@ boolean auto_canMakeCupOf13sDrink() {
 	}
 	return true;
 }
+
+float auto_CupOf13sDesirability() {
+	item[int] ingredients = auto_pickCupOf13sIngredients();
+	float net_adv_gain = 12.0;
+	for x from 1 to 3 {
+		if (tentative_ingredients[x] == $item[meat shield] && (free_crafts() - x < 1)) {
+			net_adv_gain -= 1;
+		}
+		else if (tentative_ingredients[x] == $item[meat shield]) {
+			// valuing free crafts at 0.5 adv
+			net_adv_gain -= 0.5;
+		}
+	}
+	return net_adv_gain;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -508,6 +508,7 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 
 boolean consumeCupOf13s() {
 	item[int] ing = auto_pickCupOf13sIngredients();
+	auto_log_info(`Consuming a delicious drink of {ing[1]}, {ing[2]}, and {ing[3]} from our Cup of 13s.`)
 	if (!auto_acquireCupOf13sIngredients(ing)) {return false;}
 	int advs = my_adventures();
 	string url1 = `inventory.php?pwd=${my_hash()}&action=cupof13s`;

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -453,7 +453,7 @@ boolean auto_canMakeCupOf13sDrink() {
 }
 
 float auto_CupOf13sDesirability() {
-	item[int] ingredients = auto_pickCupOf13sIngredients();
+	item[int] tentative_ingredients = auto_pickCupOf13sIngredients();
 	float net_adv_gain = 12.0;
 	for x from 1 to 3 {
 		if (tentative_ingredients[x] == $item[meat shield] && (free_crafts() - x < 1)) {
@@ -471,7 +471,7 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 	// get spoon count
 	int spoon_count = 0;
 	for x from 1 to 3 {
-		if (ing[x] == $item[spoon]) {
+		if (ingredients[x] == $item[spoon]) {
 			spoon_count += 1;
 		}
 	}
@@ -511,8 +511,8 @@ boolean consumeCupOf13s() {
 	if (!auto_acquireCupOf13sIngredients(ing)) {return false;}
 	int advs = my_adventures();
 	string url1 = `inventory.php?pwd=${my_hash()}&action=cupof13s`;
-	string url2 = `choice.php?pwd={my_hash()}&whichchoice=1601&option=1`
-	string url3 = `&whichitem1={to_int(ing[1])}&whichitem2={to_int(ing[2])}&whichitem3={to_int(ing[3])}`
+	string url2 = `choice.php?pwd={my_hash()}&whichchoice=1601&option=1`;
+	string url3 = `&whichitem1={to_int(ing[1])}&whichitem2={to_int(ing[2])}&whichitem3={to_int(ing[3])}`;
   	visit_url(url1);
   	visit_url(url2 + url3);
 

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -466,3 +466,42 @@ float auto_CupOf13sDesirability() {
 	}
 	return net_adv_gain;
 }
+
+boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
+	// get spoon count
+	int spoon_count = 0;
+	for x from 1 to 3 {
+		if (ing[x] == $item[spoon]) {
+			spoon_count += 1;
+		}
+	}
+	// make sure we have enough. Spoons are gotten elsewhere.
+	if (item_amount($item[spoon]) < spoon_count) {
+		return false;
+	}
+	// if we're only using spoons for our drink, we don't need to get any other ingredients
+	if (spoon_count > 2) {
+		return true;
+	}
+
+	// alt as in alternative to spoon (not that we expect spoon-having)
+	item alt = ingredients[3];
+	int alt_count = 3 - spoon_count;
+	if (alt == $item[meat shield]) {
+		return (
+			auto_buyUpTo(alt_count, $item[buckler buckle]) &&
+			cli_execute(`make {alt_count} dense meat stack`) &&
+			autoCraft("smith", alt_count, $item[buckler buckle], $item[dense meat stack]) >= alt_count
+		);
+	}
+	else if (alt == $item[dripping meat staff]) {
+		return (
+			auto_buyUpTo(alt_count, $item[big stick]) &&
+			cli_execute(`make {alt_count} meat stack`) &&
+			auto_hermit(alt_count, $item`ketchup`) &&
+			autoCraft("smith", alt_count, $item[big stick], $item[meat stack]) >= alt_count &&
+			autoCraft("smith", alt_count, $item[basic meat staff], $item[ketchup]) >= alt_count
+		);
+	}
+	else {return false;}
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -411,3 +411,43 @@ boolean auto_haveCupOf13s() {
 	}
 	return false;
 }
+
+item[int] auto_pickCupOf13sIngredients() {
+	item spoon = $item[spoon];
+	item spoon_alt;
+	// deciding on which other item we want if spoon isn't available
+	// these items partially come from the meatsmith, but that follows armory and leggery restrictions
+	if (knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
+		spoon_alt = $item[dripping meat staff];
+	}
+	else if (my_meat() > 12200 && have_skill($skill[Armorcrafting]) && isArmoryAndLeggeryStoreAvailable()) {
+		spoon_alt = $item[meat shield];
+	}
+	else {spoon_alt = $item[none];}
+
+	// summon spoons if possible
+	while (item_amount($item[spoon]) < 3 && canUse($skill[Generate Irony]) && my_mp() > 30) {
+		useSkill($skill[Generate Irony]);
+	}
+
+	item[int] cup_ingredients;
+	for x from 1 to 3 {
+		if (item_amount(spoon) >= x) {
+			cup_ingredients[x] = spoon;
+		}
+		else {
+			cup_ingredients[x] = spoon_alt;
+		}
+	}
+	return cup_ingredients;
+}
+
+// answers the question of "are supported ingredients available"
+boolean auto_canMakeCupOf13sDrink() {
+	if (!auto_haveCupOf13s() || in_small()) {return false;} // taken from irrat's fork, using just in case we don't get 10x adv in small
+	item[int] tentative_ingredients = auto_pickCupOf13sIngredients();
+	if (tentative_ingredients[3] == $item[none]) {
+		return false;
+	}
+	return true;
+}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -424,6 +424,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	else if (my_meat() > 12200 && have_skill($skill[Armorcraftiness]) && isArmoryAndLeggeryStoreAvailable()) {
 		spoon_alt = $item[meat shield];
 	}
+	// auto_canMakeCupOf13sDrink() expects that $item[none] is located in slot #3 (at least) of the return value if we were unable to pick an alternative to spoon
 	else {spoon_alt = $item[none];}
 
 	// summon spoons if possible. We do this here because mafia doesn't track how many times we can cast generate irony
@@ -460,6 +461,7 @@ float auto_CupOf13sDesirability() {
 	float net_adv_gain = 11.0;
 	for x from 1 to 3 {
 		if (tentative_ingredients[x] == $item[meat shield] && (free_crafts() - x < 1)) {
+			// if we have to craft or use our last free craft, we value this drink 1 adv less.
 			net_adv_gain -= 1;
 		}
 		else if (tentative_ingredients[x] == $item[meat shield]) {
@@ -488,6 +490,8 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 	}
 
 	// alt as in alternative to spoon (not that we expect spoon-having)
+	// Note: auto_pickCupOf13sIngredients() puts x spoons in slots 1 to x and 3-x alternative ingredients in slots 3-x to 3.
+	// This code assumes that, so it will need modified if auto_pickCupOf13Ingredients() is modified to support other ingredients.
 	item alt = ingredients[3];
 	int alt_count = 3 - spoon_count;
 	if (alt == $item[meat shield]) {
@@ -510,6 +514,7 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 }
 
 boolean consumeCupOf13s() {
+	// below code is based on Irrat's fork
 	item[int] ing = auto_pickCupOf13sIngredients();
 	auto_log_info(`Consuming a delicious drink of {ing[1]}, {ing[2]}, and {ing[3]} from our Cup of 13s.`);
 	if (!auto_acquireCupOf13sIngredients(ing)) {return false;}

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -420,7 +420,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	if (knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
 		spoon_alt = $item[dripping meat staff];
 	}
-	else if (my_meat() > 12200 && have_skill($skill[Armorcrafting]) && isArmoryAndLeggeryStoreAvailable()) {
+	else if (my_meat() > 12200 && have_skill($skill[Armorcraftiness]) && isArmoryAndLeggeryStoreAvailable()) {
 		spoon_alt = $item[meat shield];
 	}
 	else {spoon_alt = $item[none];}
@@ -498,7 +498,7 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 		return (
 			auto_buyUpTo(alt_count, $item[big stick]) &&
 			cli_execute(`make {alt_count} meat stack`) &&
-			auto_hermit(alt_count, $item`ketchup`) &&
+			auto_hermit(alt_count, $item[ketchup]) &&
 			autoCraft("smith", alt_count, $item[big stick], $item[meat stack]) >= alt_count &&
 			autoCraft("smith", alt_count, $item[basic meat staff], $item[ketchup]) >= alt_count
 		);
@@ -510,15 +510,15 @@ boolean consumeCupOf13s() {
 	item[int] ing = auto_pickCupOf13sIngredients();
 	if (!auto_acquireCupOf13sIngredients(ing)) {return false;}
 	int advs = my_adventures();
-  	visit_url(`inventory.php?pwd=${myHash()}&action=cupof13s`);
-  	visit_url(
-    `choice.php?pwd={my_hash()}&whichchoice=1601&option=1` +
-      `&whichitem1={to_int(ing[1])}&whichitem2={to_int(ing[2])}&whichitem3={to_int(ing[3])}`,
-  	);
+	string url1 = `inventory.php?pwd=${my_hash()}&action=cupof13s`;
+	string url2 = `choice.php?pwd={my_hash()}&whichchoice=1601&option=1`
+	string url3 = `&whichitem1={to_int(ing[1])}&whichitem2={to_int(ing[2])}&whichitem3={to_int(ing[3])}`
+  	visit_url(url1);
+  	visit_url(url2 + url3);
 
   	if (advs == my_adventures()) {
-    	visitUrl("main.php");
-		cliExecute("refresh inventory");
+    	visit_url("main.php");
+		cli_execute("refresh inventory");
 		return false;
 	}
 	return true;

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -432,7 +432,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	else {spoon_alt = $item[none];}
 
 	int speculative_spoons = get_property("skillLevel245").to_int() - get_property("_generateIronyUsed").to_int() + item_amount($item[spoon]);
-	if (my_mp() < 50) {speculative_spoons = 0;}
+	if (my_mp() < 50 || !auto_is_valid($skill[Generate Irony])) {speculative_spoons = 0;}
 
 	item[int] cup_ingredients;
 	for x from 1 to 3 {

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -491,6 +491,13 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 		return true;
 	}
 
+	// warn users that might not have the spoon pref set up right
+	if (canUse($skill[Generate Irony]) && my_mp() > 50) {
+		auto_log_warning("Autoscend has detected that the \"skillLevel245\" property does not match the number of times you can cast \"Generate Irony\" per day");
+		auto_log_warning("Run \"set skillLevel245=[correct # here]\" in the gCLI to fix this\"");
+	}
+
+
 	// alt as in alternative to spoon (not that we expect spoon-having)
 	// Note: auto_pickCupOf13sIngredients() puts x spoons in slots 1 to x and 3-x alternative ingredients in slots 3-x to 3.
 	// This code assumes that, so it will need modified if auto_pickCupOf13Ingredients() is modified to support other ingredients.

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -421,7 +421,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	if (item_amount($item[dripping meat staff]) >= 3 || knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
 		spoon_alt = $item[dripping meat staff];
 	}
-	else if (item_amount($item[meat shield]) >= 3 || isArmoryAndLeggeryStoreAvailable() && (my_meat() > 12200 || (my_meat() > meatReserve() + 5000 && my_level() >= 11)) && have_skill($skill[Armorcraftiness])) {
+	else if (item_amount($item[meat shield]) >= 3 || !knoll_available() && isArmoryAndLeggeryStoreAvailable() && (my_meat() > 12200 || (my_meat() > meatReserve() + 5000 && my_level() >= 11)) && have_skill($skill[Armorcraftiness])) {
 		spoon_alt = $item[meat shield];
 	}
 	// auto_canMakeCupOf13sDrink() expects that $item[none] is located in slot #3 (at least) of the return value if we were unable to pick an alternative to spoon

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -421,7 +421,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	if (item_amount($item[dripping meat staff]) >= 3 || knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
 		spoon_alt = $item[dripping meat staff];
 	}
-	else if (item_amount($item[meat shield]) >= 3 || isArmoryAndLeggeryStoreAvailable() && (my_meat() > 12200 || (my_meat() + 5000 > meatReserve() && my_level() >= 11)) && have_skill($skill[Armorcraftiness])) {
+	else if (item_amount($item[meat shield]) >= 3 || isArmoryAndLeggeryStoreAvailable() && (my_meat() > 12200 || (my_meat() > meatReserve() + 5000 && my_level() >= 11)) && have_skill($skill[Armorcraftiness])) {
 		spoon_alt = $item[meat shield];
 	}
 	// auto_canMakeCupOf13sDrink() expects that $item[none] is located in slot #3 (at least) of the return value if we were unable to pick an alternative to spoon

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -427,15 +427,12 @@ item[int] auto_pickCupOf13sIngredients() {
 	// auto_canMakeCupOf13sDrink() expects that $item[none] is located in slot #3 (at least) of the return value if we were unable to pick an alternative to spoon
 	else {spoon_alt = $item[none];}
 
-	// summon spoons if possible. We do this here because mafia doesn't track how many times we can cast generate irony
-	// Therefore we can't tell how many spoons we have available without actually generating them.
-	while (item_amount($item[spoon]) < 3 && canUse($skill[Generate Irony]) && my_mp() > 30) {
-		useSkill($skill[Generate Irony]);
-	}
+	int speculative_spoons = get_property("skillLevel245").to_int() - get_property("_generateIronyUsed").to_int() + item_amount($item[spoon]);
+	if (my_mp() < 50) {speculative_spoons = 0;}
 
 	item[int] cup_ingredients;
 	for x from 1 to 3 {
-		if (item_amount(spoon) >= x) {
+		if (speculative_spoons >= x) {
 			cup_ingredients[x] = spoon;
 		}
 		else {
@@ -477,7 +474,12 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 	int spoon_count = 0;
 	for x from 1 to 3 {
 		if (ingredients[x] == $item[spoon]) {
-			spoon_count += 1;
+			if (canUse($skill[Generate Irony]) && my_mp() > 30 && useSkill($skill[Generate Irony])) {
+				spoon_count += 1;
+			}
+			else {
+				auto_log_warning("Failure to get a spoon (ironic, right?)");
+			}
 		}
 	}
 	// make sure we have enough. Spoons are gotten elsewhere.

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -474,18 +474,16 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 	int spoon_count = 0;
 	for x from 1 to 3 {
 		if (ingredients[x] == $item[spoon]) {
-			if (canUse($skill[Generate Irony]) && my_mp() > 30 && use_skill(1, $skill[Generate Irony])) {
-				spoon_count += 1;
-			}
-			else {
-				auto_log_warning("Failure to get a spoon (ironic, right?)");
-			}
+			spoon_count += 1;
 		}
 	}
-	// make sure we have enough. Spoons are gotten elsewhere.
-	if (item_amount($item[spoon]) < spoon_count) {
-		return false;
+	while (item_amount($item[spoon]) < spoon_count) {
+		if (!(canUse($skill[Generate Irony]) && my_mp() > 30 && use_skill(1, $skill[Generate Irony]))) {
+			auto_log_warning("Failure to get a spoon (ironic, right?)");
+			return false;
+		}
 	}
+	
 	// if we're only using spoons for our drink, we don't need to get any other ingredients
 	if (spoon_count > 2) {
 		return true;

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -422,6 +422,10 @@ item[int] auto_pickCupOf13sIngredients() {
 		spoon_alt = $item[dripping meat staff];
 	}
 	else if (item_amount($item[meat shield]) >= 3 || !knoll_available() && isArmoryAndLeggeryStoreAvailable() && (my_meat() > 12200 || (my_meat() > meatReserve() + 5000 && my_level() >= 11)) && have_skill($skill[Armorcraftiness])) {
+		if((item_amount($item[Tenderizing Hammer]) == 0) && ((my_meat() >= (npc_price($item[Tenderizing Hammer]) * 2)) && (npc_price($item[Tenderizing Hammer]) != 0)))
+			{
+				auto_buyUpTo(1, $item[Tenderizing Hammer]);
+			}
 		spoon_alt = $item[meat shield];
 	}
 	// auto_canMakeCupOf13sDrink() expects that $item[none] is located in slot #3 (at least) of the return value if we were unable to pick an alternative to spoon

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -493,13 +493,6 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 		return true;
 	}
 
-	// warn users that might not have the spoon pref set up right
-	if (canUse($skill[Generate Irony]) && my_mp() > 50) {
-		auto_log_warning("Autoscend has detected that the \"skillLevel245\" property does not match the number of times you can cast \"Generate Irony\" per day");
-		auto_log_warning("Run \"set skillLevel245=[correct # here]\" in the gCLI to fix this\"");
-	}
-
-
 	// alt as in alternative to spoon (not that we expect spoon-having)
 	// Note: auto_pickCupOf13sIngredients() puts x spoons in slots 1 to x and 3-x alternative ingredients in slots 3-x to 3.
 	// This code assumes that, so it will need modified if auto_pickCupOf13Ingredients() is modified to support other ingredients.

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -474,7 +474,7 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 	int spoon_count = 0;
 	for x from 1 to 3 {
 		if (ingredients[x] == $item[spoon]) {
-			if (canUse($skill[Generate Irony]) && my_mp() > 30 && useSkill($skill[Generate Irony])) {
+			if (canUse($skill[Generate Irony]) && my_mp() > 30 && use_skill(1, $skill[Generate Irony])) {
 				spoon_count += 1;
 			}
 			else {

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -418,10 +418,10 @@ item[int] auto_pickCupOf13sIngredients() {
 	// deciding on which other item we want if spoon isn't available
 	// these items partially come from the meatsmith, but that follows armory and leggery restrictions
 	// these items can be expensive, so we have a meat threshold to probably avoid meat issues
-	if (knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
+	if (item_amount($item[dripping meat staff]) >= 3 || knoll_available() && isHermitAvailable() && isArmoryAndLeggeryStoreAvailable() && my_meat() > 7200) {
 		spoon_alt = $item[dripping meat staff];
 	}
-	else if ((my_meat() > 12200 || (my_meat() + 5000 > meatReserve() && my_level() >= 11)) && have_skill($skill[Armorcraftiness]) && isArmoryAndLeggeryStoreAvailable()) {
+	else if (item_amount($item[meat shield]) >= 3 || isArmoryAndLeggeryStoreAvailable() && (my_meat() > 12200 || (my_meat() + 5000 > meatReserve() && my_level() >= 11)) && have_skill($skill[Armorcraftiness])) {
 		spoon_alt = $item[meat shield];
 	}
 	// auto_canMakeCupOf13sDrink() expects that $item[none] is located in slot #3 (at least) of the return value if we were unable to pick an alternative to spoon
@@ -501,6 +501,9 @@ boolean auto_acquireCupOf13sIngredients(item[int] ingredients) {
 	// This code assumes that, so it will need modified if auto_pickCupOf13Ingredients() is modified to support other ingredients.
 	item alt = ingredients[3];
 	int alt_count = 3 - spoon_count;
+	if (item_amount(alt) >= alt_count) {
+		return true;
+	}
 	if (alt == $item[meat shield]) {
 		return (
 			auto_buyUpTo(alt_count, $item[buckler buckle]) &&


### PR DESCRIPTION
# Description

Implements Cup of 13s as pure turnbloat--using spoon, dripping meat staff, and/or meat shield to create a 12 adv drink, net 9-12 advs depending on crafting. In effect this makes it 1/day because we use 12 of the 13 gems to do this.

Could be implemented to use more drunkenness and/or take advantage of the effects and/or use more ingredients (probably by someone else), but this is good enough for me.

## How Has This Been Tested?

Not yet, will probably be tested along with #1753 in a combined (separate) testing branch.

Edit: Tested over a few standard runs

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
