### PR TITLE
fix: set autoSettings() before potentially aborting

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -2092,6 +2092,8 @@ boolean doTasks()
 
 void auto_begin()
 {
+	auto_settings();
+
 	if(get_auto_attack() != 0)
 	{
 		boolean shouldUnset = user_confirm("You have an auto attack enabled. This can cause issues. Would you like us to disable it? Will default to 'No' in 30 seconds.", 30000, false);
@@ -2150,8 +2152,6 @@ void auto_begin()
 	auto_log_info("You have: " + banishSources() + " banish sources, " + freeRunSources() + " free-run sources, " +
 	freeKillSources() + " free kill sources, " + instaKillSources() + " insta-kill sources, " + yellowRaySources() +
 	" yellow ray sources, " + copySources() + " copy sources, and " + sniffSources() + " sniff sources.");
-
-	auto_settings();
 
 	backupSetting("promptAboutCrafting", 0);
 	backupSetting("requireBoxServants", false);


### PR DESCRIPTION
# Description

This ensures auto_log_level is set to a value that will log warnings for a user running the script for the first time.

## How Has This Been Tested?

Untested.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
