### PR TITLE
Update florist availability check in oldPeoplePlantStuff

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2013.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2013.ash
@@ -108,7 +108,7 @@ void trickMafiaAboutFlorist()
 
 void oldPeoplePlantStuff()
 {
-	if(!florist_available())
+	if(!get_property("floristFriarAvailable").to_boolean())
 	{
 		return;
 	}


### PR DESCRIPTION

# Description

As of a few kolmafia builds ago, the function `florist_available()` performs a http request in certain situations. It may be a bug, but this seems like a quick solution to check the pref instead.

https://github.com/kolmafia/kolmafia/pull/3595


Fixes # (issue)

## How Has This Been Tested?

Eyes

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
