### PR TITLE
Blue vs red init

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r29089; //  last legendaries [noodle dishes]
+since r29167; // Blue vs. Red path and team pick
 
 /***
 	autoscend_header.ash must be first import
@@ -310,6 +310,7 @@ void initializeSettings() {
 	wereprof_initializeSettings();
 	ag_initializeSettings();
 	amw_initializeSettings();
+	bluevsred_initializeSettings();
 
 	set_property("auto_doneInitializePath", my_path().name);		//which path we initialized as
 	set_property("auto_doneInitialize", my_ascensions());

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -1269,6 +1269,13 @@ boolean rightKickHasInstaKill();
 boolean LX_zootoFight();
 
 ########################################################################################################
+//Defined in autoscend/paths/blue_vs_read.ash
+boolean in_bluevsred();
+boolean bluevsred_isBlue();
+boolean bluevsred_isRed();
+boolean bluevsred_initializeSettings();
+
+########################################################################################################
 //Defined in autoscend/quests/level_01.ash
 void tootOriole();
 void tootGetMeat();

--- a/RELEASE/scripts/autoscend/paths/blue_vs_red.ash
+++ b/RELEASE/scripts/autoscend/paths/blue_vs_red.ash
@@ -1,0 +1,26 @@
+boolean in_bluevsred()
+{
+	return my_path() == $path[Blue vs. Red];
+}
+
+boolean bluevsred_isBlue()
+{
+	return in_bluevsred() && get_property("blueVsRedTeam") == "blue";
+}
+
+boolean bluevsred_isRed()
+{
+	return in_bluevsred() && get_property("blueVsRedTeam") == "red";
+}
+
+void bluevsred_initializeSettings()
+{
+	if(!in_bluevsred())
+	{
+		return;
+	}
+	set_property("auto_wandOfNagamar", false);		//wand not used in this path
+
+	// TODO: Remove when quest handling is correct.
+	set_property("auto_paranoia", 1);
+}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1414,6 +1414,23 @@ boolean L11_aridDesert()
 
 		autoAdv(1, $location[The Arid\, Extra-Dry Desert]);
 
+		if (in_bluevsred())
+		{
+			// TODO: desertExploration tracking is currently not working for the same team noncombats
+			int initial = get_property("desertExploration").to_int();
+			string page = visit_url("place.php?whichplace=desertbeach");
+			matcher desert_matcher = create_matcher("title=\"[(](\\d+)% explored[)]\"", page);
+			if(desert_matcher.find())
+			{
+				int found = to_int(desert_matcher.group(1));
+				if(found != initial)
+				{
+					auto_log_info("Incorrectly had exploration value of " + initial + " when it should be at " + found + ". This was corrected. Trying to resume.", "blue");
+					set_property("desertExploration", found);
+				}
+			}
+		}
+
 		if(contains_text(get_property("lastEncounter"), "A Sietch in Time"))
 		{
 			auto_log_info("We've found the gnome!! Sightseeing pamphlets for everyone!", "green");


### PR DESCRIPTION
# Description

Basic init for Blue Vs Red

- need to set auto_paranoia until council quest tracking is working
- desertExploration is not counting correctly for the non-combats
- don't need a wand

Fixes # (issue)

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
