### PR TITLE
Blue vs. Red: Go for crumbling wooden wheels

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3524,7 +3524,7 @@ boolean L11_unlockEd()
 		if(!get_property("controlRoomUnlock").to_boolean())
 		{
 			// Blue team can't fight tomb rats
-			if (bluevsred_isRed() && total < 10)
+			if(bluevsred_isRed() && total < 10)
 			{
 				provideItem(400, $location[The Middle Chamber], true);
 			}

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3517,10 +3517,21 @@ boolean L11_unlockEd()
 		}
 		return true;
 	}
-	if(total < 10)
+
+	// Crumbling wooden wheels are more consistent for Blue vs. Red
+	if(in_bluevsred())
 	{
-		// tomb ratchets have 20% drop rate
-		provideItem(400, $location[The Middle Chamber], true);
+		if(!get_property("controlRoomUnlock").to_boolean())
+		{
+			// Blue team can't fight tomb rats
+			if (bluevsred_isRed() && total < 10)
+			{
+				provideItem(400, $location[The Middle Chamber], true);
+			}
+			autoAdv(1, $location[The Middle Chamber])
+		}
+		providePlusNonCombat(auto_combatModCap(), $location[The Upper Chamber], true);
+		return autoAdv(1, $location[The Upper Chamber]);
 	}
 
 	if(get_property("controlRoomUnlock").to_boolean())
@@ -3529,6 +3540,12 @@ boolean L11_unlockEd()
 		{
 			return autoAdv(1, $location[The Upper Chamber]);
 		}
+	}
+
+	if(total < 10)
+	{
+		// tomb ratchets have 20% drop rate
+		provideItem(400, $location[The Middle Chamber], true);
 	}
 
 	if (canSniff($monster[Tomb Rat], $location[The Middle Chamber]) && auto_mapTheMonsters())

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -3528,7 +3528,7 @@ boolean L11_unlockEd()
 			{
 				provideItem(400, $location[The Middle Chamber], true);
 			}
-			autoAdv(1, $location[The Middle Chamber])
+			autoAdv(1, $location[The Middle Chamber]);
 		}
 		providePlusNonCombat(auto_combatModCap(), $location[The Upper Chamber], true);
 		return autoAdv(1, $location[The Upper Chamber]);


### PR DESCRIPTION
# Description

Crumbling wooden wheels should be more consistent for Blue vs. Red regardless of team

Fixes # (issue)

## How Has This Been Tested?

Tested with blue team

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [x] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
