### PR TITLE
fix: mafia support for blue vs. red updated

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r29167; // Blue vs. Red path and team pick
+since r29170; // feat: update quest progress on Blue vs Red NC
 
 /***
 	autoscend_header.ash must be first import

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -1,4 +1,4 @@
-since r29170; // feat: update quest progress on Blue vs Red NC
+since r29171; // BvR: War Progress from NCs
 
 /***
 	autoscend_header.ash must be first import

--- a/RELEASE/scripts/autoscend/paths/blue_vs_red.ash
+++ b/RELEASE/scripts/autoscend/paths/blue_vs_red.ash
@@ -21,9 +21,6 @@ void bluevsred_initializeSettings()
 	}
 	set_property("auto_wandOfNagamar", false);		//wand not used in this path
 
-	// TODO: Remove when quest handling is correct.
-	set_property("auto_paranoia", 1);
-
 	if (bluevsred_isRed())
 	{
 		set_property("auto_hippyInstead", true);

--- a/RELEASE/scripts/autoscend/quests/level_11.ash
+++ b/RELEASE/scripts/autoscend/quests/level_11.ash
@@ -1414,23 +1414,6 @@ boolean L11_aridDesert()
 
 		autoAdv(1, $location[The Arid\, Extra-Dry Desert]);
 
-		if (in_bluevsred())
-		{
-			// TODO: desertExploration tracking is currently not working for the same team noncombats
-			int initial = get_property("desertExploration").to_int();
-			string page = visit_url("place.php?whichplace=desertbeach");
-			matcher desert_matcher = create_matcher("title=\"[(](\\d+)% explored[)]\"", page);
-			if(desert_matcher.find())
-			{
-				int found = to_int(desert_matcher.group(1));
-				if(found != initial)
-				{
-					auto_log_info("Incorrectly had exploration value of " + initial + " when it should be at " + found + ". This was corrected. Trying to resume.", "blue");
-					set_property("desertExploration", found);
-				}
-			}
-		}
-
 		if(contains_text(get_property("lastEncounter"), "A Sietch in Time"))
 		{
 			auto_log_info("We've found the gnome!! Sightseeing pamphlets for everyone!", "green");


### PR DESCRIPTION
# Description

Require a Mafia version that supports council text + NC quest updates in Blue vs. Red, remove auto_paranoia.

## How Has This Been Tested?

Hasn't.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
