### PR TITLE
Consider doing flyers for hippy

### DIFF
--- a/RELEASE/scripts/autoscend/auto_routing.ash
+++ b/RELEASE/scripts/autoscend/auto_routing.ash
@@ -216,6 +216,17 @@ boolean auto_earlyRoutingHandling()
 		// Just make sure the other two quests are started too
 		visit_url("bigisland.php?place=lighthouse&action=pyro&pwd");
 		visit_url("bigisland.php?action=junkman&pwd");
+		return true;
+	}
+	
+	// Check we have flyers if war hippy and war is progressed, first because takes no turns.
+	if(!in_koe() && internalQuestStatus("questL12War") == 1 && get_property("auto_hippyInstead").to_boolean() &&
+	  (get_property("fratboysDefeated").to_int() >= 458) &&
+	  get_property("sidequestArenaCompleted")!="hippy" && available_amount($item[jam band flyers])==0)
+	{
+		outfit("war hippy fatigues"); // don't use the equipOutfit func here since this is just temporary, we don't want to adventure like this.
+		visit_url("bigisland.php?place=concert&pwd");
+		return true;
 	}
 
 	// force forcing non-combats.

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -292,10 +292,6 @@ WarPlan auto_bestWarPlan()
 	{
 		considerArena = false;
 	}
-	if(auto_warSide() == "hippy")		//arena not implemented for hippies yet. TODO implement it then remove this
-	{
-		considerArena = false;
-	}
 	if(get_property("auto_skipNuns").to_boolean())
 	{
 		considerNuns = false;
@@ -1692,6 +1688,11 @@ boolean L12_flyerFinish()
 	if(robot_delay("outfit"))
 	{
 		return false;	//delay for You, Robot path
+	}
+	//Does hippy side have access to arena yet?
+	if (get_property("auto_hippyInstead").to_boolean() && (get_property("fratboysDefeated").to_int() < 458))
+	{
+		return false;
 	}
 	
 	auto_log_info("Done with this Flyer crap", "blue");

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1618,6 +1618,11 @@ boolean L12_lastDitchFlyer()
 	{
 		return false;		//let the powerlevel lock release first so we can do quests that are waiting for optimal conditions.
 	}
+	//Does hippy side have access to arena yet?
+	if (get_property("auto_hippyInstead").to_boolean() && (get_property("fratboysDefeated").to_int() < 458))
+	{
+		return false;
+	}
 
 	auto_log_info("Not enough flyer ML but we are ready for the war... uh oh", "blue");
 	if(LX_freeCombats(true)) return true;	//try to use free combats to make up the difference.


### PR DESCRIPTION
# Description

Fixes logic that was preventing doing war hippy flyers

Fixes # (issue)

## How Has This Been Tested?

Works in a Blue vs Red Red Team run

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
