### PR TITLE
feat: throw interesting coin to free kill

### DIFF
--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -731,6 +731,7 @@ boolean auto_willEatLegendaryNoodles();
 boolean auto_legendaryNoodlesAvailable();
 boolean auto_forceCombatLegendaryNoodles();
 void legendaryNoodlesChoiceHandler();
+boolean wantToThrowInterestingCoin(location loc, monster enemy);
 
 
 ########################################################################################################

--- a/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_default_stage2.ash
@@ -168,6 +168,13 @@ string auto_combatDefaultStage2(int round, monster enemy, string text)
 		}
 	}
 	
+	//throw interesting coin to free kill the enemy but don't get any items
+	if(canUse($item[interesting coin]) && wantToThrowInterestingCoin(my_location(), enemy))
+	{
+		handleTracker(enemy, $item[interesting coin], "auto_instakill");
+		return useItem($item[interesting coin]);
+	}
+
 	//throw gravel to free kill the enemy but don't get any items
 	if(wantToThrowGravel(my_location(), enemy))
 	{

--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -404,3 +404,13 @@ void legendaryNoodlesChoiceHandler() {
 	}
 	else {run_choice(5);}
 }
+
+boolean wantToThrowInterestingCoin(location loc, monster enemy)
+{
+	if(item_amount($item[interesting coin]) == 0) return false;
+	if(!auto_is_valid($item[interesting coin])) return false;
+	if(get_property("_interestingCoinHeads").to_boolean()) return false;
+	if (isFreeMonster(enemy, loc)) { return false; } // don't use coin against inherently free fights
+	
+	return auto_wantToFreeKillWithNoDrops(loc, enemy);
+}


### PR DESCRIPTION
# Description

Use interesting coin once per day to free kill.

Not consumed in combat, once per day, destroys drops (and meat, unlike
gravel, but I think it's okay to use the same function because we mostly
don't care about meat).

## How Has This Been Tested?

One run, worked as expected.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
