### PR TITLE
Avoid friars if we're forcing a NC, which isn't ready yet

### DIFF
--- a/RELEASE/scripts/autoscend/quests/level_06.ash
+++ b/RELEASE/scripts/autoscend/quests/level_06.ash
@@ -44,17 +44,22 @@ boolean L6_friarsGetParts()
 			handleFamiliar($familiar[Robortender]);
 		}
 	}
-	
+
+	location forced_loc = to_location(get_property("auto_forceNonCombatLocation"));
+	boolean forced_here = $locations[The Dark Neck of the Woods, The Dark Elbow of the Woods, The Dark Heart of the Woods] contains forced_loc;
+	// If we're about to force a non-combat, but it's not ready yet
+	if (forced_here && !auto_haveQueuedForcedNonCombat()) {
+		return false;
+	}
+
 	// Don't burn all our NC forces early on d1 unless we are running low on turns.
-	if(my_daycount() == 1 && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean())
+	if(!forced_here && my_daycount() == 1 && !isAboutToPowerlevel() && !get_property("auto_getSteelOrgan").to_boolean())
 	{
-		location forced_loc = to_location(get_property("auto_forceNonCombatLocation"));
-		boolean forced_here = $locations[The Dark Neck of the Woods, The Dark Elbow of the Woods, The Dark Heart of the Woods] contains forced_loc;
 		boolean running_low_on_turns = auto_roughExpectedTurnsLeftToday() < 10 + turnsUsedByRemainingNCForcesToday();
 		// Probably need to make sure we still have other stuff to do? Softblock?
 		// Could probably then make this run every day.
 		int total_daily_forces = baseNCForcesToday();
-		if(!forced_here && total_daily_forces > 0 && !running_low_on_turns)
+		if(total_daily_forces > 0 && !running_low_on_turns)
 		{
 			auto_log_debug("Friars: delaying to save NC forces for later today.", "blue");
 			return false;


### PR DESCRIPTION
# Description

Currently the script will burn a turn setting up a forced non-combat, in the very place it's going to force a non-combat.

This effects other files. [Search repo for `auto_forceNextNoncombat`](https://github.com/search?q=repo%3Aloathers/autoscend%20auto_forceNextNoncombat&type=code)

It only effects them when they are ready to be called in the normal task order.
The one side effect I can think of, is that this isn't going to play well if there are no other tasks available.

Also potentially the ability to add in `turnsUntilForcedNoncombat` which kolmafia now exposes, to consider if should be forcing a NC, but that's out of scope.

## How Has This Been Tested?

Unfortunately this was not tested as the changes I made were on my own fork, this is more of a demostration of the issue, if someone else wants to properly fix it. I'm happy for them to make the changes in their own PR and this one to be closed.