### PR TITLE
Fix regex in usedCount functions for skills and items

### DIFF
--- a/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
+++ b/RELEASE/scripts/autoscend/combat/auto_combat_util.ash
@@ -17,7 +17,7 @@ boolean haveUsed(item it)
 
 int usedCount(skill sk)
 {
-	matcher m = create_matcher("(sk" + sk.to_int().to_string() + ")", get_property("_auto_combatState"));
+	matcher m = create_matcher("\\(sk" + sk.to_int().to_string() + "\\)", get_property("_auto_combatState"));
 	int count = 0;
 	while(m.find())
 	{
@@ -28,7 +28,7 @@ int usedCount(skill sk)
 
 int usedCount(item it)
 {
-	matcher m = create_matcher("(it" + it.to_int().to_string() + ")", get_property("_auto_combatState"));
+	matcher m = create_matcher("\\(it" + it.to_int().to_string() + "\\)", get_property("_auto_combatState"));
 	int count = 0;
 	while(m.find())
 	{


### PR DESCRIPTION
Previously it was creating a capturing group using the `()` as they were not escaped. Tested via ash on CLI.

This meant it would return 2, for a skill No. 2 and a string `(sk2)(sk20)`