### PR TITLE
Prevent Avatar of Boris dropping trusty to get April Shield buffs

### DIFF
--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -44,6 +44,11 @@ boolean autoEquip(slot s, item it)
 			return false;
 		}
 	}
+	if($slot[off-hand] == s && is_boris())
+	{
+		auto_log_debug("Boris has no need for puny offhands, skipping", "gold");
+		return false;
+	}
 
 	auto_log_info("Equipping " + it + " to slot " + s, "gold");
 
@@ -60,6 +65,7 @@ boolean autoEquip(item it)
 // mostly for the Antique Machete and unstable fulminate
 boolean autoForceEquip(slot s, item it, boolean noMaximize)
 {
+	auto_log_debug('Forcing equip of "' + it + '"', "gold");
 	if(it == $item[none])
 	{
 		return equip(s, it);
@@ -1313,6 +1319,11 @@ void equipRollover(boolean silent)
 
 boolean auto_forceEquipSword(boolean speculative) {
 	item swordToEquip = $item[none];
+	// Boris won't be caught dead with a sword
+	if (is_boris()) {
+		return false;
+	}
+
 	// use the ebony epee if we have it
 	if (possessEquipment($item[ebony epee]))
 	{

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -44,6 +44,7 @@ boolean autoEquip(slot s, item it)
 			return false;
 		}
 	}
+
 	auto_log_info("Equipping " + it + " to slot " + s, "gold");
 
 	return tryAddItemToMaximize(s, it);

--- a/RELEASE/scripts/autoscend/auto_equipment.ash
+++ b/RELEASE/scripts/autoscend/auto_equipment.ash
@@ -44,12 +44,6 @@ boolean autoEquip(slot s, item it)
 			return false;
 		}
 	}
-	if($slot[off-hand] == s && is_boris())
-	{
-		auto_log_debug("Boris has no need for puny offhands, skipping", "gold");
-		return false;
-	}
-
 	auto_log_info("Equipping " + it + " to slot " + s, "gold");
 
 	return tryAddItemToMaximize(s, it);

--- a/RELEASE/scripts/autoscend/iotms/mr2025.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2025.ash
@@ -238,6 +238,11 @@ boolean auto_equipAprilShieldBuff()
 	{
 		return false;
 	}
+	if(is_boris())
+	{
+		auto_log_debug('Boris would neither be caught dead with a shield, nor showering', "gold");
+		return false;
+	}
 	//force equip the shield if this is called
 	if(weapon_hands(equipped_item($slot[weapon])) > 1)
 	{


### PR DESCRIPTION
# Description

Previously, Boris would periodically unequip Trusty in post-adventure and be prevented from reequipping it when April Shower Shield is owned, causing combat difficulties. This PR resolves this, as well as adding some useful debug statement for future force-equip difficulties and a couple of minor fixes for things that were not the cause, but had incorrect behavior turned up in the investigation

## How Has This Been Tested?

Tested in situ in Hardcore Avatar of Boris, debug statement hit instead of dropping Trusty

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [X] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
