### PR TITLE
fix: no spoons if we can't cast Generate Irony

### DIFF
--- a/RELEASE/scripts/autoscend/iotms/mr2026.ash
+++ b/RELEASE/scripts/autoscend/iotms/mr2026.ash
@@ -432,7 +432,7 @@ item[int] auto_pickCupOf13sIngredients() {
 	else {spoon_alt = $item[none];}
 
 	int speculative_spoons = get_property("skillLevel245").to_int() - get_property("_generateIronyUsed").to_int() + item_amount($item[spoon]);
-	if (my_mp() < 50 || !auto_is_valid($skill[Generate Irony])) {speculative_spoons = 0;}
+	if (my_mp() < 50 || !canUse($skill[Generate Irony])) {speculative_spoons = 0;}
 
 	item[int] cup_ingredients;
 	for x from 1 to 3 {


### PR DESCRIPTION
# Description

We can't use a spoon as a Cup of 13s ingredient if we can't cast Generate Irony.

## How Has This Been Tested?

Zootomist.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
- [ ] I have updated the GitHub wiki [path](https://github.com/loathers/autoscend/wiki/Path-Support) or [IOTM](https://github.com/loathers/autoscend/wiki/IOTM-Support) support pages, as appropriate.
